### PR TITLE
Update with language changes

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -55,7 +55,7 @@ impl Copy for SocketOption {}
 const HAUSNUMERO: int = 156384712;
 
 /// ØMQ errors.
-#[deriving(PartialEq, Show)]
+#[derive(PartialEq, Debug)]
 pub enum ErrorCode {
     /// Invalid argument
     EINVAL = libc::EINVAL as int,

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -2,7 +2,7 @@ pub static MORE: u8 = 1;
 pub static COMMAND: u8 = 2;
 
 
-#[deriving(Show)]
+#[derive(Debug)]
 pub struct Msg {
     pub data: Vec<u8>,
     pub flags: u8,

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use consts::ErrorCode;
 use std;
-use std::io::{IoError, IoErrorKind};
+use std::old_io::{IoError, IoErrorKind};
 
 
 pub type ZmqResult<T> = Result<T, ZmqError>;
@@ -26,12 +26,12 @@ impl ZmqError {
     pub fn from_io_error(e: IoError) -> ZmqError {
         ZmqError {
             code: match e.kind {
-                std::io::PermissionDenied => ErrorCode::EACCES,
-                std::io::ConnectionRefused => ErrorCode::ECONNREFUSED,
-                std::io::ConnectionReset => ErrorCode::ECONNRESET,
-                std::io::ConnectionAborted => ErrorCode::ECONNABORTED,
-                std::io::NotConnected => ErrorCode::ENOTCONN,
-                std::io::TimedOut => ErrorCode::ETIMEDOUT,
+                std::old_io::PermissionDenied => ErrorCode::EACCES,
+                std::old_io::ConnectionRefused => ErrorCode::ECONNREFUSED,
+                std::old_io::ConnectionReset => ErrorCode::ECONNRESET,
+                std::old_io::ConnectionAborted => ErrorCode::ECONNABORTED,
+                std::old_io::NotConnected => ErrorCode::ENOTCONN,
+                std::old_io::TimedOut => ErrorCode::ETIMEDOUT,
 
                 _ => ErrorCode::EIOERROR,
             },

--- a/src/result.rs
+++ b/src/result.rs
@@ -5,7 +5,7 @@ use std::io::{IoError, IoErrorKind};
 
 pub type ZmqResult<T> = Result<T, ZmqError>;
 
-#[deriving(Show)]
+#[derive(Debug)]
 pub struct ZmqError {
     pub code: ErrorCode,
     pub desc: &'static str,

--- a/src/socket_base.rs
+++ b/src/socket_base.rs
@@ -11,9 +11,9 @@ use tcp_listener::TcpListener;
 
 use std::collections::HashMap;
 use std::sync::mpsc::Select;
-use std::io;
-use std::io::Listener;
-use std::io::net::ip::SocketAddr;
+use std::old_io as io;
+use std::old_io::Listener;
+use std::old_io::net::ip::SocketAddr;
 use std::sync::{Arc, RwLock};
 use std::sync::mpsc::{Receiver, Sender};
 

--- a/src/stream_engine.rs
+++ b/src/stream_engine.rs
@@ -8,8 +8,8 @@ use socket_base::SocketMessage;
 use v2_encoder::V2Encoder;
 use v2_decoder::V2Decoder;
 
-use std::io::extensions;
-use std::io::{TcpStream, Reader};
+use std::old_io::extensions;
+use std::old_io::{TcpStream, Reader};
 use std::sync::{RwLock, Arc};
 use std::sync::mpsc::Sender;
 use std::sync::mpsc::Receiver;

--- a/src/tcp_connecter.rs
+++ b/src/tcp_connecter.rs
@@ -6,8 +6,8 @@ use socket_base::SocketMessage;
 use stream_engine::StreamEngine;
 
 use std::cmp;
-use std::io::net::ip::SocketAddr;
-use std::io::{TcpStream, timer};
+use std::old_io::net::ip::SocketAddr;
+use std::old_io::{TcpStream, timer};
 use std::num::SignedInt;
 use std::rand;
 use std::sync::{Arc, RwLock};

--- a/src/tcp_listener.rs
+++ b/src/tcp_listener.rs
@@ -3,8 +3,8 @@ use result::{ZmqError, ZmqResult};
 use socket_base::SocketMessage;
 use stream_engine::StreamEngine;
 
-use std::io::Acceptor;
-use std::io::net::tcp::TcpAcceptor;
+use std::old_io::Acceptor;
+use std::old_io::net::tcp::TcpAcceptor;
 use std::sync::Arc;
 use std::sync::RwLock;
 use std::sync::mpsc::Sender;

--- a/src/v2_decoder.rs
+++ b/src/v2_decoder.rs
@@ -4,7 +4,7 @@ use msg::Msg;
 use result::{ZmqError, ZmqResult};
 use v2_protocol::{MORE_FLAG, LARGE_FLAG, COMMAND_FLAG};
 
-use std::io::Reader;
+use std::old_io::Reader;
 
 
 pub struct V2Decoder {

--- a/src/v2_encoder.rs
+++ b/src/v2_encoder.rs
@@ -2,7 +2,7 @@ use msg;
 use msg::Msg;
 use v2_protocol::{MORE_FLAG, LARGE_FLAG, COMMAND_FLAG};
 
-use std::io::{IoResult, Writer};
+use std::old_io::{IoResult, Writer};
 
 
 pub struct V2Encoder;


### PR DESCRIPTION
These are just a few quick refactors to keep pace with changes in the rust language.

 * Updated attribute `deriving` -> `derive`
 * Refactored `std::io` -> `std::old_io`

I was unable to solve some failures surrounding the `SocketAddr::from_str` function.  For some reason it is not recognized.  So this doesn't bring `zmq.rs` to build-ready, but hopefully it takes care of some of the busy-work.