### PR TITLE
Added github-actions CI and removed travis

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -56,7 +56,7 @@ jobs:
           command: fmt
           args: --all -- --check
 
-  clippy:
+  lint:
     name: Linting
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
           components: clippy
       - name: Cache cargo dependencies
@@ -73,7 +73,7 @@ jobs:
         with:
           path: ~/.cargo/
           key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
-      - uses: actions-rs/cargo@v1
+      - uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
-          args: -- -D warnings
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,0 +1,79 @@
+name: Main CI
+on: push
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+  clippy:
+    name: Linting
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: clippy
+      - name: Cache cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: rust
-rust:
-  - stable
-cache: cargo
-before_cache:
-  - rm -rf "$TRAVIS_HOME/.cargo/registry/src"
-script:
-  - cargo test -v

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+error_on_unformatted = true
+error_on_line_overflow = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-error_on_unformatted = true
-error_on_line_overflow = true
+# Use default rustfmt settings


### PR DESCRIPTION
This switches from travis CI to github actions.

Added:
- main-ci.yml, which describes the main CI workflow of the project. Deployment CI will likely go in a separate workflow.
- Four CI jobs: check that code compiles, check that tests pass, check that code is formatted, check for lints. The lint job can fail and will produce warnings instead of blocking a merge.
- Added a rustfmt.toml file. While technically unnecessary, it announces that the project is formatted with rustfmt and any deviations from the default config.

Removed:
- travis config yaml

The following in the repo settings will require the status checks to pass before merging to master:

1. Go to settings, branches, then add rule.
2. Enter the name of the branch as `master`
3. Select "Require status checks to pass before merging", and check the boxes for the 4 newly added status checks (note that even though the lint job is marked as required, its not actually going to block a merge due to the settings in the config.yml file.)
4. Check "include administrators", to avoid accidentally merging stuff to master that fails the checks (this one is less important than steps 1-3)