### PR TITLE
Added prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,3 +137,9 @@ pub trait Socket {
     async fn bind(&mut self, endpoint: &str) -> ZmqResult<()>;
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()>;
 }
+
+pub mod prelude {
+    //! Re-exports important traits. Consider glob-importing.
+
+    pub use crate::{BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket};
+}


### PR DESCRIPTION
I've added a prelude module, akin to the standard library's prelude module and similar modules in other crates. The intent is that we can put commonly used traits here to help people more easily use the library - they won't get errors about missing functions if they `use zeromq::prelude::*`.