### PR TITLE
Integration tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,9 +22,6 @@ mod req;
 mod sub;
 pub mod util;
 
-#[cfg(test)]
-mod tests;
-
 use crate::codec::*;
 pub use crate::dealer_router::*;
 pub use crate::error::ZmqError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,3 +137,9 @@ pub trait Socket {
     async fn bind(&mut self, endpoint: &str) -> ZmqResult<()>;
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()>;
 }
+
+pub mod prelude {
+    //! Re-exports important traits. Consider glob-importing.
+
+    pub use crate::{BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket};
+}

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -1,0 +1,57 @@
+use futures::channel::{mpsc, oneshot};
+use futures::{SinkExt, StreamExt};
+use std::convert::TryInto;
+use std::time::Duration;
+use zeromq::prelude::*;
+
+#[tokio::test]
+async fn test_pub_sub_sockets() {
+    let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
+    let (results_sender, results) = mpsc::channel(100);
+    tokio::spawn(async move {
+        let mut pub_socket = zeromq::PubSocket::new();
+        pub_socket
+            .bind("127.0.0.1:5556")
+            .await
+            .expect("Failed to bind socket");
+
+        loop {
+            if let Ok(Some(_)) = server_stop.try_recv() {
+                break;
+            }
+            pub_socket
+                .send(chrono::Utc::now().to_rfc2822().into())
+                .expect("Failed to send");
+            tokio::time::delay_for(Duration::from_millis(100)).await;
+        }
+    });
+
+    for _ in 0..10 {
+        let mut client_sender = results_sender.clone();
+        tokio::spawn(async move {
+            let mut sub_socket = zeromq::SubSocket::new();
+            sub_socket
+                .connect("127.0.0.1:5556")
+                .await
+                .expect("Failed to connect");
+
+            sub_socket.subscribe("").await.expect("Failed to subscribe");
+
+            for _ in 0..10i32 {
+                let repl: String = sub_socket
+                    .recv()
+                    .await
+                    .expect("Failed to recv")
+                    .try_into()
+                    .expect("Malformed string");
+                assert_eq!(chrono::Utc::now().to_rfc2822(), repl);
+                client_sender.send(true).await.unwrap();
+            }
+        });
+    }
+    drop(results_sender);
+
+    let res_vec: Vec<bool> = results.collect().await;
+    server_stop_sender.send(()).unwrap();
+    assert_eq!(100, res_vec.len());
+}

--- a/tests/rep_req.rs
+++ b/tests/rep_req.rs
@@ -1,65 +1,10 @@
-use crate::{BlockingRecv, BlockingSend, NonBlockingSend, Socket};
-use chrono::Utc;
-use futures::channel::{mpsc, oneshot};
-use futures::{SinkExt, StreamExt};
 use std::convert::TryInto;
 use std::error::Error;
 use std::time::Duration;
-
-#[tokio::test]
-async fn test_pub_sub_sockets() {
-    let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
-    let (results_sender, results) = mpsc::channel(100);
-    tokio::spawn(async move {
-        let mut pub_socket = crate::PubSocket::new();
-        pub_socket
-            .bind("127.0.0.1:5556")
-            .await
-            .expect("Failed to bind socket");
-
-        loop {
-            if let Ok(Some(_)) = server_stop.try_recv() {
-                break;
-            }
-            pub_socket
-                .send(Utc::now().to_rfc2822().into())
-                .expect("Failed to send");
-            tokio::time::delay_for(Duration::from_millis(100)).await;
-        }
-    });
-
-    for _ in 0..10 {
-        let mut client_sender = results_sender.clone();
-        tokio::spawn(async move {
-            let mut sub_socket = crate::SubSocket::new();
-            sub_socket
-                .connect("127.0.0.1:5556")
-                .await
-                .expect("Failed to connect");
-
-            sub_socket.subscribe("").await.expect("Failed to subscribe");
-
-            for _ in 0..10i32 {
-                let repl: String = sub_socket
-                    .recv()
-                    .await
-                    .expect("Failed to recv")
-                    .try_into()
-                    .expect("Malformed string");
-                assert_eq!(Utc::now().to_rfc2822(), repl);
-                client_sender.send(true).await.unwrap();
-            }
-        });
-    }
-    drop(results_sender);
-
-    let res_vec: Vec<bool> = results.collect().await;
-    server_stop_sender.send(()).unwrap();
-    assert_eq!(100, res_vec.len());
-}
+use zeromq::prelude::*;
 
 async fn run_rep_server() -> Result<(), Box<dyn Error>> {
-    let mut rep_socket = crate::RepSocket::new();
+    let mut rep_socket = zeromq::RepSocket::new();
     rep_socket.bind("127.0.0.1:5557").await?;
     println!("Started rep server on 127.0.0.1:5557");
 
@@ -80,7 +25,7 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
 
     // yield for a moment to ensure that server has some time to open socket
     tokio::time::delay_for(Duration::from_millis(10)).await;
-    let mut req_socket = crate::ReqSocket::new();
+    let mut req_socket = zeromq::ReqSocket::new();
     req_socket.connect("127.0.0.1:5557").await?;
 
     for i in 0..10i32 {
@@ -97,7 +42,7 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
         tokio::spawn(async move {
             // yield for a moment to ensure that server has some time to open socket
             tokio::time::delay_for(Duration::from_millis(100)).await;
-            let mut req_socket = crate::ReqSocket::new();
+            let mut req_socket = zeromq::ReqSocket::new();
             req_socket.connect("127.0.0.1:5558").await.unwrap();
 
             for j in 0..100i32 {
@@ -112,7 +57,7 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
         });
     }
 
-    let mut rep_socket = crate::RepSocket::new();
+    let mut rep_socket = zeromq::RepSocket::new();
     rep_socket.bind("127.0.0.1:5558").await?;
     println!("Started rep server on 127.0.0.1:5558");
 


### PR DESCRIPTION
Currently rebased on #61, see that one first

I moved the contents of `zeromq::tests` into cargo's `tests` directory, to better align with cargo's package layout, as well as re-frame the tests as integration tests. This ensures the tests only depend on externally visible functionality. I've also organized them by socket type, so its a little more modular and helps make clear what is and isn't tested.

