### PR TITLE
Fix flaky test and test multiple addresses

### DIFF
--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -6,52 +6,56 @@ use zeromq::prelude::*;
 
 #[tokio::test]
 async fn test_pub_sub_sockets() {
-    let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
-    let (results_sender, results) = mpsc::channel(100);
-    tokio::spawn(async move {
-        let mut pub_socket = zeromq::PubSocket::new();
-        pub_socket
-            .bind("127.0.0.1:5556")
-            .await
-            .expect("Failed to bind socket");
-
-        loop {
-            if let Ok(Some(_)) = server_stop.try_recv() {
-                break;
-            }
-            pub_socket
-                .send(chrono::Utc::now().to_rfc2822().into())
-                .expect("Failed to send");
-            tokio::time::delay_for(Duration::from_millis(100)).await;
-        }
-    });
-
-    for _ in 0..10 {
-        let mut client_sender = results_sender.clone();
+    async fn helper(bind_addr: &'static str) {
+        let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
+        let (results_sender, results) = mpsc::channel(100);
         tokio::spawn(async move {
-            let mut sub_socket = zeromq::SubSocket::new();
-            sub_socket
-                .connect("127.0.0.1:5556")
+            let mut pub_socket = zeromq::PubSocket::new();
+            pub_socket
+                .bind(bind_addr)
                 .await
-                .expect("Failed to connect");
+                .expect("Failed to bind socket");
 
-            sub_socket.subscribe("").await.expect("Failed to subscribe");
-
-            for _ in 0..10i32 {
-                let repl: String = sub_socket
-                    .recv()
-                    .await
-                    .expect("Failed to recv")
-                    .try_into()
-                    .expect("Malformed string");
-                assert_eq!(chrono::Utc::now().to_rfc2822(), repl);
-                client_sender.send(true).await.unwrap();
+            loop {
+                if let Ok(Some(_)) = server_stop.try_recv() {
+                    break;
+                }
+                pub_socket
+                    .send(chrono::Utc::now().to_rfc2822().into())
+                    .expect("Failed to send");
+                tokio::time::delay_for(Duration::from_millis(100)).await;
             }
         });
-    }
-    drop(results_sender);
 
-    let res_vec: Vec<bool> = results.collect().await;
-    server_stop_sender.send(()).unwrap();
-    assert_eq!(100, res_vec.len());
+        for _ in 0..10 {
+            let mut client_sender = results_sender.clone();
+            tokio::spawn(async move {
+                let mut sub_socket = zeromq::SubSocket::new();
+                sub_socket
+                    .connect(bind_addr)
+                    .await
+                    .expect("Failed to connect");
+
+                sub_socket.subscribe("").await.expect("Failed to subscribe");
+
+                for _ in 0..10i32 {
+                    let repl: String = sub_socket
+                        .recv()
+                        .await
+                        .expect("Failed to recv")
+                        .try_into()
+                        .expect("Malformed string");
+                    assert_eq!(chrono::Utc::now().to_rfc2822(), repl);
+                    client_sender.send(true).await.unwrap();
+                }
+            });
+        }
+        drop(results_sender);
+
+        let res_vec: Vec<bool> = results.collect().await;
+        server_stop_sender.send(()).unwrap();
+        assert_eq!(100, res_vec.len());
+    }
+    let addrs = vec!["127.0.0.1:5556", "localhost:5555"];
+    futures::future::join_all(addrs.into_iter().map(helper)).await;
 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -7,8 +7,10 @@ use zeromq::prelude::*;
 #[tokio::test]
 async fn test_pub_sub_sockets() {
     async fn helper(bind_addr: &'static str) {
+        let payload = chrono::Utc::now().to_rfc2822();
+
+        let cloned_payload = payload.clone();
         let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
-        let (results_sender, results) = mpsc::channel(100);
         tokio::spawn(async move {
             let mut pub_socket = zeromq::PubSocket::new();
             pub_socket
@@ -20,15 +22,18 @@ async fn test_pub_sub_sockets() {
                 if let Ok(Some(_)) = server_stop.try_recv() {
                     break;
                 }
+
                 pub_socket
-                    .send(chrono::Utc::now().to_rfc2822().into())
+                    .send(cloned_payload.clone().into())
                     .expect("Failed to send");
-                tokio::time::delay_for(Duration::from_millis(100)).await;
+                tokio::time::delay_for(Duration::from_millis(1)).await;
             }
         });
 
+        let (sub_results_sender, sub_results) = mpsc::channel(100);
         for _ in 0..10 {
-            let mut client_sender = results_sender.clone();
+            let mut cloned_sub_sender = sub_results_sender.clone();
+            let cloned_payload = payload.clone();
             tokio::spawn(async move {
                 let mut sub_socket = zeromq::SubSocket::new();
                 sub_socket
@@ -38,24 +43,24 @@ async fn test_pub_sub_sockets() {
 
                 sub_socket.subscribe("").await.expect("Failed to subscribe");
 
-                for _ in 0..10i32 {
-                    let repl: String = sub_socket
+                for _ in 0..10 {
+                    let recv_payload: String = sub_socket
                         .recv()
                         .await
                         .expect("Failed to recv")
                         .try_into()
                         .expect("Malformed string");
-                    assert_eq!(chrono::Utc::now().to_rfc2822(), repl);
-                    client_sender.send(true).await.unwrap();
+                    assert_eq!(cloned_payload, recv_payload);
+                    cloned_sub_sender.send(()).await.unwrap();
                 }
             });
         }
-        drop(results_sender);
-
-        let res_vec: Vec<bool> = results.collect().await;
-        server_stop_sender.send(()).unwrap();
+        drop(sub_results_sender);
+        let res_vec: Vec<()> = sub_results.collect().await;
         assert_eq!(100, res_vec.len());
+
+        server_stop_sender.send(()).unwrap();
     }
-    let addrs = vec!["127.0.0.1:5556", "localhost:5555"];
+    let addrs = vec!["127.0.0.1:5554", "[::1]:5555", "127.0.0.1:5556"];
     futures::future::join_all(addrs.into_iter().map(helper)).await;
 }


### PR DESCRIPTION
Currently rebased on #62, see that one first

I refactored the pub_sub test to allow for multiple addresses to be tested, and am now testing multiple ipv4 and ipv6 addresses.

I also took the opportunity to make the test less flaky - there is no guarantee that the current time of receipt matches when it was sent, and this caused the test to fail non-deterministically. I fixed it by cloning the payload so that the received value could be directly compared against the expected value in the subscribers.