### PR TITLE
No longer #![deny(warnings)]

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   lint:
     name: Linting
-    continue-on-error: true
+    continue-on-error: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,4 +76,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features -- --deny warnings

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(warnings)]
 #![recursion_limit = "1024"]
 #[macro_use]
 extern crate enum_primitive_derive;


### PR DESCRIPTION
Rebased on #67, see that PR first

denying warnings in the crate itself rather than in only CI has a few harmful effects, which include accidentally making what would otherwise be backwards compatible changes into breaking ones. For example if a dependent crate marks some functionality as deprecated or a new warning is added to the rust compiler, these are considered minor version changes, but would be breaking if we deny all warnings.

In this PR I have stopped denying warnings. To achieve the same effect as what was originally intended I have made passing the linting step of CI required and the linter now denies warnings. This should keep the intended effect (we don't tolerate warnings), but avoid the unintended consequence of violating semver compatibility.

See also:
- https://www.reddit.com/r/rust/comments/f5xpib/psa_denywarnings_is_actively_harmful
- https://github.com/rust-unofficial/patterns/blob/master/anti_patterns/deny-warnings.md
