### PR TITLE
Added Endpoint enum to better encode endpoints for different transport types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ enum-primitive-derive = "^0.1"
 dashmap = "^3.11"
 crossbeam = "^0.7"
 uuid = { version = "^0.8", features = ["v4"] }
+regex = "1"
+lazy_static = "1"
+
 
 [dev-dependencies]
 chrono = "^0.4"

--- a/examples/message_broker.rs
+++ b/examples/message_broker.rs
@@ -7,11 +7,11 @@ use zeromq::{Socket, ZmqError};
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut frontend = zeromq::RouterSocket::new();
     frontend
-        .bind("127.0.0.1:5559")
+        .bind("tcp://127.0.0.1:5559")
         .await
         .expect("Failed to bind");
 
-    // let mut backend = zmq_rs::DealerSocket::bind("127.0.0.1:5560")
+    // let mut backend = zmq_rs::DealerSocket::bind("tcp://127.0.0.1:5560")
     //     .await
     //     .expect("Failed to bind");
     //

--- a/examples/message_client.rs
+++ b/examples/message_client.rs
@@ -7,7 +7,7 @@ use zeromq::{BlockingRecv, BlockingSend};
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut socket = zeromq::ReqSocket::new();
     socket
-        .connect("127.0.0.1:5559")
+        .connect("tcp://127.0.0.1:5559")
         .await
         .expect("Failed to connect");
 

--- a/examples/socket_client.rs
+++ b/examples/socket_client.rs
@@ -7,7 +7,7 @@ use zeromq::{BlockingRecv, BlockingSend};
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut socket = zeromq::ReqSocket::new();
     socket
-        .connect("127.0.0.1:5555")
+        .connect("tcp://127.0.0.1:5555")
         .await
         .expect("Failed to connect");
     println!("Connected to server");

--- a/examples/socket_server.rs
+++ b/examples/socket_server.rs
@@ -5,7 +5,7 @@ use zeromq::*;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Start server");
     let mut socket = zeromq::RepSocket::new();
-    socket.bind("127.0.0.1:5555").await?;
+    socket.bind("tcp://127.0.0.1:5555").await?;
 
     loop {
         let mut repl: String = socket.recv().await?.try_into()?;

--- a/examples/weather_client.rs
+++ b/examples/weather_client.rs
@@ -6,7 +6,7 @@ use zeromq::{BlockingRecv, Socket};
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut socket = zeromq::SubSocket::new();
     socket
-        .connect("127.0.0.1:5556")
+        .connect("tcp://127.0.0.1:5556")
         .await
         .expect("Failed to connect");
 

--- a/examples/weather_server.rs
+++ b/examples/weather_server.rs
@@ -7,7 +7,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = rand::thread_rng();
     println!("Start server");
     let mut socket = zeromq::PubSocket::new();
-    socket.bind("127.0.0.1:5556").await?;
+    socket.bind("tcp://127.0.0.1:5556").await?;
 
     println!("Start sending loop");
     loop {

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,0 +1,249 @@
+use crate::error::ZmqError;
+use lazy_static::lazy_static;
+use regex::Regex;
+use std::convert::{TryFrom, TryInto};
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::str::FromStr;
+
+// TODO: Figure out better error types for this module.
+
+pub type Port = u16;
+
+/// Represents a host address. Does not include the port, and may be either an
+/// ip address or a domain name
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub enum Host {
+    /// An IPv4 address
+    Ipv4(Ipv4Addr),
+    /// An Ipv6 address
+    Ipv6(Ipv6Addr),
+    /// A domain name, such as `example.com` in `tcp://example.com:4567`.
+    Domain(String),
+}
+
+impl fmt::Display for Host {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        match self {
+            Host::Ipv4(addr) => write!(f, "{}", addr),
+            Host::Ipv6(addr) => write!(f, "[{}]", addr),
+            Host::Domain(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl TryFrom<String> for Host {
+    type Error = ZmqError;
+
+    /// An Ipv6 address must be enclosed by `[` and `]`.
+    fn try_from(s: String) -> Result<Self, Self::Error> {
+        if s.is_empty() {
+            return Err(ZmqError::Other("Host string should not be empty"));
+        }
+        if let Ok(addr) = s.parse::<Ipv4Addr>() {
+            return Ok(Host::Ipv4(addr));
+        }
+        if s.len() >= 4 {
+            if let Ok(addr) = s[1..s.len() - 1].parse::<Ipv6Addr>() {
+                return Ok(Host::Ipv6(addr));
+            }
+        }
+        Ok(Host::Domain(s))
+    }
+}
+
+impl FromStr for Host {
+    type Err = ZmqError;
+
+    /// Equivalent to [`Self::try_from()`]
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.to_string();
+        Self::try_from(s)
+    }
+}
+
+/// The type of transport used by a given endpoint
+#[derive(Debug, Clone, Hash, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Transport {
+    /// TCP transport
+    Tcp,
+}
+
+impl FromStr for Transport {
+    type Err = ZmqError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let result = match s {
+            "tcp" => Transport::Tcp,
+            _ => return Err(ZmqError::Other("Unknown transport type")),
+        };
+        Ok(result)
+    }
+}
+impl TryFrom<&str> for Transport {
+    type Error = ZmqError;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        s.parse()
+    }
+}
+
+impl fmt::Display for Transport {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        let s = match self {
+            Transport::Tcp => "tcp",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+/// Represents a ZMQ Endpoint.
+///
+/// # Examples
+/// ```
+/// # use zeromq::{Endpoint, Host};
+/// # fn main() -> Result<(), zeromq::ZmqError> {
+/// assert_eq!(
+///     "tcp://example.com:4567".parse::<Endpoint>()?,
+///     Endpoint::Tcp(Host::Domain("example.com".to_string()), 4567)
+/// );
+/// # Ok(()) }
+/// ```
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
+pub enum Endpoint {
+    // TODO: Add endpoints for the other transport variants
+    Tcp(Host, Port),
+}
+
+impl Endpoint {
+    pub fn transport(&self) -> Transport {
+        match self {
+            Self::Tcp(_, _) => Transport::Tcp,
+        }
+    }
+}
+
+impl FromStr for Endpoint {
+    type Err = ZmqError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref TRANSPORT_REGEX: Regex = Regex::new(r"^(.+)://(.+)$").unwrap();
+            static ref HOST_PORT_REGEX: Regex = Regex::new(r"^(.+):(\d+)$").unwrap();
+        }
+
+        let caps = TRANSPORT_REGEX
+            .captures(s)
+            .ok_or(ZmqError::Other("Invalid Syntax"))?;
+        let transport: &str = caps.get(1).unwrap().into();
+        let transport: Transport = transport.parse()?;
+        let address = caps.get(2).unwrap().as_str();
+
+        fn extract_host_port(address: &str) -> Result<(Host, Port), ZmqError> {
+            let caps = HOST_PORT_REGEX
+                .captures(address)
+                .ok_or(ZmqError::Other("Invalid Syntax"))?;
+            let host = caps.get(1).unwrap().as_str();
+            let port = caps.get(2).unwrap().as_str();
+            let port: Port = port
+                .parse()
+                .map_err(|_| ZmqError::Other("Port must be a u16 but was out of range"))?;
+
+            let host: Host = host.parse()?;
+            Ok((host, port))
+        }
+
+        let endpoint = match transport {
+            Transport::Tcp => {
+                let (host, port) = extract_host_port(address)?;
+                Endpoint::Tcp(host, port)
+            }
+        };
+
+        Ok(endpoint)
+    }
+}
+
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter) -> std::result::Result<(), std::fmt::Error> {
+        match self {
+            Endpoint::Tcp(host, port) => write!(f, "tcp://{}:{}", host, port),
+        }
+    }
+}
+
+// Trait aliases (https://github.com/rust-lang/rust/issues/41517) would make this unecessary
+/// Any type that can be converted into an [`Endpoint`] should implement this
+pub trait TryIntoEndpoint: Send {
+    fn try_into(self) -> Result<Endpoint, ZmqError>;
+}
+
+impl<T> TryIntoEndpoint for T
+where
+    T: TryInto<Endpoint, Error = ZmqError> + Send,
+{
+    fn try_into(self) -> Result<Endpoint, ZmqError> {
+        self.try_into()
+    }
+}
+
+impl TryIntoEndpoint for &str {
+    fn try_into(self) -> Result<Endpoint, ZmqError> {
+        self.parse()
+    }
+}
+
+impl TryIntoEndpoint for String {
+    fn try_into(self) -> Result<Endpoint, ZmqError> {
+        self.parse()
+    }
+}
+
+impl TryIntoEndpoint for Endpoint {
+    fn try_into(self) -> Result<Endpoint, ZmqError> {
+        Ok(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lazy_static::lazy_static;
+
+    lazy_static! {
+        static ref PAIRS: Vec<(Endpoint, &'static str)> = vec![
+            (
+                Endpoint::Tcp(Host::Domain("www.example.com".to_string()), 1234),
+                "tcp://www.example.com:1234",
+            ),
+            (
+                Endpoint::Tcp(Host::Domain("*".to_string()), 2345),
+                "tcp://*:2345",
+            ),
+            (
+                Endpoint::Tcp(Host::Ipv4("127.0.0.1".parse().unwrap()), 8080),
+                "tcp://127.0.0.1:8080",
+            ),
+            (
+                Endpoint::Tcp(Host::Ipv6("::1".parse().unwrap()), 34567),
+                "tcp://[::1]:34567",
+            ),
+        ];
+    }
+
+    #[test]
+    fn test_endpoint_display() {
+        for (e, s) in PAIRS.iter() {
+            assert_eq!(&format!("{}", e), s);
+        }
+    }
+
+    #[test]
+    fn test_endpoint_parse() {
+        for (e, s) in PAIRS.iter() {
+            assert_eq!(&s.parse::<Endpoint>().unwrap(), e);
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,8 +4,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ZmqError {
-    #[error("Malformed socket address")]
-    Address(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    Endpoint(#[from] EndpointError),
     #[error("Network error")]
     Network(#[from] std::io::Error),
     #[error("{0}")]
@@ -35,4 +35,15 @@ impl From<futures::channel::mpsc::SendError> for ZmqError {
     fn from(_: futures::channel::mpsc::SendError) -> Self {
         ZmqError::BufferFull("Failed to send message. Send queue full/broken")
     }
+}
+
+/// Represents an error when parsing an [`Endpoint`]
+#[derive(Error, Debug)]
+pub enum EndpointError {
+    #[error("Failed to parse IP address or port")]
+    ParseIpAddr(#[from] std::net::AddrParseError),
+    #[error("Unknown transport type {0}")]
+    UnknownTransport(String),
+    #[error("Invalid Syntax: {0}")]
+    Syntax(&'static str),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,11 +7,12 @@ use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
-use std::net::SocketAddr;
+
 use tokio_util::codec::Framed;
 
 mod codec;
 mod dealer_router;
+mod endpoint;
 mod error;
 mod fair_queue;
 mod message;
@@ -23,6 +24,7 @@ pub mod util;
 
 use crate::codec::*;
 pub use crate::dealer_router::*;
+pub use crate::endpoint::{Endpoint, Host, Transport, TryIntoEndpoint};
 pub use crate::error::ZmqError;
 pub use crate::r#pub::*;
 pub use crate::rep::*;
@@ -129,13 +131,16 @@ pub trait NonBlockingRecv {
 pub trait Socket {
     fn new() -> Self;
 
-    /// Opens port described by endpoint and starts a coroutine to accept new connections on it
-    async fn bind(&mut self, endpoint: &str) -> ZmqResult<()>;
-    async fn connect(&mut self, endpoint: &str) -> ZmqResult<()>;
+    /// Opens port described by endpoint and starts a coroutine to accept new
+    /// connections on it
+    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
+    async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
 }
 
 pub mod prelude {
     //! Re-exports important traits. Consider glob-importing.
 
-    pub use crate::{BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket};
+    pub use crate::{
+        BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket, TryIntoEndpoint,
+    };
 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -13,7 +13,6 @@ async fn test_pub_sub_sockets() {
         let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
         tokio::spawn(async move {
             let mut pub_socket = zeromq::PubSocket::new();
-            println!("Binding to {}", bind_addr);
             pub_socket
                 .bind(bind_addr)
                 .await
@@ -37,7 +36,6 @@ async fn test_pub_sub_sockets() {
             let cloned_payload = payload.clone();
             tokio::spawn(async move {
                 let mut sub_socket = zeromq::SubSocket::new();
-                println!("Connecting to {}", bind_addr);
                 sub_socket
                     .connect(bind_addr)
                     .await

--- a/tests/rep_req.rs
+++ b/tests/rep_req.rs
@@ -5,8 +5,8 @@ use zeromq::prelude::*;
 
 async fn run_rep_server() -> Result<(), Box<dyn Error>> {
     let mut rep_socket = zeromq::RepSocket::new();
-    rep_socket.bind("127.0.0.1:5557").await?;
-    println!("Started rep server on 127.0.0.1:5557");
+    rep_socket.bind("tcp://127.0.0.1:5557").await?;
+    println!("Started rep server on tcp://127.0.0.1:5557");
 
     for i in 0..10i32 {
         let mess: String = rep_socket.recv().await?.try_into()?;
@@ -26,7 +26,7 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
     // yield for a moment to ensure that server has some time to open socket
     tokio::time::delay_for(Duration::from_millis(10)).await;
     let mut req_socket = zeromq::ReqSocket::new();
-    req_socket.connect("127.0.0.1:5557").await?;
+    req_socket.connect("tcp://127.0.0.1:5557").await?;
 
     for i in 0..10i32 {
         req_socket.send(format!("Req - {}", i).into()).await?;
@@ -43,7 +43,7 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
             // yield for a moment to ensure that server has some time to open socket
             tokio::time::delay_for(Duration::from_millis(100)).await;
             let mut req_socket = zeromq::ReqSocket::new();
-            req_socket.connect("127.0.0.1:5558").await.unwrap();
+            req_socket.connect("tcp://127.0.0.1:5558").await.unwrap();
 
             for j in 0..100i32 {
                 req_socket
@@ -58,8 +58,8 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
     }
 
     let mut rep_socket = zeromq::RepSocket::new();
-    rep_socket.bind("127.0.0.1:5558").await?;
-    println!("Started rep server on 127.0.0.1:5558");
+    rep_socket.bind("tcp://127.0.0.1:5558").await?;
+    println!("Started rep server on tcp://127.0.0.1:5558");
 
     for _ in 0..10000i32 {
         let mess: String = rep_socket.recv().await?.try_into()?;


### PR DESCRIPTION
I've added an `Endpoint` enum, along with a `Host` and `Transport` enum. These enums should help us add support for new transport types other than tcp or udp.

Without the enums, I found myself having to check the syntax of the string based endpoint a lot. For example, if its tcp the string should be host:port, but if its ipc it should just be a string address. By consolidating all of these checks into the parse() method of `Endpoint`, we can avoid scattering these parsing and checking steps everywhere in the code, and we can also let people avoid that overhead by directly constructing the Endpoint.

```rust
let str_endpoint: Endpoint = "tcp://example.com:4567".parse()
let enum_endpoint = Endpoint::Tcp("example.com".to_string(), 4567)
```

Things to discuss:
1. I have not figured out the proper types to encode the errors in the `endpoint` module yet - most of them are labeled as `ZmqError::Other`. What do you recommend the error type be?
2. ~~I have made a custom trait called `TryIntoEndpoint` which basically does the same thing as `TryInto<Endpoint, Error=ZmqError>`. I have the trait because I wanted something similar to a trait alias, but that isn't a thing in rust yet (see https://github.com/rust-lang/rust/issues/41517). Is this the right approach?~~
3. ~~I currently accept arguments as `a: impl TryIntoEndpoint` for the user-facing functions accepting an endpoint. This form of static dispatch will get monomorphized in most cases and lead to code bloat, but lets the user pass either strings or `Endpoint` types to these functions, which is a little more ergonomic. However, its really not that hard to pass the argument as `"tcp://example.com:4567".parse()`. It might be worth removing the `impl TryIntoEndpoint` and just doing `a: Endpoint` instead. That might also let us delete the `TryIntoEndpoint` trait entirely, and will lead to faster compile times and smaller binary sizes. Especially if we intend to support WASM as a platform, where binary size really matters, this will be important. What are your thoughts?~~
4. The different variants of the `Endpoint` enum are currently just tuples. For example, I have `Endpoint::Tcp(Host, Port)`. This means that if there are functions that operate exclusively on a particular type of endpoint (lets say `TcpEndpoint`), we currently have to do a match to make sure that we have the right transport type for any given `Endpoint`. It might be worth instead making each variant of the `Endpoint` have a type. For example, we could have both `Endpoint` and `TcpEndpoint`, where `TcpEndpoint` is a tuple struct of `(Host, Port)`, and we would have `Endpoint::Tcp(TcpEndpoint)`. We could also `impl From<TcpEndpoint> for Endpoint` to allow to easily convert from a TcpEndpoint to an Endpoint. The only downside is that it would introduce a lot of additional types, but I think that its worth it for the increase in type safety

