### PR TITLE
Allow endpoints with port 0 or unspecified interface

### DIFF
--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -96,13 +96,16 @@ impl Socket for RouterSocket {
         }
     }
 
-    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let mut endpoint = endpoint.try_into()?;
-        let stop_handle =
-            util::start_accepting_connections(&mut endpoint, self.backend.clone()).await?;
+    async fn bind(
+        &mut self,
+        endpoint: impl TryIntoEndpoint + 'async_trait,
+    ) -> ZmqResult<&Endpoint> {
+        let endpoint = endpoint.try_into()?;
+        let (endpoint, stop_handle) =
+            util::start_accepting_connections(endpoint, self.backend.clone()).await?;
         self._accept_close_handle = Some(stop_handle);
         self.binds.push(endpoint);
-        Ok(())
+        Ok(self.binds.last().unwrap())
     }
 
     async fn connect(&mut self, _endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
 
 use crate::codec::*;
-use crate::endpoint::TryIntoEndpoint;
+use crate::endpoint::{Endpoint, TryIntoEndpoint};
 use crate::error::*;
 use crate::message::*;
 use crate::util::*;
@@ -75,6 +75,7 @@ impl SocketBackend for RouterSocketBackend {
 pub struct RouterSocket {
     backend: Arc<RouterSocketBackend>,
     _accept_close_handle: Option<oneshot::Sender<bool>>,
+    binds: Vec<Endpoint>,
 }
 
 impl Drop for RouterSocket {
@@ -91,19 +92,25 @@ impl Socket for RouterSocket {
                 peers: Arc::new(DashMap::new()),
             }),
             _accept_close_handle: None,
+            binds: Vec::new(),
         }
     }
 
     async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let endpoint = endpoint.try_into()?;
+        let mut endpoint = endpoint.try_into()?;
         let stop_handle =
-            util::start_accepting_connections(&endpoint, self.backend.clone()).await?;
+            util::start_accepting_connections(&mut endpoint, self.backend.clone()).await?;
         self._accept_close_handle = Some(stop_handle);
+        self.binds.push(endpoint);
         Ok(())
     }
 
     async fn connect(&mut self, _endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
         unimplemented!()
+    }
+
+    fn binds(&self) -> &[Endpoint] {
+        &self.binds
     }
 }
 

--- a/src/endpoint.rs
+++ b/src/endpoint.rs
@@ -1,9 +1,9 @@
-use crate::error::EndpointError;
+use crate::error::{EndpointError, ZmqError};
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
 
 // TODO: Figure out better error types for this module.
@@ -28,6 +28,27 @@ impl fmt::Display for Host {
             Host::Ipv4(addr) => write!(f, "{}", addr),
             Host::Ipv6(addr) => write!(f, "[{}]", addr),
             Host::Domain(name) => write!(f, "{}", name),
+        }
+    }
+}
+
+impl TryFrom<Host> for IpAddr {
+    type Error = ZmqError;
+
+    fn try_from(h: Host) -> Result<Self, Self::Error> {
+        match h {
+            Host::Ipv4(a) => Ok(IpAddr::V4(a)),
+            Host::Ipv6(a) => Ok(IpAddr::V6(a)),
+            Host::Domain(_) => Err(ZmqError::Other("Host was neither Ipv4 nor Ipv6")),
+        }
+    }
+}
+
+impl From<IpAddr> for Host {
+    fn from(a: IpAddr) -> Self {
+        match a {
+            IpAddr::V4(a) => Host::Ipv4(a),
+            IpAddr::V6(a) => Host::Ipv6(a),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,6 +135,8 @@ pub trait Socket {
     /// connections on it
     async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
+    /// Retrieves the list of currently bound endpoints
+    fn binds(&self) -> &[Endpoint];
 }
 
 pub mod prelude {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,9 +132,16 @@ pub trait Socket {
     fn new() -> Self;
 
     /// Opens port described by endpoint and starts a coroutine to accept new
-    /// connections on it
-    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
+    /// connections on it.
+    ///
+    /// Returns the bound-to endpoint, with the port resolved (if applicable).
+    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait)
+        -> ZmqResult<&Endpoint>;
+
+    // TODO: Although it would reduce how convenient the function is, taking an
+    // `&Endpoint` would be better for performance here
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
+
     /// Retrieves the list of currently bound endpoints
     fn binds(&self) -> &[Endpoint];
 }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -170,26 +170,29 @@ impl Socket for PubSocket {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Host, ZmqResult};
+    use crate::util::tests::{
+        test_bind_to_any_port_helper, test_bind_to_unspecified_interface_helper,
+    };
+    use crate::ZmqResult;
+    use std::net::IpAddr;
+
     #[tokio::test]
-    async fn test_bind_to_any() -> ZmqResult<()> {
-        let mut s = PubSocket::new();
-        assert!(s.binds().is_empty());
-        for _ in 0..4 {
-            s.bind("tcp://localhost:0").await?;
-        }
+    async fn test_bind_to_any_port() -> ZmqResult<()> {
+        let s = PubSocket::new();
+        test_bind_to_any_port_helper(s).await
+    }
 
-        let bound_to = s.binds();
-        assert_eq!(bound_to.len(), 4);
-        let mut port_set = std::collections::HashSet::new();
-        for b in bound_to {
-            let Endpoint::Tcp(host, port) = b;
-            assert_eq!(host, &Host::Domain("localhost".to_string()));
-            assert_ne!(*port, 0);
-            // Insert and check that it wasn't already present
-            assert!(port_set.insert(*port));
-        }
+    #[tokio::test]
+    async fn test_bind_to_any_ipv4_interface() -> ZmqResult<()> {
+        let any_ipv4: IpAddr = "0.0.0.0".parse().unwrap();
+        let s = PubSocket::new();
+        test_bind_to_unspecified_interface_helper(any_ipv4, s, 4000).await
+    }
 
-        Ok(())
+    #[tokio::test]
+    async fn test_bind_to_any_ipv6_interface() -> ZmqResult<()> {
+        let any_ipv6: IpAddr = "::".parse().unwrap();
+        let s = PubSocket::new();
+        test_bind_to_unspecified_interface_helper(any_ipv6, s, 4010).await
     }
 }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -144,13 +144,16 @@ impl Socket for PubSocket {
         }
     }
 
-    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let mut endpoint = endpoint.try_into()?;
-        let stop_handle =
-            util::start_accepting_connections(&mut endpoint, self.backend.clone()).await?;
+    async fn bind(
+        &mut self,
+        endpoint: impl TryIntoEndpoint + 'async_trait,
+    ) -> ZmqResult<&Endpoint> {
+        let endpoint = endpoint.try_into()?;
+        let (endpoint, stop_handle) =
+            util::start_accepting_connections(endpoint, self.backend.clone()).await?;
         self._accept_close_handle = Some(stop_handle);
         self.binds.push(endpoint);
-        Ok(())
+        Ok(self.binds.last().unwrap())
     }
 
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -65,13 +65,16 @@ impl Socket for RepSocket {
         }
     }
 
-    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let mut endpoint = endpoint.try_into()?;
-        let stop_handle =
-            util::start_accepting_connections(&mut endpoint, self.backend.clone()).await?;
+    async fn bind(
+        &mut self,
+        endpoint: impl TryIntoEndpoint + 'async_trait,
+    ) -> ZmqResult<&Endpoint> {
+        let endpoint = endpoint.try_into()?;
+        let (endpoint, stop_handle) =
+            util::start_accepting_connections(endpoint, self.backend.clone()).await?;
         self._accept_close_handle = Some(stop_handle);
         self.binds.push(endpoint);
-        Ok(())
+        Ok(self.binds.last().unwrap())
     }
 
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -146,13 +146,16 @@ impl Socket for SubSocket {
         }
     }
 
-    async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let mut endpoint = endpoint.try_into()?;
-        let stop_handle =
-            util::start_accepting_connections(&mut endpoint, self.backend.clone()).await?;
+    async fn bind(
+        &mut self,
+        endpoint: impl TryIntoEndpoint + 'async_trait,
+    ) -> ZmqResult<&Endpoint> {
+        let endpoint = endpoint.try_into()?;
+        let (endpoint, stop_handle) =
+            util::start_accepting_connections(endpoint, self.backend.clone()).await?;
         self._accept_close_handle = Some(stop_handle);
         self.binds.push(endpoint);
-        Ok(())
+        Ok(self.binds.last().unwrap())
     }
 
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -62,10 +62,10 @@ async fn test_pub_sub_sockets() {
         server_stop_sender.send(()).unwrap();
     }
     let addrs = vec![
+        "tcp://localhost:5553",
         "tcp://127.0.0.1:5554",
         "tcp://[::1]:5555",
         "tcp://127.0.0.1:5556",
-        "tcp://localhost:5557",
     ];
     futures::future::join_all(addrs.into_iter().map(helper)).await;
 }


### PR DESCRIPTION
Zeromq lets you bind to the unspecified ipv4 interface or the unspecified ipv6 interface. It also lets you bind to any available port via port 0. This PR adds the necessary logic for these cases, as well as unit tests for the functionality in `Pub` ports, along with the `Socket::binds()` function which returns a list of the resolved endpoints.

Side note: A lot of these tests are brittle to maintain, because we have to hard code the port numbers that won't clash with any other running processes, or any of the other ports in the unit/integration tests. Its probably a good idea to make a utility for tests to get port numbers that won't conflict with the other tests, but thats out of scope for this PR