### PR TITLE
Added ability to generically convert to &Endpoint without needing ownership of value

### DIFF
--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpStream;
 use tokio_util::codec::Framed;
 
 use crate::codec::*;
-use crate::endpoint::{Endpoint, TryIntoEndpoint};
+use crate::endpoint::{Endpoint, TryAsRefEndpoint, TryIntoEndpoint};
 use crate::error::*;
 use crate::message::*;
 use crate::util::*;
@@ -103,7 +103,10 @@ impl Socket for RouterSocket {
         Ok(endpoint)
     }
 
-    async fn connect(&mut self, _endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
+    async fn connect<E>(&mut self, _endpoint: &E) -> ZmqResult<()>
+    where
+        E: TryAsRefEndpoint + ?Sized,
+    {
         unimplemented!()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod util;
 
 use crate::codec::*;
 pub use crate::dealer_router::*;
-pub use crate::endpoint::{Endpoint, Host, Transport, TryIntoEndpoint};
+pub use crate::endpoint::{Endpoint, Host, Transport, TryAsRefEndpoint, TryIntoEndpoint};
 pub use crate::error::ZmqError;
 pub use crate::r#pub::*;
 pub use crate::rep::*;
@@ -138,9 +138,9 @@ pub trait Socket {
     /// Returns the bound-to endpoint, with the port resolved (if applicable).
     async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<Endpoint>;
 
-    // TODO: Although it would reduce how convenient the function is, taking an
-    // `&Endpoint` would be better for performance here
-    async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
+    async fn connect<E>(&mut self, endpoint: &E) -> ZmqResult<()>
+    where
+        E: TryAsRefEndpoint + ?Sized;
 
     fn binds(&self) -> &HashMap<Endpoint, oneshot::Sender<bool>>;
 }
@@ -149,6 +149,7 @@ pub mod prelude {
     //! Re-exports important traits. Consider glob-importing.
 
     pub use crate::{
-        BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket, TryIntoEndpoint,
+        BlockingRecv, BlockingSend, NonBlockingRecv, NonBlockingSend, Socket, TryAsRefEndpoint,
+        TryIntoEndpoint,
     };
 }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -1,5 +1,5 @@
 use crate::codec::*;
-use crate::endpoint::{Endpoint, TryIntoEndpoint};
+use crate::endpoint::{Endpoint, TryAsRefEndpoint, TryIntoEndpoint};
 use crate::message::*;
 use crate::util::*;
 use crate::{util, MultiPeer, NonBlockingSend, Socket, SocketBackend, SocketType, ZmqResult};
@@ -151,11 +151,14 @@ impl Socket for PubSocket {
         Ok(endpoint)
     }
 
-    async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let endpoint = endpoint.try_into()?;
-        let Endpoint::Tcp(host, port) = endpoint;
+    async fn connect<E>(&mut self, endpoint: &E) -> ZmqResult<()>
+    where
+        E: TryAsRefEndpoint + ?Sized,
+    {
+        let endpoint = endpoint.try_ref()?;
+        let Endpoint::Tcp(host, port) = endpoint.as_ref();
 
-        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), port)).await?;
+        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), *port)).await?;
         util::peer_connected(raw_socket, self.backend.clone()).await;
         Ok(())
     }

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -1,5 +1,5 @@
 use crate::codec::*;
-use crate::endpoint::{Endpoint, TryIntoEndpoint};
+use crate::endpoint::{Endpoint, TryAsRefEndpoint, TryIntoEndpoint};
 use crate::error::*;
 use crate::fair_queue::FairQueue;
 use crate::util::FairQueueProcessor;
@@ -72,11 +72,14 @@ impl Socket for RepSocket {
         Ok(endpoint)
     }
 
-    async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let endpoint = endpoint.try_into()?;
-        let Endpoint::Tcp(host, port) = endpoint;
+    async fn connect<E>(&mut self, endpoint: &E) -> ZmqResult<()>
+    where
+        E: TryAsRefEndpoint + ?Sized,
+    {
+        let endpoint = endpoint.try_ref()?;
+        let Endpoint::Tcp(host, port) = endpoint.as_ref();
 
-        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), port)).await?;
+        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), *port)).await?;
         util::peer_connected(raw_socket, self.backend.clone()).await;
         Ok(())
     }

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,5 +1,5 @@
 use crate::codec::*;
-use crate::endpoint::{Endpoint, TryIntoEndpoint};
+use crate::endpoint::{Endpoint, TryAsRefEndpoint, TryIntoEndpoint};
 use crate::error::*;
 use crate::util::{self, Peer, PeerIdentity};
 use crate::*;
@@ -130,11 +130,14 @@ impl Socket for ReqSocket {
         Ok(endpoint)
     }
 
-    async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
-        let endpoint = endpoint.try_into()?;
-        let Endpoint::Tcp(host, port) = endpoint;
+    async fn connect<E>(&mut self, endpoint: &E) -> ZmqResult<()>
+    where
+        E: TryAsRefEndpoint + ?Sized,
+    {
+        let endpoint = endpoint.try_ref()?;
+        let Endpoint::Tcp(host, port) = endpoint.as_ref();
 
-        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), port)).await?;
+        let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), *port)).await?;
         util::peer_connected(raw_socket, self.backend.clone()).await;
         Ok(())
     }


### PR DESCRIPTION
Rebased on #76, suggest reviewing that one first

TryIntoEndpoint has a signature of `try_into(self)`, which takes ownership over `Self`. This is not conducive to situations where we only have a `&Endpoint` or only need a `&Endpoint` returned, such as in `Socket::connect()`. This PR adds `TryAsRefEndpoint`, a failable version of `AsRef<Endpoint>`. This allows generically passing either `&Endpoint` or `&str` values to a function, and getting out `&Endpoint`, without needing to move in the endpoint or perform a clone.  This allows functions that would want to take `&Endpoint` and return `&Endpoint` to be generic.

~In addition, this PR breaks up the endpoints module into submodules for readability, fixes a bug associated with parsing and displaying `Host`s, and fixes a flaky test.~