### PR TITLE
Ci check and lint tests as well as workspaces

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --all --tests
 
   test:
     name: Test
@@ -39,6 +40,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
+          args: --all
 
   fmt:
     name: Formatting
@@ -76,4 +78,4 @@ jobs:
       - uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features -- --deny warnings
+          args: --all --tests --all-features -- --deny warnings

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -231,8 +231,8 @@ impl ZmqCodec {
 }
 
 impl Decoder for ZmqCodec {
-    type Item = Message;
     type Error = ZmqError;
+    type Item = Message;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if src.len() < self.waiting_for {
@@ -325,8 +325,8 @@ impl ZmqCodec {
 }
 
 impl Encoder for ZmqCodec {
-    type Item = Message;
     type Error = ZmqError;
+    type Item = Message;
 
     fn encode(&mut self, message: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
         match message {

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -61,6 +61,7 @@ async fn test_pub_sub_sockets() {
 
         server_stop_sender.send(()).unwrap();
     }
+
     let addrs = vec![
         "tcp://127.0.0.1:5554",
         "tcp://[::1]:5555",


### PR DESCRIPTION
Clippy and check were not running on tests. Additionally, all of the commands only ran on the particular package, rather than all packages (only relevant in the presence of multiple workspaces, of course). This PR addresses these issues.