### PR TITLE
Ported code to use futures_codec and tokio_util's Compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,13 @@ futures_codec = "0.4"
 chrono = "^0.4"
 criterion = "0.3"
 
-# [[bench]]
-# name = "pub_sub"
-# harness = false
+[lib]
+bench = false
+
+[[bench]]
+name = "pub_sub" 
+harness = false 
+bench = false # Don't actually benchmark this, until we fix it
 
 [[bench]]
 name = "req_rep"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "^0.1"
 rand = "^0.7"
 bytes = "^0.5"
 tokio = { version = "^0.2", features = ["full", "tcp"] }
-tokio-util = { version = "^0.2", features = ["codec"] }
+tokio-util = { version = "0.3", features = ["compat"] }
 num-traits = "^0.2"
 enum-primitive-derive = "^0.1"
 dashmap = "^3.11"
@@ -23,6 +23,7 @@ uuid = { version = "^0.8", features = ["v4"] }
 regex = "1"
 lazy_static = "1"
 log = "0.4"
+futures_codec = "0.4"
 
 [dev-dependencies]
 chrono = "^0.4"

--- a/benches/req_rep.rs
+++ b/benches/req_rep.rs
@@ -79,8 +79,8 @@ criterion_group! {
     name = benches;
     config = Criterion::default()
         .sample_size(128)
-        .measurement_time(Duration::from_secs(32))
-        .warm_up_time(Duration::from_secs(5));
+        .measurement_time(Duration::from_secs(30))
+        .warm_up_time(Duration::from_secs(10));
     targets = criterion_benchmark
 }
 criterion_main!(benches);

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,9 +1,9 @@
 use crate::error::ZmqError;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use futures_codec::{Decoder, Encoder};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Display;
-use tokio_util::codec::{Decoder, Encoder};
 
 use crate::message::*;
 use crate::SocketType;

--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -3,10 +3,10 @@ use dashmap::DashMap;
 use futures::channel::{mpsc, oneshot};
 use futures::lock::Mutex;
 use futures::SinkExt;
+use futures_codec::Framed;
 use std::convert::TryInto;
 use std::sync::Arc;
 use tokio::net::TcpStream;
-use tokio_util::codec::Framed;
 
 use crate::codec::*;
 use crate::endpoint::{Endpoint, TryIntoEndpoint};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ use futures::channel::{mpsc, oneshot};
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
 
-use tokio_util::codec::Framed;
+use futures_codec::Framed;
 
 mod codec;
 mod dealer_router;


### PR DESCRIPTION
This MR is a smaller change than #77, which avoids any dynamic dispatch or boxing. It is intended to isolate the changes to just that what is necessary to use `futures_codec` and `tokio_util::compat` instead of `tokio_util::codec`. 

~**Don't merge this MR** - we need to merge some basic performance benchmarks to master first,~ and then we can see the performance impact of the codec changes, separately from the dynamic dispatch stuff in #77.