### PR TITLE
Basic perf bench using criterion for pub sub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,12 @@ crossbeam = "^0.7"
 uuid = { version = "^0.8", features = ["v4"] }
 regex = "1"
 lazy_static = "1"
-
+log = "0.4"
 
 [dev-dependencies]
 chrono = "^0.4"
+criterion = "0.3"
+
+[[bench]]
+name = "pub_sub"
+harness = false

--- a/benches/pub_sub.rs
+++ b/benches/pub_sub.rs
@@ -1,4 +1,4 @@
-use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tokio::runtime::Runtime;
 
 use zeromq::{prelude::*, PubSocket, SubSocket};
@@ -11,24 +11,71 @@ async fn setup(m_pubs: u8, n_subs: u8) -> (Vec<zeromq::PubSocket>, Vec<zeromq::S
     for _ in 0..m_pubs {
         let mut p = PubSocket::new();
         let bind_endpoint = p.bind("tcp://localhost:0").await.unwrap();
+        println!("Bind endpoint: {}", bind_endpoint);
         for s in subs.iter_mut() {
             s.connect(bind_endpoint.clone()).await.unwrap();
         }
         pubs.push(p);
     }
+
+    for s in subs.iter_mut() {
+        s.subscribe("")
+            .await
+            .expect("Could not set subscription filter");
+    }
+
     (pubs, subs)
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rt = Runtime::new().unwrap();
-    let (mut pubs, mut subs) = rt.block_on(setup(4, 16));
+
+    const M_PUBS: u8 = 1;
+    const N_SUBS: u8 = 16;
+    let (pubs, subs) = rt.block_on(setup(M_PUBS, N_SUBS));
+    assert_eq!(pubs.len(), usize::from(M_PUBS));
+    assert_eq!(subs.len(), usize::from(N_SUBS));
+    // Wrap in option to allow `f` to temporarily assume ownership
+    let (mut pubs, mut subs) = (Some(pubs), Some(subs));
 
     c.bench_function("m pubs and n subs messaging", |b| {
         b.iter(|| rt.block_on(f(&mut pubs, &mut subs)))
     });
 
-    async fn f(pubs: &mut [PubSocket], subs: &mut [SubSocket]) {
-        // Send/Recv messages
+    async fn f(pubs: &mut Option<Vec<PubSocket>>, subs: &mut Option<Vec<SubSocket>>) {
+        let owned_pubs = pubs.take().unwrap();
+        let owned_subs = subs.take().unwrap();
+        const MSGS_PER_PUB: u16 = 100;
+
+        async fn send_msgs(mut pubs: Vec<PubSocket>) -> Vec<PubSocket> {
+            for i in 0..MSGS_PER_PUB {
+                for (j, p) in pubs.iter_mut().enumerate() {
+                    p.send(format!("Sending {}th message from publisher {}", i, j).into())
+                        .expect("Could not send message");
+                }
+            }
+            println!("Sent all messages");
+            pubs
+        }
+        async fn recv_msgs(mut subs: Vec<SubSocket>) -> Vec<SubSocket> {
+            for i in 0..(u32::from(MSGS_PER_PUB) * u32::from(M_PUBS)) {
+                for s in subs.iter_mut() {
+                    println!("Attempting recv");
+                    let msg = s.recv().await.expect("Could not recv");
+                    black_box(msg);
+                }
+                println!("Received {}", i);
+            }
+            subs
+        }
+        println!("Starting send/recv loops");
+        let owned_pubs = tokio::spawn(send_msgs(owned_pubs)).await.unwrap();
+        tokio::time::delay_for(std::time::Duration::from_millis(1000)).await;
+        let owned_subs = tokio::spawn(recv_msgs(owned_subs)).await.unwrap();
+        // let (owned_pubs, owned_subs) = tokio::try_join!(pubs_handle,
+        // subs_handle).unwrap();
+        pubs.replace(owned_pubs);
+        subs.replace(owned_subs);
     }
 }
 

--- a/benches/pub_sub.rs
+++ b/benches/pub_sub.rs
@@ -1,0 +1,36 @@
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use tokio::runtime::Runtime;
+
+use zeromq::{prelude::*, PubSocket, SubSocket};
+
+/// Binds n pubs and connects n subs to them
+async fn setup(m_pubs: u8, n_subs: u8) -> (Vec<zeromq::PubSocket>, Vec<zeromq::SubSocket>) {
+    let mut pubs = Vec::new();
+    let mut subs: Vec<_> = (0..n_subs).map(|_| SubSocket::new()).collect();
+
+    for _ in 0..m_pubs {
+        let mut p = PubSocket::new();
+        let bind_endpoint = p.bind("tcp://localhost:0").await.unwrap();
+        for s in subs.iter_mut() {
+            s.connect(bind_endpoint.clone()).await.unwrap();
+        }
+        pubs.push(p);
+    }
+    (pubs, subs)
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut rt = Runtime::new().unwrap();
+    let (mut pubs, mut subs) = rt.block_on(setup(4, 16));
+
+    c.bench_function("m pubs and n subs messaging", |b| {
+        b.iter(|| rt.block_on(f(&mut pubs, &mut subs)))
+    });
+
+    async fn f(pubs: &mut [PubSocket], subs: &mut [SubSocket]) {
+        // Send/Recv messages
+    }
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -135,7 +135,7 @@ impl RouterSocket {
                     return Ok(envelope);
                 }
                 Some((peer_id, None)) => {
-                    println!("Peer disconnected {:?}", peer_id);
+                    log::info!("Peer disconnected {:?}", peer_id);
                     self.backend.peers.remove(&peer_id);
                 }
                 Some((_peer_id, _)) => todo!(),

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -99,7 +99,7 @@ impl MultiPeer for PubSocketBackend {
     }
 
     async fn peer_disconnected(&self, peer_id: &PeerIdentity) {
-        println!("Client disconnected {:?}", peer_id);
+        log::info!("Client disconnected {:?}", peer_id);
         self.subscribers.remove(peer_id);
     }
 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -2,7 +2,9 @@ use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
 use std::convert::TryInto;
 use std::time::Duration;
+
 use zeromq::prelude::*;
+use zeromq::Endpoint;
 
 #[tokio::test]
 async fn test_pub_sub_sockets() {
@@ -11,14 +13,16 @@ async fn test_pub_sub_sockets() {
 
         let cloned_payload = payload.clone();
         let (server_stop_sender, mut server_stop) = oneshot::channel::<()>();
-        let (has_bound_sender, has_bound) = oneshot::channel::<()>();
+        let (has_bound_sender, has_bound) = oneshot::channel::<Endpoint>();
         tokio::spawn(async move {
             let mut pub_socket = zeromq::PubSocket::new();
-            pub_socket
+            let bound_to = pub_socket
                 .bind(bind_addr)
                 .await
                 .unwrap_or_else(|_| panic!("Failed to bind to {}", bind_addr));
-            has_bound_sender.send(()).expect("channel was dropped");
+            has_bound_sender
+                .send(bound_to)
+                .expect("channel was dropped");
 
             loop {
                 if let Ok(Some(_)) = server_stop.try_recv() {
@@ -34,16 +38,17 @@ async fn test_pub_sub_sockets() {
         // Block until the pub has finished binding
         // TODO: ZMQ sockets should not care about this sort of ordering.
         // See https://github.com/zeromq/zmq.rs/issues/73
-        has_bound.await.expect("channel was cancelled");
+        let bound_addr = has_bound.await.expect("channel was cancelled");
 
         let (sub_results_sender, sub_results) = mpsc::channel(100);
         for _ in 0..10 {
             let mut cloned_sub_sender = sub_results_sender.clone();
             let cloned_payload = payload.clone();
+            let cloned_bound_addr = bound_addr.clone();
             tokio::spawn(async move {
                 let mut sub_socket = zeromq::SubSocket::new();
                 sub_socket
-                    .connect(bind_addr)
+                    .connect(cloned_bound_addr)
                     .await
                     .unwrap_or_else(|_| panic!("Failed to connect to {}", bind_addr));
 
@@ -73,6 +78,9 @@ async fn test_pub_sub_sockets() {
         "tcp://127.0.0.1:5554",
         "tcp://[::1]:5555",
         "tcp://127.0.0.1:5556",
+        "tcp://localhost:0",
+        "tcp://127.0.0.1:0",
+        "tcp://[::1]:0",
     ];
     futures::future::join_all(addrs.into_iter().map(helper)).await;
 }


### PR DESCRIPTION
This PR adds a basic performance benchmark using criterion.rs.

Currently, it hangs on the first `s.recv()` in the `recv_msgs()` function. I can't figure out why it is hanging here. Any ideas?