### PR TITLE
Tests now use 0 port where possible to avoid collisions

### DIFF
--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -42,6 +42,11 @@ async fn test_pub_sub_sockets() {
         // TODO: ZMQ sockets should not care about this sort of ordering.
         // See https://github.com/zeromq/zmq.rs/issues/73
         let bound_addr = has_bound.await.expect("channel was cancelled");
+        assert!(if let Endpoint::Tcp(_host, port) = bound_addr.clone() {
+            port != 0
+        } else {
+            unreachable!()
+        });
 
         let (sub_results_sender, sub_results) = mpsc::channel(100);
         for _ in 0..10 {
@@ -82,10 +87,10 @@ async fn test_pub_sub_sockets() {
     }
 
     let addrs = vec![
-        "tcp://localhost:5553",
-        "tcp://127.0.0.1:5554",
-        "tcp://[::1]:5555",
-        "tcp://127.0.0.1:5556",
+        "tcp://localhost:0",
+        "tcp://127.0.0.1:0",
+        "tcp://[::1]:0",
+        "tcp://127.0.0.1:0",
         "tcp://localhost:0",
         "tcp://127.0.0.1:0",
         "tcp://[::1]:0",

--- a/tests/rep_req.rs
+++ b/tests/rep_req.rs
@@ -1,11 +1,11 @@
+use zeromq::prelude::*;
+use zeromq::RepSocket;
+
 use std::convert::TryInto;
 use std::error::Error;
 use std::time::Duration;
-use zeromq::prelude::*;
 
-async fn run_rep_server() -> Result<(), Box<dyn Error>> {
-    let mut rep_socket = zeromq::RepSocket::new();
-    rep_socket.bind("tcp://127.0.0.1:5557").await?;
+async fn run_rep_server(mut rep_socket: RepSocket) -> Result<(), Box<dyn Error>> {
     println!("Started rep server on tcp://127.0.0.1:5557");
 
     for i in 0..10i32 {
@@ -19,14 +19,16 @@ async fn run_rep_server() -> Result<(), Box<dyn Error>> {
 
 #[tokio::test]
 async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
-    tokio::spawn(async move {
-        run_rep_server().await.unwrap();
+    let mut rep_socket = zeromq::RepSocket::new();
+    let endpoint = rep_socket.bind("tcp://localhost:0").await?;
+    println!("Started rep server on {}", endpoint);
+
+    tokio::spawn(async {
+        run_rep_server(rep_socket).await.unwrap();
     });
 
-    // yield for a moment to ensure that server has some time to open socket
-    tokio::time::delay_for(Duration::from_millis(10)).await;
     let mut req_socket = zeromq::ReqSocket::new();
-    req_socket.connect("tcp://127.0.0.1:5557").await?;
+    req_socket.connect(endpoint).await?;
 
     for i in 0..10i32 {
         req_socket.send(format!("Req - {}", i).into()).await?;
@@ -38,12 +40,17 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
 
 #[tokio::test]
 async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
+    let mut rep_socket = zeromq::RepSocket::new();
+    let endpoint = rep_socket.bind("tcp://localhost:0").await?;
+    println!("Started rep server on {}", endpoint);
+
     for i in 0..100i32 {
+        let cloned_endpoint = endpoint.clone();
         tokio::spawn(async move {
             // yield for a moment to ensure that server has some time to open socket
             tokio::time::delay_for(Duration::from_millis(100)).await;
             let mut req_socket = zeromq::ReqSocket::new();
-            req_socket.connect("tcp://127.0.0.1:5558").await.unwrap();
+            req_socket.connect(cloned_endpoint).await.unwrap();
 
             for j in 0..100i32 {
                 req_socket
@@ -56,10 +63,6 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
             drop(req_socket);
         });
     }
-
-    let mut rep_socket = zeromq::RepSocket::new();
-    rep_socket.bind("tcp://127.0.0.1:5558").await?;
-    println!("Started rep server on tcp://127.0.0.1:5558");
 
     for _ in 0..10000i32 {
         let mess: String = rep_socket.recv().await?.try_into()?;


### PR DESCRIPTION
The tests can easily collide on ports. Refactored to use port 0 select any free port instead.