### PR TITLE
Further generalize across transports

### DIFF
--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -7,6 +7,7 @@ pub use transport::Transport;
 use lazy_static::lazy_static;
 use regex::Regex;
 use std::fmt;
+use std::net::SocketAddr;
 use std::str::FromStr;
 
 use crate::error::EndpointError;
@@ -37,6 +38,11 @@ impl Endpoint {
         match self {
             Self::Tcp(_, _) => Transport::Tcp,
         }
+    }
+
+    /// Creates an `Endpoint::Tcp` from a [`SocketAddr`]
+    pub fn from_tcp_sock_addr(addr: SocketAddr) -> Self {
+        Endpoint::Tcp(addr.ip().into(), addr.port())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use crate::sub::*;
 pub use message::*;
 
 use crate::codec::*;
+use crate::transport::AcceptStopChannel;
 use crate::util::*;
 
 #[macro_use]
@@ -141,7 +142,7 @@ pub trait Socket {
     // `&Endpoint` would be better for performance here
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()>;
 
-    fn binds(&self) -> &HashMap<Endpoint, oneshot::Sender<bool>>;
+    fn binds(&self) -> &HashMap<Endpoint, AcceptStopChannel>;
 }
 
 pub mod prelude {

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -2,7 +2,7 @@ use crate::codec::*;
 use crate::endpoint::{Endpoint, TryIntoEndpoint};
 use crate::fair_queue::FairQueue;
 use crate::message::*;
-use crate::transport;
+use crate::transport::{self, AcceptStopChannel};
 use crate::util::*;
 use crate::{util, BlockingRecv, MultiPeer, Socket, SocketBackend, SocketType, ZmqResult};
 
@@ -30,7 +30,7 @@ pub struct SubSocket {
     backend: Arc<SubSocketBackend>,
     fair_queue: mpsc::Receiver<(PeerIdentity, Message)>,
     _fair_queue_close_handle: oneshot::Sender<bool>,
-    binds: HashMap<Endpoint, oneshot::Sender<bool>>,
+    binds: HashMap<Endpoint, AcceptStopChannel>,
 }
 
 impl Drop for SubSocket {
@@ -147,11 +147,10 @@ impl Socket for SubSocket {
 
     async fn bind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<Endpoint> {
         let endpoint = endpoint.try_into()?;
-        let Endpoint::Tcp(host, port) = endpoint;
 
         let cloned_backend = self.backend.clone();
         let cback = move |result| util::peer_connected(result, cloned_backend.clone());
-        let (endpoint, stop_handle) = transport::tcp::begin_accept(host, port, cback).await?;
+        let (endpoint, stop_handle) = transport::begin_accept(endpoint, cback).await?;
 
         self.binds.insert(endpoint.clone(), stop_handle);
         Ok(endpoint)
@@ -159,14 +158,13 @@ impl Socket for SubSocket {
 
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
         let endpoint = endpoint.try_into()?;
-        let Endpoint::Tcp(host, port) = endpoint;
 
-        let connect_result = transport::tcp::connect(host, port).await;
+        let connect_result = transport::connect(endpoint).await;
         util::peer_connected(connect_result, self.backend.clone()).await;
         Ok(())
     }
 
-    fn binds(&self) -> &HashMap<Endpoint, oneshot::Sender<bool>> {
+    fn binds(&self) -> &HashMap<Endpoint, AcceptStopChannel> {
         &self.binds
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,1 +1,33 @@
-pub mod tcp;
+mod tcp;
+
+use crate::codec::FramedIo;
+use crate::endpoint::Endpoint;
+use crate::ZmqResult;
+
+pub(crate) async fn connect(endpoint: Endpoint) -> ZmqResult<(FramedIo, Endpoint)> {
+    match endpoint {
+        Endpoint::Tcp(host, port) => tcp::connect(host, port).await,
+    }
+}
+
+pub struct AcceptStopChannel(pub(crate) futures::channel::oneshot::Sender<()>);
+
+/// Spawns an async task that listens for connections at the provided endpoint.
+///
+/// `cback` will be invoked when a connection is accepted. If the result was
+/// `Ok`, it will receive a tuple containing the framed raw socket, along with
+/// the endpoint of the remote connection accepted.
+///
+/// Returns a ZmqResult, which when Ok is a tuple of the resolved bound
+/// endpoint, as well as a channel to stop the async accept task
+pub(crate) async fn begin_accept<T>(
+    endpoint: Endpoint,
+    cback: impl Fn(ZmqResult<(FramedIo, Endpoint)>) -> T + Send + 'static,
+) -> ZmqResult<(Endpoint, AcceptStopChannel)>
+where
+    T: std::future::Future<Output = ()> + Send + 'static,
+{
+    match endpoint {
+        Endpoint::Tcp(host, port) => tcp::begin_accept(host, port, cback).await,
+    }
+}

--- a/src/transport/tcp/mod.rs
+++ b/src/transport/tcp/mod.rs
@@ -4,25 +4,18 @@ mod tokio;
 use self::tokio as tk;
 use crate::codec::FramedIo;
 use crate::endpoint::{Endpoint, Host, Port};
+use crate::transport::AcceptStopChannel;
 use crate::ZmqResult;
 
-use std::net::SocketAddr;
-
-pub(crate) async fn connect(host: Host, port: Port) -> ZmqResult<(FramedIo, SocketAddr)> {
+pub(crate) async fn connect(host: Host, port: Port) -> ZmqResult<(FramedIo, Endpoint)> {
     tk::connect(host, port).await
 }
 
-/// Spawns an async task that listens for tcp connections at the provided
-/// address.
-///
-/// `cback` will be invoked when a tcp connection is accepted. If the result was
-/// `Ok`, we get a tuple containing the framed raw socket, along with the ip
-/// address of the remote connection accepted.
 pub(crate) async fn begin_accept<T>(
     host: Host,
     port: Port,
-    cback: impl Fn(ZmqResult<(FramedIo, SocketAddr)>) -> T + Send + 'static,
-) -> ZmqResult<(Endpoint, futures::channel::oneshot::Sender<bool>)>
+    cback: impl Fn(ZmqResult<(FramedIo, Endpoint)>) -> T + Send + 'static,
+) -> ZmqResult<(Endpoint, AcceptStopChannel)>
 where
     T: std::future::Future<Output = ()> + Send + 'static,
 {

--- a/src/transport/tcp/tokio.rs
+++ b/src/transport/tcp/tokio.rs
@@ -2,30 +2,33 @@
 
 use crate::codec::FramedIo;
 use crate::endpoint::{Endpoint, Host, Port};
+use crate::transport::AcceptStopChannel;
 use crate::ZmqResult;
 
 use futures::{select, FutureExt};
-use std::net::SocketAddr;
 use tokio_util::compat::Tokio02AsyncReadCompatExt;
 
-pub(crate) async fn connect(host: Host, port: Port) -> ZmqResult<(FramedIo, SocketAddr)> {
+pub(crate) async fn connect(host: Host, port: Port) -> ZmqResult<(FramedIo, Endpoint)> {
     let raw_socket = tokio::net::TcpStream::connect((host.to_string().as_str(), port)).await?;
     let remote_addr = raw_socket.peer_addr()?;
     let boxed_sock = Box::new(raw_socket.compat());
-    Ok((FramedIo::new(boxed_sock), remote_addr))
+    Ok((
+        FramedIo::new(boxed_sock),
+        Endpoint::from_tcp_sock_addr(remote_addr),
+    ))
 }
 
 pub(crate) async fn begin_accept<T>(
     mut host: Host,
     port: Port,
-    cback: impl Fn(ZmqResult<(FramedIo, SocketAddr)>) -> T + Send + 'static,
-) -> ZmqResult<(Endpoint, futures::channel::oneshot::Sender<bool>)>
+    cback: impl Fn(ZmqResult<(FramedIo, Endpoint)>) -> T + Send + 'static,
+) -> ZmqResult<(Endpoint, AcceptStopChannel)>
 where
     T: std::future::Future<Output = ()> + Send + 'static,
 {
     let mut listener = tokio::net::TcpListener::bind((host.to_string().as_str(), port)).await?;
     let resolved_addr = listener.local_addr()?;
-    let (stop_handle, stop_callback) = futures::channel::oneshot::channel::<bool>();
+    let (stop_handle, stop_callback) = futures::channel::oneshot::channel::<()>();
     tokio::spawn(async move {
         let mut stop_callback = stop_callback.fuse();
         loop {
@@ -33,7 +36,7 @@ where
                 incoming = listener.accept().fuse() => {
                     let maybe_accepted: Result<_, _> = incoming.map(|(raw_sock, remote_addr)| {
                         let raw_sock = FramedIo::new(Box::new(raw_sock.compat()));
-                        (raw_sock, remote_addr)
+                        (raw_sock, Endpoint::from_tcp_sock_addr(remote_addr))
                     }).map_err(|err| err.into());
                     tokio::spawn(cback(maybe_accepted.into()));
                 },
@@ -53,5 +56,5 @@ where
         debug_assert_eq!(ip, resolved_addr.ip());
         host = resolved_host;
     }
-    Ok((Endpoint::Tcp(host, port), stop_handle))
+    Ok((Endpoint::Tcp(host, port), AcceptStopChannel(stop_handle)))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,6 @@ use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use futures::SinkExt;
 use std::convert::{TryFrom, TryInto};
-use std::net::SocketAddr;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -144,10 +143,10 @@ pub(crate) async fn ready_exchange(
 }
 
 pub(crate) async fn peer_connected(
-    accept_result: ZmqResult<(FramedIo, SocketAddr)>,
+    accept_result: ZmqResult<(FramedIo, Endpoint)>,
     backend: Arc<dyn MultiPeer>,
 ) {
-    let (mut raw_socket, _remote_addr) = accept_result.expect("Failed to accept");
+    let (mut raw_socket, _remote_endpoint) = accept_result.expect("Failed to accept");
     greet_exchange(&mut raw_socket)
         .await
         .expect("Failed to exchange greetings");


### PR DESCRIPTION
~Rebased on #77 - I suggest diffing against that for review~

In preparation for new transport types, this PR takes steps to generalize the signatures of `transport::connect()` and `transport::begin_accept()`. This should help make it trivial to add support for new transports to pubsub and reqrep. It also wraps the oneshot channel for killing the accept task in a struct to increase type safety.