### PR TITLE
Fix racey unbind in tests, and add Socket.close() and Socket.unbind()

### DIFF
--- a/src/dealer_router.rs
+++ b/src/dealer_router.rs
@@ -11,12 +11,12 @@ use std::sync::Arc;
 use crate::codec::FramedIo;
 use crate::codec::*;
 use crate::endpoint::{Endpoint, TryIntoEndpoint};
-use crate::error::*;
+use crate::error::{ZmqError, ZmqResult};
 use crate::message::*;
 use crate::transport::{self, AcceptStopHandle};
 use crate::util::{self, Peer, PeerIdentity};
+use crate::SocketType;
 use crate::{MultiPeer, Socket, SocketBackend};
-use crate::{SocketType, ZmqResult};
 
 struct RouterSocketBackend {
     pub(crate) peers: Arc<DashMap<PeerIdentity, Peer>>,
@@ -104,6 +104,14 @@ impl Socket for RouterSocket {
 
         self.binds.insert(endpoint.clone(), stop_handle);
         Ok(endpoint)
+    }
+
+    async fn unbind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
+        let endpoint = endpoint.try_into()?;
+
+        let stop_handle = self.binds.remove(&endpoint);
+        let stop_handle = stop_handle.ok_or(ZmqError::NoSuchBind(endpoint))?;
+        stop_handle.0.shutdown().await
     }
 
     async fn connect(&mut self, _endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use crate::codec::{CodecError, Message};
+use crate::endpoint::Endpoint;
 use crate::endpoint::EndpointError;
 use crate::task_handle::TaskError;
 use crate::ZmqMessage;
@@ -13,6 +14,8 @@ pub enum ZmqError {
     Endpoint(#[from] EndpointError),
     #[error("Network Error: {0}")]
     Network(#[from] std::io::Error),
+    #[error("Socket bind doesn't exist: {0}")]
+    NoSuchBind(Endpoint),
     #[error("Codec Error: {0}")]
     Codec(#[from] CodecError),
     #[error("Socket Error: {0}")]

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -77,6 +77,14 @@ impl Socket for RepSocket {
         Ok(endpoint)
     }
 
+    async fn unbind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
+        let endpoint = endpoint.try_into()?;
+
+        let stop_handle = self.binds.remove(&endpoint);
+        let stop_handle = stop_handle.ok_or(ZmqError::NoSuchBind(endpoint))?;
+        stop_handle.0.shutdown().await
+    }
+
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
         let endpoint = endpoint.try_into()?;
 

--- a/src/req.rs
+++ b/src/req.rs
@@ -134,6 +134,14 @@ impl Socket for ReqSocket {
         Ok(endpoint)
     }
 
+    async fn unbind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
+        let endpoint = endpoint.try_into()?;
+
+        let stop_handle = self.binds.remove(&endpoint);
+        let stop_handle = stop_handle.ok_or(ZmqError::NoSuchBind(endpoint))?;
+        stop_handle.0.shutdown().await
+    }
+
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
         let endpoint = endpoint.try_into()?;
 

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -1,10 +1,11 @@
 use crate::codec::*;
 use crate::endpoint::{Endpoint, TryIntoEndpoint};
+use crate::error::{ZmqError, ZmqResult};
 use crate::fair_queue::FairQueue;
 use crate::message::*;
 use crate::transport::{self, AcceptStopHandle};
-use crate::util::*;
-use crate::{util, BlockingRecv, MultiPeer, Socket, SocketBackend, SocketType, ZmqResult};
+use crate::util::{self, FairQueueProcessor, PeerIdentity};
+use crate::{BlockingRecv, MultiPeer, Socket, SocketBackend, SocketType};
 
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
@@ -154,6 +155,14 @@ impl Socket for SubSocket {
 
         self.binds.insert(endpoint.clone(), stop_handle);
         Ok(endpoint)
+    }
+
+    async fn unbind(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {
+        let endpoint = endpoint.try_into()?;
+
+        let stop_handle = self.binds.remove(&endpoint);
+        let stop_handle = stop_handle.ok_or(ZmqError::NoSuchBind(endpoint))?;
+        stop_handle.0.shutdown().await
     }
 
     async fn connect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) -> ZmqResult<()> {

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -39,6 +39,11 @@ async fn test_pub_sub_sockets() {
                     .expect("Failed to send");
                 tokio::time::delay_for(Duration::from_millis(1)).await;
             }
+
+            let errs = pub_socket.close().await;
+            if !errs.is_empty() {
+                panic!("Could not unbind socket: {:?}", errs);
+            }
         }));
         // Block until the pub has finished binding
         // TODO: ZMQ sockets should not care about this sort of ordering.
@@ -95,6 +100,7 @@ async fn test_pub_sub_sockets() {
         "tcp://127.0.0.1:0",
         "tcp://[::1]:0",
         "ipc://asdf.sock",
+        "ipc://anothersocket-asdf",
     ];
     futures::future::join_all(addrs.into_iter().map(helper)).await;
 }

--- a/tests/rep_req.rs
+++ b/tests/rep_req.rs
@@ -13,7 +13,10 @@ async fn run_rep_server(mut rep_socket: RepSocket) -> Result<(), Box<dyn Error>>
         rep_socket.send(format!("{} Rep - {}", mess, i).into())?;
     }
     // yield for a moment to ensure that server has some time to flush socket
-    tokio::time::delay_for(Duration::from_millis(100)).await;
+    let errs = rep_socket.close().await;
+    if !errs.is_empty() {
+        panic!("Could not unbind socket: {:?}", errs);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Currently rebased on #88 

Fixes #87 by giving users the ability to `close()` sockets, which will block until the socket is destroyed. Updates the tests to use this feature.