### PR TITLE
Added ipc benchmark

### DIFF
--- a/benches/req_rep.rs
+++ b/benches/req_rep.rs
@@ -5,12 +5,11 @@ use tokio::runtime::Runtime;
 
 use zeromq::{prelude::*, RepSocket, ReqSocket};
 
-async fn setup() -> (ReqSocket, RepSocket) {
+type BenchGroup<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
+
+async fn setup(endpoint: &str) -> (ReqSocket, RepSocket) {
     let mut rep_socket = RepSocket::new();
-    let bind_endpoint = rep_socket
-        .bind("tcp://localhost:0")
-        .await
-        .expect("failed to bind rep");
+    let bind_endpoint = rep_socket.bind(endpoint).await.expect("failed to bind rep");
     println!("Bound rep socket to {}", &bind_endpoint);
 
     let mut req_socket = ReqSocket::new();
@@ -25,16 +24,23 @@ async fn setup() -> (ReqSocket, RepSocket) {
 fn criterion_benchmark(c: &mut Criterion) {
     let mut rt = Runtime::new().unwrap();
 
-    let (req, rep) = rt.block_on(setup());
-    let (mut req, mut rep) = (Some(req), Some(rep));
-
     const N_MSG: u32 = 512;
 
-    c.bench_function("1 req and 1 rep messaging", |b| {
-        b.iter(|| rt.block_on(f(&mut req, &mut rep)))
-    });
+    let mut group = c.benchmark_group("1-1 Req Rep messaging");
 
-    async fn f(req: &mut Option<ReqSocket>, rep: &mut Option<RepSocket>) {
+    bench(&mut group, "TCP", "tcp://localhost:0", &mut rt);
+    bench(&mut group, "IPC", "ipc://req_rep.sock", &mut rt);
+
+    fn bench(group: &mut BenchGroup, bench_name: &str, endpoint: &str, rt: &mut Runtime) {
+        let (req, rep) = rt.block_on(setup(endpoint));
+        let (mut req, mut rep) = (Some(req), Some(rep));
+
+        group.bench_function(bench_name, |b| {
+            b.iter(|| rt.block_on(iter_fn(&mut req, &mut rep)))
+        });
+    }
+
+    async fn iter_fn(req: &mut Option<ReqSocket>, rep: &mut Option<RepSocket>) {
         let mut req_owned = req.take().unwrap();
         let mut rep_owned = rep.take().unwrap();
         let rep_handle = tokio::spawn(async move {

--- a/src/endpoint/host.rs
+++ b/src/endpoint/host.rs
@@ -81,7 +81,7 @@ impl TryFrom<String> for Host {
 impl FromStr for Host {
     type Err = EndpointError;
 
-    /// Equivalent to [`Self::try_from()`]
+    /// Equivalent to [`TryFrom<String>`]
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_string();
         Self::try_from(s)

--- a/src/transport/ipc/tokio.rs
+++ b/src/transport/ipc/tokio.rs
@@ -1,3 +1,5 @@
+//! Tokio-specific implementations
+
 use crate::codec::FramedIo;
 use crate::endpoint::Endpoint;
 use crate::transport::AcceptStopChannel;

--- a/src/transport/tcp/tokio.rs
+++ b/src/transport/tcp/tokio.rs
@@ -1,4 +1,4 @@
-//! Tokio-specific utilities for the functionality in [`super::compat`]
+//! Tokio-specific implementations
 
 use crate::codec::FramedIo;
 use crate::endpoint::{Endpoint, Host, Port};


### PR DESCRIPTION
Adds ipc to the benchmarks for each socket type, and groups them against the other transports for comparison