### PR TITLE
Relax ZMTP version requirements according to the spec

### DIFF
--- a/src/codec/greeting.rs
+++ b/src/codec/greeting.rs
@@ -4,9 +4,11 @@ use super::mechanism::ZmqMechanism;
 use bytes::{Bytes, BytesMut};
 use std::convert::TryFrom;
 
+pub type ZmtpVersion = (u8, u8);
+
 #[derive(Debug, Copy, Clone)]
 pub struct ZmqGreeting {
-    pub version: (u8, u8),
+    pub version: ZmtpVersion,
     pub mechanism: ZmqMechanism,
     pub as_server: bool,
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -8,7 +8,8 @@ mod zmq_codec;
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};
 pub(crate) use framed::{FrameableRead, FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
-pub(crate) use greeting::ZmqGreeting;
+pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
+pub(crate) use mechanism::ZmqMechanism;
 pub(crate) use zmq_codec::ZmqCodec;
 
 use crate::message::ZmqMessage;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::codec::{CodecError, Message};
+use crate::codec::{CodecError, Message, ZmtpVersion};
 use crate::endpoint::Endpoint;
 use crate::endpoint::EndpointError;
 use crate::task_handle::TaskError;
@@ -41,6 +41,8 @@ pub enum ZmqError {
     Other(&'static str),
     #[error("No message received")]
     NoMessage,
+    #[error("Unsupported ZMTP version")]
+    UnsupportedVersion(ZmtpVersion),
 }
 
 impl From<futures::channel::mpsc::TrySendError<Message>> for ZmqError {


### PR DESCRIPTION
One of the compliance tests was failing for me locally, because the peer was using a newer version of the ZMTP protocol.

According to the spec, instead of checking for a specific version supported by this implementation, we should allow any version that is equal or greater, as in this case the peer should adjust to us. If they choose not to, they are expected to close the connection immediately.

Similarly, this implementation may support communication with peers using the older version of the ZMTP protocol in the future.