### PR TITLE
Updated Cargo.toml to consistently use the canonical semver syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,20 +7,20 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-thiserror = "^1"
-futures = "^0.3"
-futures-util = "^0.3"
-async-trait = "^0.1"
+thiserror = "1"
+futures = "0.3"
+futures-util = "0.3"
+async-trait = "0.1"
 parking_lot = "0.11"
-rand = "^0.7"
-bytes = "^0.5"
-tokio = { version = "^0.2", features = ["full", "tcp"] }
+rand = "0.7"
+bytes = "0.5"
+tokio = { version = "0.2", features = ["full", "tcp"] }
 tokio-util = { version = "0.3", features = ["compat"] }
-num-traits = "^0.2"
-enum-primitive-derive = "^0.1"
-dashmap = "^3.11"
-crossbeam = "^0.7"
-uuid = { version = "^0.8", features = ["v4"] }
+num-traits = "0.2"
+enum-primitive-derive = "0.1"
+dashmap = "3.11"
+crossbeam = "0.7"
+uuid = { version = "0.8", features = ["v4"] }
 regex = "1"
 lazy_static = "1"
 log = "0.4"


### PR DESCRIPTION
We mentioned this a few months ago in a PR that the recommended way to specify semver dependencies in Cargo is by omitting the "^" symbol, as its implied. Here's the original thread: https://github.com/zeromq/zmq.rs/pull/88#discussion_r507217746
I've taken the liberty and made the Cargo.toml file consistent with this style, lmk if this cosmetic change is amenable to you!