### PR TITLE
Fixed CI not running for PRs

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -1,5 +1,5 @@
 name: Main CI
-on: [push]
+on: [pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
Currently, CI will run for any pushes on `zeromq/zmq.rs`, but not on pull requests. This works fine for any maintainers of the repo, but contributors with their own forks will not have any CI run for their pull requests. This is because their pull request does not ever `push` to the repo, until after the merge request is approved and merged. This means that untested code via PRs submitted from forked repos can merge to master. You can observe this behavior in #106 for example: At the time of writing, that PR failed CI on my forked repo, but no CI was run on the main repo.

To avoid this, I believe the correct course of action is to have the workflow trigger on pull request, rather than on push. This will solve the fork issue, and @Alexei-Kornienko already opens PRs for everything anyway, it shouldn't impact your workflow. Another solution, but wasteful of resources, would be to run CI both on pull request and on push, as it was before #98 