### PR TITLE
Refactor last few tokio specific parts to be runtime agnostic

### DIFF
--- a/src/async_rt/mod.rs
+++ b/src/async_rt/mod.rs
@@ -1,0 +1,1 @@
+pub mod task;

--- a/src/async_rt/task/mod.rs
+++ b/src/async_rt/task/mod.rs
@@ -16,11 +16,7 @@ pub enum JoinError {
 }
 impl JoinError {
     pub fn is_cancelled(&self) -> bool {
-        if let Self::Cancelled = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Cancelled)
     }
 
     pub fn is_panic(&self) -> bool {

--- a/src/async_rt/task/mod.rs
+++ b/src/async_rt/task/mod.rs
@@ -1,0 +1,4 @@
+mod tokio;
+use self::tokio as rt;
+
+pub use rt::{spawn, spawn_blocking, JoinError, JoinHandle};

--- a/src/async_rt/task/mod.rs
+++ b/src/async_rt/task/mod.rs
@@ -1,4 +1,29 @@
 mod tokio;
+use std::any::Any;
+
 use self::tokio as rt;
 
-pub use rt::{spawn, spawn_blocking, JoinError, JoinHandle};
+pub use rt::{spawn, spawn_blocking, JoinHandle};
+
+/// The type of error the occurred in the task. See [`JoinHandle`].
+///
+/// Note that some async runtimes (like async-std), may not bubble up panics
+/// but instead abort the entire application. In these runtimes, you won't ever
+/// get the opportunity to see the JoinError, because you're already dead.
+pub enum JoinError {
+    Cancelled,
+    Panic(Box<dyn Any + Send + 'static>),
+}
+impl JoinError {
+    pub fn is_cancelled(&self) -> bool {
+        if let Self::Cancelled = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_panic(&self) -> bool {
+        !self.is_cancelled()
+    }
+}

--- a/src/async_rt/task/tokio.rs
+++ b/src/async_rt/task/tokio.rs
@@ -11,6 +11,7 @@ where
     tokio::task::spawn(task).into()
 }
 
+#[allow(unused)]
 pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
 where
     F: FnOnce() -> R + Send + 'static,

--- a/src/async_rt/task/tokio.rs
+++ b/src/async_rt/task/tokio.rs
@@ -1,0 +1,38 @@
+use std::{future::Future, task::Context};
+use std::{pin::Pin, task::Poll};
+
+pub fn spawn<T>(task: T) -> JoinHandle<T::Output>
+where
+    T: Future + Send + 'static,
+    T::Output: Send + 'static,
+{
+    tokio::task::spawn(task).into()
+}
+
+pub fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::task::spawn_blocking(f).into()
+}
+
+pub struct JoinError(tokio::task::JoinError);
+impl From<tokio::task::JoinError> for JoinError {
+    fn from(err: tokio::task::JoinError) -> Self {
+        Self(err)
+    }
+}
+pub struct JoinHandle<T>(tokio::task::JoinHandle<T>);
+impl<T> Future for JoinHandle<T> {
+    type Output = Result<T, JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        tokio::task::JoinHandle::poll(Pin::new(&mut self.0), cx).map_err(|e| e.into())
+    }
+}
+impl<T> From<tokio::task::JoinHandle<T>> for JoinHandle<T> {
+    fn from(h: tokio::task::JoinHandle<T>) -> Self {
+        Self(h)
+    }
+}

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,5 +1,3 @@
-//! General types and traits to facilitate compatibility across async runtimes
-
 use crate::codec::ZmqCodec;
 use futures_codec::{FramedRead, FramedWrite};
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -1,3 +1,6 @@
+//! Implements a codec for ZMQ, providing a way to convert from a byte-oriented
+//! io device to a protocal comprised of [`Message`] frames. See [`FramedIo`]
+
 mod command;
 mod error;
 mod framed;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "1024"]
 
+mod async_rt;
 mod backend;
 mod codec;
 mod dealer;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -97,7 +97,7 @@ impl MultiPeerBackend for PubSocketBackend {
     fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (mut recv_queue, send_queue) = io.into_parts();
         // TODO provide handling for recv_queue
-        let (sender, mut stop_receiver) = oneshot::channel();
+        let (sender, stop_receiver) = oneshot::channel();
         self.subscribers.insert(
             peer_id.clone(),
             Subscriber {
@@ -108,7 +108,7 @@ impl MultiPeerBackend for PubSocketBackend {
         );
         let backend = self;
         let peer_id = peer_id.clone();
-        tokio::spawn(async move {
+        async_rt::task::spawn(async move {
             use futures::StreamExt;
             let mut stop_receiver = stop_receiver.fuse();
             loop {

--- a/src/task_handle.rs
+++ b/src/task_handle.rs
@@ -1,5 +1,4 @@
-pub use self::tk::TaskHandle;
-
+use crate::async_rt;
 use crate::error::{ZmqError, ZmqResult};
 
 use thiserror::Error;
@@ -13,8 +12,8 @@ pub enum TaskError {
     #[error("Task cancelled")]
     Cancelled,
 }
-impl From<tokio::task::JoinError> for TaskError {
-    fn from(err: tokio::task::JoinError) -> Self {
+impl From<async_rt::task::JoinError> for TaskError {
+    fn from(err: async_rt::task::JoinError) -> Self {
         if err.is_panic() {
             TaskError::Panic
         } else {
@@ -24,38 +23,34 @@ impl From<tokio::task::JoinError> for TaskError {
     }
 }
 
-mod tk {
-    use super::*;
-
-    pub struct TaskHandle<T> {
-        // Using options to allow us to move resource without consuming `self`
+pub struct TaskHandle<T> {
+    // Using options to allow us to move resource without consuming `self`
+    stop_channel: futures::channel::oneshot::Sender<()>,
+    join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,
+}
+impl<T> TaskHandle<T> {
+    pub(crate) fn new(
         stop_channel: futures::channel::oneshot::Sender<()>,
-        join_handle: tokio::task::JoinHandle<ZmqResult<T>>,
-    }
-    impl<T> TaskHandle<T> {
-        pub(crate) fn new(
-            stop_channel: futures::channel::oneshot::Sender<()>,
-            join_handle: tokio::task::JoinHandle<ZmqResult<T>>,
-        ) -> Self {
-            Self {
-                stop_channel,
-                join_handle,
-            }
+        join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,
+    ) -> Self {
+        Self {
+            stop_channel,
+            join_handle,
         }
+    }
 
-        /// Shutdown the task and return the task's result, consuming the handle
-        /// in the process
-        #[allow(dead_code)]
-        pub(crate) async fn shutdown(self) -> ZmqResult<T> {
-            // Its ok to ignore possible error, because a dropped channel it has the same
-            // effect as sending stop signal
-            let _ = self.stop_channel.send(());
-            let join_result = self.join_handle.await.map_err(TaskError::from);
-            match join_result {
-                Ok(Ok(ok)) => Ok(ok),
-                Ok(Err(zmq_err)) => Err(zmq_err),
-                Err(task_err) => Err(task_err.into()),
-            }
+    /// Shutdown the task and return the task's result, consuming the handle
+    /// in the process
+    #[allow(dead_code)]
+    pub(crate) async fn shutdown(self) -> ZmqResult<T> {
+        // Its ok to ignore possible error, because a dropped channel it has the same
+        // effect as sending stop signal
+        let _ = self.stop_channel.send(());
+        let join_result = self.join_handle.await.map_err(TaskError::from);
+        match join_result {
+            Ok(Ok(ok)) => Ok(ok),
+            Ok(Err(zmq_err)) => Err(zmq_err),
+            Err(task_err) => Err(task_err.into()),
         }
     }
 }

--- a/src/transport/tcp/tokio.rs
+++ b/src/transport/tcp/tokio.rs
@@ -1,6 +1,7 @@
 //! Tokio-specific implementations
 
 use super::AcceptStopHandle;
+use crate::async_rt;
 use crate::codec::FramedIo;
 use crate::endpoint::{Endpoint, Host, Port};
 use crate::task_handle::TaskHandle;
@@ -29,7 +30,7 @@ where
     let listener = tokio::net::TcpListener::bind((host.to_string().as_str(), port)).await?;
     let resolved_addr = listener.local_addr()?;
     let (stop_channel, stop_callback) = futures::channel::oneshot::channel::<()>();
-    let task_handle = tokio::spawn(async move {
+    let task_handle = async_rt::task::spawn(async move {
         let mut stop_callback = stop_callback.fuse();
         loop {
             select! {
@@ -39,7 +40,7 @@ where
                         let raw_sock = FramedIo::new(Box::new(read.compat()), Box::new(write.compat_write()));
                         (raw_sock, Endpoint::from_tcp_addr(remote_addr))
                     }).map_err(|err| err.into());
-                    tokio::spawn(cback(maybe_accepted));
+                    async_rt::task::spawn(cback(maybe_accepted));
                 },
                 _ = stop_callback => {
                     break


### PR DESCRIPTION
In preparation for #108, this PR refactors the last few places where we bake tokio-specifc functionality into the code, and organizes them into the `async_rt` module. The `async_rt` module will serve as a common denominator between the different runtimes we wish to support, and bundle up any runtime-specific code that we can't accomplish simply with just `futures`.

The main parts of this are providing a way to spawn and join on tasks in a runtime agnostic way, as well as a minor refactor of a couple things that could be done with `futures` instead of `tokio`