### PR TITLE
Feature-gate each transport type

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all --all-targets --no-default-features --features async-std-runtime -- --deny warnings
+          args: --all --all-targets --no-default-features --features async-std-runtime,all-transport -- --deny warnings
 
   test:
     name: Test
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --no-default-features --features async-std-runtime
+          args: --all --no-default-features --features async-std-runtime,all-transport
 
   fmt:
     name: Formatting

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,12 @@ authors = ["Alexei Kornienko <alexei.kornienko@gmail.com>"]
 edition = "2018"
 
 [features]
-default = ["tokio-runtime"]
+default = ["tokio-runtime", "all-transport"]
 tokio-runtime = ["tokio", "tokio-util"]
 async-std-runtime = ["async-std"]
+all-transport = ["ipc-transport", "tcp-transport"]
+ipc-transport = []
+tcp-transport = []
 
 [dependencies]
 thiserror = "1"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Feature flags provide a way to customize the functionality provided by this libr
 Features:
 - (default) `tokio-runtime`: Use `tokio` as your async runtime.
 - `async-std-runtime`: Use `async-std` as your async runtime.
+- (default) `all-transport`: Enable all the `*-transport` flags
+- `ipc-transport`: Enable IPC as a transport mechanism
+- `tcp-transport`: Enable TPC as a transport mechanism
 
 ## Contributing
 Contributions are welcome! See our issue tracker for a list of the things we need help with.

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -10,8 +10,7 @@ impl<T> FrameableWrite for T where T: futures::AsyncWrite + Unpin + Send + Sync 
 pub(crate) type ZmqFramedRead = futures_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 pub(crate) type ZmqFramedWrite = futures_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
 
-/// Equivalent to [`futures_codec::Framed<T, ZmqCodec>`] or
-/// [`tokio_util::codec::Framed`]
+/// Equivalent to [`futures_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
     pub read_half: ZmqFramedRead,
     pub write_half: ZmqFramedWrite,

--- a/src/endpoint/error.rs
+++ b/src/endpoint/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// Represents an error when parsing an [`Endpoint`]
+/// Represents an error when parsing an [`crate::Endpoint`]
 #[derive(Error, Debug)]
 pub enum EndpointError {
     #[error("Failed to parse IP address or port")]

--- a/src/task_handle.rs
+++ b/src/task_handle.rs
@@ -29,6 +29,7 @@ pub struct TaskHandle<T> {
     join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,
 }
 impl<T> TaskHandle<T> {
+    #[allow(unused)]
     pub(crate) fn new(
         stop_channel: futures::channel::oneshot::Sender<()>,
         join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,


### PR DESCRIPTION
Not all platforms will support all transport types. For example, only linux supports ipc, and wasm won't support either ipc or tcp. In preparation for a more robust way of handling platform specific transports, I've gone ahead and feature gated each transport type.

### Notes for review
You will notice that I did not feature gate the actual variants of an `Endpoint`. This is because the public API should not change just because we add or remove a transport feature. Additionally, we likely still want the ability to describe endpoints of various types, regardless of if we actually support interacting with them for a given set of features.