### PR TITLE
Make all socket types support multipart messages.

### DIFF
--- a/examples/message_broker.rs
+++ b/examples/message_broker.rs
@@ -20,22 +20,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .expect("Failed to bind");
     loop {
         select! {
-            router_mess = frontend.recv_multipart().fuse() => {
+            router_mess = frontend.recv().fuse() => {
                 dbg!(&router_mess);
                 match router_mess {
                     Ok(message) => {
-                        backend.send_multipart(message).await?;
+                        backend.send(message).await?;
                     }
                     Err(_) => {
                         todo!()
                     }
                 }
             },
-            dealer_mess = backend.recv_multipart().fuse() => {
+            dealer_mess = backend.recv().fuse() => {
                 dbg!(&dealer_mess);
                 match dealer_mess {
                     Ok(message) => {
-                        frontend.send_multipart(message).await?;
+                        frontend.send(message).await?;
                     }
                     Err(_) => {
                         todo!()

--- a/examples/message_client.rs
+++ b/examples/message_client.rs
@@ -1,6 +1,5 @@
 mod async_helpers;
 
-use std::convert::TryInto;
 use std::error::Error;
 use zeromq::Socket;
 use zeromq::{BlockingRecv, BlockingSend};
@@ -14,11 +13,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .expect("Failed to connect");
 
     socket.send("Hello".into()).await?;
-    let repl: String = socket.recv().await?.try_into()?;
+    let repl = socket.recv().await?;
     dbg!(repl);
 
-    socket.send("NewHello".into()).await?;
-    let repl: String = socket.recv().await?.try_into()?;
+    socket.send("Hello".into()).await?;
+    let repl = socket.recv().await?;
     dbg!(repl);
     Ok(())
 }

--- a/examples/socket_client.rs
+++ b/examples/socket_client.rs
@@ -1,9 +1,7 @@
 mod async_helpers;
 
-use std::convert::TryInto;
 use std::error::Error;
-use zeromq::Socket;
-use zeromq::{BlockingRecv, BlockingSend};
+use zeromq::{BlockingRecv, BlockingSend, Socket};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -16,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for _ in 0..10u64 {
         socket.send("Hello".into()).await?;
-        let repl: String = socket.recv().await?.try_into()?;
+        let repl = socket.recv().await?;
         dbg!(repl);
     }
     Ok(())

--- a/examples/socket_server.rs
+++ b/examples/socket_server.rs
@@ -1,7 +1,7 @@
 mod async_helpers;
 
-use zeromq::*;
 use std::convert::TryInto;
+use zeromq::*;
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let mut repl: String = socket.recv().await?.try_into()?;
         dbg!(&repl);
-	repl.push_str(" Reply");
-	socket.send(repl.into()).await?;
+        repl.push_str(" Reply");
+        socket.send(repl.into()).await?;
     }
 }

--- a/examples/socket_server.rs
+++ b/examples/socket_server.rs
@@ -1,7 +1,7 @@
 mod async_helpers;
 
-use std::convert::TryInto;
 use zeromq::*;
+use std::convert::TryInto;
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         let mut repl: String = socket.recv().await?.try_into()?;
         dbg!(&repl);
-        repl.push_str(" Reply");
-        socket.send(repl.into()).await?;
+	repl.push_str(" Reply");
+	socket.send(repl.into()).await?;
     }
 }

--- a/examples/stock_client.rs
+++ b/examples/stock_client.rs
@@ -1,0 +1,36 @@
+mod async_helpers;
+
+use std::convert::TryInto;
+use std::env;
+use std::error::Error;
+use zeromq::{BlockingRecv, Socket};
+
+#[async_helpers::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let args: Vec<String> = env::args().collect();
+    let mut subscription = "";
+    if args.len() > 1 {
+        subscription = &args[1];
+    }
+    let mut socket = zeromq::SubSocket::new();
+    socket
+        .connect("tcp://127.0.0.1:5556")
+        .await
+        .expect("Failed to connect");
+
+    socket.subscribe(subscription).await?;
+
+    loop {
+        let mut recv = socket.recv().await?;
+        let stock: String = String::from_utf8(recv.pop_front().unwrap().to_vec())?;
+        let price: u32 = u32::from_ne_bytes(
+            recv.pop_front()
+                .unwrap()
+                .to_vec()
+                .try_into()
+                .expect("Couldn't deserialze u32 from data"),
+        );
+        println!("{}: {}", stock, price);
+    }
+    Ok(())
+}

--- a/examples/stock_client.rs
+++ b/examples/stock_client.rs
@@ -21,10 +21,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     socket.subscribe(subscription).await?;
 
     loop {
-        let mut recv = socket.recv().await?;
-        let stock: String = String::from_utf8(recv.pop_front().unwrap().to_vec())?;
+        let recv = socket.recv().await?;
+        let stock: String = String::from_utf8(recv.get(0).unwrap().to_vec())?;
         let price: u32 = u32::from_ne_bytes(
-            recv.pop_front()
+            recv.get(1)
                 .unwrap()
                 .to_vec()
                 .try_into()
@@ -32,5 +32,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
         println!("{}: {}", stock, price);
     }
-    Ok(())
 }

--- a/examples/stock_server.rs
+++ b/examples/stock_server.rs
@@ -1,0 +1,26 @@
+mod async_helpers;
+
+use rand::Rng;
+use std::time::Duration;
+use zeromq::*;
+
+#[async_helpers::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut rng = rand::thread_rng();
+    let stocks: Vec<&str> = vec!["AAA", "ABB", "BBB"];
+    println!("Starting server");
+    let mut socket = zeromq::PubSocket::new();
+    socket.bind("tcp://127.0.0.1:5556").await?;
+
+    println!("Start sending loop");
+    loop {
+        for stock in &stocks {
+            let price: u32 = rng.gen_range(1, 100);
+            let mut m: ZmqMessage = ZmqMessage::from(*stock);
+            m.push_back(price.to_ne_bytes().to_vec().into());
+            dbg!(m.clone());
+            socket.send(m).await?;
+        }
+        async_helpers::sleep(Duration::from_secs(1)).await;
+    }
+}

--- a/examples/task_ventilator.rs
+++ b/examples/task_ventilator.rs
@@ -4,8 +4,7 @@ use rand::Rng;
 use std::error::Error;
 use std::io::Read;
 
-use zeromq::BlockingSend;
-use zeromq::Socket;
+use zeromq::{Socket, BlockingSend};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/task_ventilator.rs
+++ b/examples/task_ventilator.rs
@@ -4,7 +4,7 @@ use rand::Rng;
 use std::error::Error;
 use std::io::Read;
 
-use zeromq::{Socket, BlockingSend};
+use zeromq::{BlockingSend, Socket};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/weather_client.rs
+++ b/examples/weather_client.rs
@@ -1,6 +1,5 @@
 mod async_helpers;
 
-use std::convert::TryInto;
 use std::error::Error;
 
 use zeromq::{BlockingRecv, Socket};
@@ -17,7 +16,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     for i in 0..10 {
         println!("Message {}", i);
-        let repl: String = socket.recv().await?.try_into()?;
+        let repl = socket.recv().await?;
         dbg!(repl);
     }
     Ok(())

--- a/examples/weather_server.rs
+++ b/examples/weather_server.rs
@@ -17,8 +17,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let zipcode = rng.gen_range(10000, 10010);
         let temperature = rng.gen_range(-80, 135);
         let relhumidity = rng.gen_range(10, 60);
-        let message = format!("{} {} {}", zipcode, temperature, relhumidity);
-        socket.send(message.into()).await?;
+        socket.send(format!("{} {} {}", zipcode, temperature, relhumidity).into()).await?;
         async_helpers::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/examples/weather_server.rs
+++ b/examples/weather_server.rs
@@ -17,7 +17,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let zipcode = rng.gen_range(10000, 10010);
         let temperature = rng.gen_range(-80, 135);
         let relhumidity = rng.gen_range(10, 60);
-        socket.send(format!("{} {} {}", zipcode, temperature, relhumidity).into()).await?;
+        socket
+            .send(format!("{} {} {}", zipcode, temperature, relhumidity).into())
+            .await?;
         async_helpers::sleep(Duration::from_millis(100)).await;
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -53,12 +53,6 @@ impl GenericSocketBackend {
                             message: m,
                         })
                     }
-                    Message::Multipart(m) => {
-                        return Err(ZmqError::ReturnToSenderMultipart {
-                            reason: "Not connected to peers. Unable to send messages",
-                            messages: m,
-                        })
-                    }
                 },
             };
             match self.peers.get_mut(&next_peer_id) {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -25,7 +25,6 @@ pub enum Message {
     Greeting(ZmqGreeting),
     Command(ZmqCommand),
     Message(ZmqMessage),
-    Multipart(Vec<ZmqMessage>),
 }
 
 pub(crate) trait TrySend {

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -112,7 +112,10 @@ impl Decoder for ZmqCodec {
 		    self.decode(src)
 		} else if let Some(mut v) = self.buffered_message.take() {
 		    v.push(data.freeze());
-		    Ok(Some(Message::Message(ZmqMessage::from(v))))
+		    match ZmqMessage::try_from(v) {
+			Ok(m) => Ok(Some(Message::Message(m))),
+			Err(_) => Err(CodecError::Other("Can't encode an empty message")),
+		    }
 		} else {
 		    panic!("Corrupted decoder state");
 		}

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -4,10 +4,10 @@ use super::greeting::ZmqGreeting;
 use super::Message;
 use crate::ZmqMessage;
 
-use bytes::{Buf, BufMut, BytesMut, Bytes};
+use bytes::{Buf, BufMut, Bytes, BytesMut};
 use futures_codec::{Decoder, Encoder};
 use std::convert::TryFrom;
-    
+
 #[derive(Debug, Clone, Copy)]
 struct Frame {
     command: bool,
@@ -54,73 +54,73 @@ impl Decoder for ZmqCodec {
     type Item = Message;
 
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
-	if src.len() < self.waiting_for {
-	    src.reserve(self.waiting_for - src.len());
-	    return Ok(None);
-	}
-	match self.state {
-	    DecoderState::Greeting => {
-		if src[0] != 0xff {
-		    return Err(CodecError::Decode("Bad first byte of greeting"));
-		}
-		self.state = DecoderState::FrameHeader;
-		self.waiting_for = 1;
-		Ok(Some(Message::Greeting(ZmqGreeting::try_from(
-		    src.split_to(64).freeze(),
-		)?)))
-	    }
-	    DecoderState::FrameHeader => {
-		let flags = src.get_u8();
-		let command = (flags & 0b0000_0100) != 0;
-		let long = (flags & 0b0000_0010) != 0;
-		let more = (flags & 0b0000_0001) != 0;
+        if src.len() < self.waiting_for {
+            src.reserve(self.waiting_for - src.len());
+            return Ok(None);
+        }
+        match self.state {
+            DecoderState::Greeting => {
+                if src[0] != 0xff {
+                    return Err(CodecError::Decode("Bad first byte of greeting"));
+                }
+                self.state = DecoderState::FrameHeader;
+                self.waiting_for = 1;
+                Ok(Some(Message::Greeting(ZmqGreeting::try_from(
+                    src.split_to(64).freeze(),
+                )?)))
+            }
+            DecoderState::FrameHeader => {
+                let flags = src.get_u8();
+                let command = (flags & 0b0000_0100) != 0;
+                let long = (flags & 0b0000_0010) != 0;
+                let more = (flags & 0b0000_0001) != 0;
 
-		if self.buffered_message.is_none() {
-		    let v: Vec<Bytes> = Vec::new();
-		    self.buffered_message = Some(v);
-		}
-		let frame = Frame {
-		    command,
-		    long,
-		    more,
-		};
-		self.state = DecoderState::FrameLen(frame);
-		self.waiting_for = if frame.long { 8 } else { 1 };
-		self.decode(src)
-	    }
-	    DecoderState::FrameLen(frame) => {
-		self.state = DecoderState::Frame(frame);
-		self.waiting_for = if frame.long {
-		    src.get_u64() as usize
-		} else {
-		    src.get_u8() as usize
-		};
-		self.decode(src)
-	    }
-	    DecoderState::Frame(frame) => {
-		let data = src.split_to(self.waiting_for);
-		self.state = DecoderState::FrameHeader;
-		self.waiting_for = 1;
-		if frame.command {
-		    Ok(Some(Message::Command(ZmqCommand::try_from(data)?)))
-		} else if frame.more {
-		    // cache incoming multipart message
-		    match &mut self.buffered_message {
-			Some(v) => v.push(data.freeze()),
-			_ => panic!("Corrupted decoder state"),
-		    }
-		    self.decode(src)
-		} else if let Some(mut v) = self.buffered_message.take() {
-		    v.push(data.freeze());
-		    match ZmqMessage::try_from(v) {
-			Ok(m) => Ok(Some(Message::Message(m))),
-			Err(_) => Err(CodecError::Other("Can't encode an empty message")),
-		    }
-		} else {
-		    panic!("Corrupted decoder state");
-		}
-	    }
-	}
+                if self.buffered_message.is_none() {
+                    let v: Vec<Bytes> = Vec::new();
+                    self.buffered_message = Some(v);
+                }
+                let frame = Frame {
+                    command,
+                    long,
+                    more,
+                };
+                self.state = DecoderState::FrameLen(frame);
+                self.waiting_for = if frame.long { 8 } else { 1 };
+                self.decode(src)
+            }
+            DecoderState::FrameLen(frame) => {
+                self.state = DecoderState::Frame(frame);
+                self.waiting_for = if frame.long {
+                    src.get_u64() as usize
+                } else {
+                    src.get_u8() as usize
+                };
+                self.decode(src)
+            }
+            DecoderState::Frame(frame) => {
+                let data = src.split_to(self.waiting_for);
+                self.state = DecoderState::FrameHeader;
+                self.waiting_for = 1;
+                if frame.command {
+                    Ok(Some(Message::Command(ZmqCommand::try_from(data)?)))
+                } else if frame.more {
+                    // cache incoming multipart message
+                    match &mut self.buffered_message {
+                        Some(v) => v.push(data.freeze()),
+                        _ => panic!("Corrupted decoder state"),
+                    }
+                    self.decode(src)
+                } else if let Some(mut v) = self.buffered_message.take() {
+                    v.push(data.freeze());
+                    match ZmqMessage::try_from(v) {
+                        Ok(m) => Ok(Some(Message::Message(m))),
+                        Err(_) => Err(CodecError::Other("Can't encode an empty message")),
+                    }
+                } else {
+                    panic!("Corrupted decoder state");
+                }
+            }
+        }
     }
 }
 

--- a/src/dealer.rs
+++ b/src/dealer.rs
@@ -56,11 +56,11 @@ impl Socket for DealerSocket {
 }
 
 impl DealerSocket {
-    pub async fn recv_multipart(&mut self) -> ZmqResult<Vec<ZmqMessage>> {
+    pub async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
         loop {
             match self.fair_queue.next().await {
-                Some((_peer_id, Ok(Message::Multipart(messages)))) => {
-                    return Ok(messages);
+                Some((_peer_id, Ok(Message::Message(message)))) => {
+                    return Ok(message);
                 }
                 Some((_peer_id, _)) => todo!(),
                 None => todo!(),
@@ -68,9 +68,9 @@ impl DealerSocket {
         }
     }
 
-    pub async fn send_multipart(&mut self, messages: Vec<ZmqMessage>) -> ZmqResult<()> {
+    pub async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
         self.backend
-            .send_round_robin(Message::Multipart(messages))
+            .send_round_robin(Message::Message(message))
             .await?;
         Ok(())
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use std::collections::vec_deque::{VecDeque,Iter};
+use std::collections::vec_deque::{Iter, VecDeque};
 use std::convert::{From, TryFrom};
 use std::fmt;
 
@@ -8,7 +8,7 @@ pub struct ZmqEmptyMessageError;
 
 impl fmt::Display for ZmqEmptyMessageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-	write!(f,"Unable to construct an empty ZmqMessage")
+        write!(f, "Unable to construct an empty ZmqMessage")
     }
 }
 
@@ -19,93 +19,95 @@ pub struct ZmqMessage {
 
 impl ZmqMessage {
     pub fn push_back(&mut self, frame: Bytes) {
-	self.frames.push_back(frame);
+        self.frames.push_back(frame);
     }
-    
+
     pub fn push_front(&mut self, frame: Bytes) {
-	self.frames.push_front(frame);
+        self.frames.push_front(frame);
     }
 
     pub fn iter(&self) -> Iter<'_, Bytes> {
-	self.frames.iter()
+        self.frames.iter()
     }
 
     pub(crate) fn pop_front(&mut self) -> Option<Bytes> {
-	self.frames.pop_front()
+        self.frames.pop_front()
     }
 
     pub fn len(&self) -> usize {
-	self.frames.len()
+        self.frames.len()
     }
 
     pub fn is_empty(&self) -> bool {
-	self.frames.is_empty()
+        self.frames.is_empty()
     }
-    
+
     pub fn get(&self, index: usize) -> Option<&Bytes> {
-	self.frames.get(index)
+        self.frames.get(index)
     }
 
     pub fn to_vec(&self) -> Vec<Bytes> {
-	Vec::from(self.frames.clone())
+        Vec::from(self.frames.clone())
     }
 
     pub fn to_vecdeque(&self) -> VecDeque<Bytes> {
-	self.frames.clone()
+        self.frames.clone()
     }
 }
 
 impl TryFrom<Vec<Bytes>> for ZmqMessage {
     type Error = ZmqEmptyMessageError;
-    fn try_from(v: Vec<Bytes>) -> Result<Self,Self::Error> {
-	if v.is_empty() {
-	    Err(ZmqEmptyMessageError)
-	} else {
-	    Ok(Self { frames: v.into() })
-	}
+    fn try_from(v: Vec<Bytes>) -> Result<Self, Self::Error> {
+        if v.is_empty() {
+            Err(ZmqEmptyMessageError)
+        } else {
+            Ok(Self { frames: v.into() })
+        }
     }
 }
 
 impl TryFrom<VecDeque<Bytes>> for ZmqMessage {
     type Error = ZmqEmptyMessageError;
-    fn try_from(v: VecDeque<Bytes>) -> Result<Self,Self::Error> {
-	if v.is_empty() {
-	    Err(ZmqEmptyMessageError)
-	} else {
-	    Ok(Self { frames: v })
-	}
+    fn try_from(v: VecDeque<Bytes>) -> Result<Self, Self::Error> {
+        if v.is_empty() {
+            Err(ZmqEmptyMessageError)
+        } else {
+            Ok(Self { frames: v })
+        }
     }
 }
 
 impl From<Bytes> for ZmqMessage {
     fn from(b: Bytes) -> Self {
-	Self{ frames: vec![b].into() }
+        Self {
+            frames: vec![b].into(),
+        }
     }
 }
 
 impl From<String> for ZmqMessage {
     fn from(s: String) -> Self {
-	let b: Bytes = s.into();
-	ZmqMessage::from(b)
+        let b: Bytes = s.into();
+        ZmqMessage::from(b)
     }
 }
 
 impl From<&str> for ZmqMessage {
     fn from(s: &str) -> Self {
-	ZmqMessage::from(s.to_owned())
-    } 
+        ZmqMessage::from(s.to_owned())
+    }
 }
 
 impl TryFrom<ZmqMessage> for String {
     type Error = &'static str;
-    
+
     fn try_from(mut z: ZmqMessage) -> Result<Self, Self::Error> {
-	if z.len() != 1 {
-	    return Err("Message must have only 1 frame to convert to String");
-	}
-	match String::from_utf8(z.pop_front().unwrap().to_vec()) {
-	    Ok(s) => Ok(s),
-	    Err(_) => Err("Could not parse string from message"),
-	}
+        if z.len() != 1 {
+            return Err("Message must have only 1 frame to convert to String");
+        }
+        match String::from_utf8(z.pop_front().unwrap().to_vec()) {
+            Ok(s) => Ok(s),
+            Err(_) => Err("Could not parse string from message"),
+        }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,10 +8,6 @@ pub struct ZmqMessage {
 }
 
 impl ZmqMessage {
-    pub fn new() -> Self {
-	Self { frames: VecDeque::new() }
-    }
-
     pub fn push_back(&mut self, frame: Bytes) {
 	self.frames.push_back(frame);
     }
@@ -51,11 +47,16 @@ impl From<Vec<Bytes>> for ZmqMessage {
     }
 }
 
+impl From<Bytes> for ZmqMessage {
+    fn from(b: Bytes) -> Self {
+	Self{ frames: vec![b].into() }
+    }
+}
+
 impl From<String> for ZmqMessage {
     fn from(s: String) -> Self {
-	let mut m: ZmqMessage = Default::default();
-	m.push_back(s.into());
-	m
+	let b: Bytes = s.into();
+	ZmqMessage::from(b)
     }
 }
 
@@ -63,12 +64,6 @@ impl From<&str> for ZmqMessage {
     fn from(s: &str) -> Self {
 	ZmqMessage::from(s.to_owned())
     } 
-}
-
-impl Default for ZmqMessage {
-    fn default() -> Self {
-	Self::new()
-    }
 }
 
 impl TryFrom<ZmqMessage> for String {

--- a/src/message.rs
+++ b/src/message.rs
@@ -34,10 +34,6 @@ impl ZmqMessage {
 	self.frames.pop_front()
     }
 
-    pub(crate) fn pop_back(&mut self) -> Option<Bytes> {
-	self.frames.pop_back()
-    }
-
     pub fn len(&self) -> usize {
 	self.frames.len()
     }

--- a/src/message.rs
+++ b/src/message.rs
@@ -49,6 +49,14 @@ impl ZmqMessage {
     pub fn get(&self, index: usize) -> Option<&Bytes> {
 	self.frames.get(index)
     }
+
+    pub fn to_vec(&self) -> Vec<Bytes> {
+	Vec::from(self.frames.clone())
+    }
+
+    pub fn to_vecdeque(&self) -> VecDeque<Bytes> {
+	self.frames.clone()
+    }
 }
 
 impl TryFrom<Vec<Bytes>> for ZmqMessage {

--- a/src/message.rs
+++ b/src/message.rs
@@ -46,12 +46,12 @@ impl ZmqMessage {
         self.frames.get(index)
     }
 
-    pub fn to_vec(&self) -> Vec<Bytes> {
-        Vec::from(self.frames.clone())
+    pub fn to_vec(self) -> Vec<Bytes> {
+        Vec::from(self.frames)
     }
 
-    pub fn to_vecdeque(&self) -> VecDeque<Bytes> {
-        self.frames.clone()
+    pub fn to_vecdeque(self) -> VecDeque<Bytes> {
+        self.frames
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -46,11 +46,11 @@ impl ZmqMessage {
         self.frames.get(index)
     }
 
-    pub fn to_vec(self) -> Vec<Bytes> {
+    pub fn into_vec(self) -> Vec<Bytes> {
         Vec::from(self.frames)
     }
 
-    pub fn to_vecdeque(self) -> VecDeque<Bytes> {
+    pub fn into_vecdeque(self) -> VecDeque<Bytes> {
         self.frames
     }
 }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -32,11 +32,11 @@ pub(crate) struct PubSocketBackend {
 
 impl PubSocketBackend {
     fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let message = match message {
+        let mut message = match message {
             Message::Message(m) => m,
             _ => return,
         };
-        let data: Vec<u8> = message.into();
+        let data: Vec<u8> = message.pop_front().unwrap().to_vec();
         if data.is_empty() {
             return;
         }
@@ -159,7 +159,7 @@ impl BlockingSend for PubSocket {
         let mut dead_peers = Vec::new();
         for mut subscriber in self.backend.subscribers.iter_mut() {
             for sub_filter in &subscriber.subscriptions {
-                if sub_filter.as_slice() == &message.data[0..sub_filter.len()] {
+                if sub_filter.as_slice() == &message.get(0).unwrap()[0..sub_filter.len()] {
                     let res = subscriber
                         .send_queue
                         .as_mut()

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -6,13 +6,13 @@ use crate::transport::AcceptStopHandle;
 use crate::*;
 use crate::{SocketType, ZmqResult};
 use async_trait::async_trait;
+use bytes::Bytes;
 use dashmap::DashMap;
 use futures::SinkExt;
 use futures::StreamExt;
 use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
-use bytes::Bytes;
 
 struct RepPeer {
     pub(crate) _identity: PeerIdentity,
@@ -113,7 +113,7 @@ impl BlockingSend for RepSocket {
         match self.current_request.take() {
             Some(peer_id) => {
                 if let Some(mut peer) = self.backend.peers.get_mut(&peer_id) {
-		    message.push_front(Bytes::from(""));
+                    message.push_front(Bytes::from(""));
                     peer.send_queue.send(Message::Message(message)).await?;
                     Ok(())
                 } else {
@@ -137,15 +137,15 @@ impl BlockingRecv for RepSocket {
         loop {
             match self.fair_queue.next().await {
                 Some((peer_id, Ok(message))) => {
-		    match message {
-			Message::Message(mut m) => {
-			    assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
-			    self.current_request = Some(peer_id);
-			    return Ok(m);
-			},
-			_ => todo!()
-		    }
-		}
+                    match message {
+                        Message::Message(mut m) => {
+                            assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
+                            self.current_request = Some(peer_id);
+                            return Ok(m);
+                        }
+                        _ => todo!(),
+                    }
+                }
                 Some((_peer_id, _)) => todo!(),
                 None => return Err(ZmqError::NoMessage),
             };

--- a/src/req.rs
+++ b/src/req.rs
@@ -7,13 +7,13 @@ use crate::*;
 use crate::{SocketType, ZmqResult};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use crossbeam::queue::SegQueue;
 use dashmap::DashMap;
 use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
-use bytes::Bytes;
-    
+
 struct ReqSocketBackend {
     pub(crate) peers: DashMap<PeerIdentity, Peer>,
     pub(crate) round_robin: SegQueue<PeerIdentity>,
@@ -77,12 +77,12 @@ impl BlockingRecv for ReqSocket {
             Some(peer_id) => {
                 if let Some(mut peer) = self.backend.peers.get_mut(&peer_id) {
                     let message = peer.recv_queue.next().await;
-		    match message {
-			Some(Ok(Message::Message(mut m))) => {
-			    assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
-			    Ok(m)
-			},
-			Some(_) => todo!(),
+                    match message {
+                        Some(Ok(Message::Message(mut m))) => {
+                            assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
+                            Ok(m)
+                        }
+                        Some(_) => todo!(),
                         None => Err(ZmqError::NoMessage),
                     }
                 } else {

--- a/src/req.rs
+++ b/src/req.rs
@@ -12,7 +12,8 @@ use dashmap::DashMap;
 use futures::{SinkExt, StreamExt};
 use std::collections::HashMap;
 use std::sync::Arc;
-
+use bytes::Bytes;
+    
 struct ReqSocketBackend {
     pub(crate) peers: DashMap<PeerIdentity, Peer>,
     pub(crate) round_robin: SegQueue<PeerIdentity>,
@@ -33,7 +34,7 @@ impl Drop for ReqSocket {
 
 #[async_trait]
 impl BlockingSend for ReqSocket {
-    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+    async fn send(&mut self, mut message: ZmqMessage) -> ZmqResult<()> {
         if self.current_request.is_some() {
             return Err(ZmqError::ReturnToSender {
                 reason: "Unable to send message. Request already in progress",
@@ -58,11 +59,8 @@ impl BlockingSend for ReqSocket {
             match self.backend.peers.get_mut(&next_peer_id) {
                 Some(mut peer) => {
                     self.backend.round_robin.push(next_peer_id.clone());
-                    let frames = vec![
-                        "".into(), // delimiter frame
-                        message,
-                    ];
-                    peer.send_queue.send(Message::Multipart(frames)).await?;
+                    message.push_front(Bytes::new());
+                    peer.send_queue.send(Message::Message(message)).await?;
                     self.current_request = Some(next_peer_id);
                     return Ok(());
                 }
@@ -79,13 +77,12 @@ impl BlockingRecv for ReqSocket {
             Some(peer_id) => {
                 if let Some(mut peer) = self.backend.peers.get_mut(&peer_id) {
                     let message = peer.recv_queue.next().await;
-                    match message {
-                        Some(Ok(Message::Multipart(mut message))) => {
-                            assert!(message.len() == 2);
-                            assert!(message[0].data.is_empty()); // Ensure that we have delimeter as first part
-                            Ok(message.pop().unwrap())
-                        }
-                        Some(_) => Err(ZmqError::Other("Wrong message type received")),
+		    match message {
+			Some(Ok(Message::Message(mut m))) => {
+			    assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
+			    Ok(m)
+			},
+			Some(_) => todo!(),
                         None => Err(ZmqError::NoMessage),
                     }
                 } else {

--- a/src/router.rs
+++ b/src/router.rs
@@ -76,9 +76,7 @@ impl RouterSocket {
         let peer_id: PeerIdentity = message.pop_front().unwrap().to_vec().try_into()?;
         match self.backend.peers.get_mut(&peer_id) {
             Some(mut peer) => {
-                peer.send_queue
-                    .send(Message::Message(message))
-                    .await?;
+                peer.send_queue.send(Message::Message(message)).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),

--- a/src/router.rs
+++ b/src/router.rs
@@ -59,12 +59,12 @@ impl Socket for RouterSocket {
 }
 
 impl RouterSocket {
-    pub async fn recv_multipart(&mut self) -> ZmqResult<Vec<ZmqMessage>> {
+    pub async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
         loop {
             match self.fair_queue.next().await {
-                Some((peer_id, Ok(Message::Multipart(mut messages)))) => {
-                    messages.insert(0, peer_id.into());
-                    return Ok(messages);
+                Some((peer_id, Ok(Message::Message(mut message)))) => {
+                    message.push_front(peer_id.into());
+                    return Ok(message);
                 }
                 Some((_peer_id, _)) => todo!(),
                 None => todo!(),
@@ -72,12 +72,12 @@ impl RouterSocket {
         }
     }
 
-    pub async fn send_multipart(&mut self, messages: Vec<ZmqMessage>) -> ZmqResult<()> {
-        let peer_id: PeerIdentity = messages[0].data.to_vec().try_into()?;
+    pub async fn send(&mut self, mut message: ZmqMessage) -> ZmqResult<()> {
+        let peer_id: PeerIdentity = message.pop_front().unwrap().to_vec().try_into()?;
         match self.backend.peers.get_mut(&peer_id) {
             Some(mut peer) => {
                 peer.send_queue
-                    .send(Message::Multipart(messages[1..].to_vec()))
+                    .send(Message::Message(message))
                     .await?;
                 Ok(())
             }

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -29,12 +29,11 @@ impl Drop for SubSocket {
 
 impl SubSocket {
     pub async fn subscribe(&mut self, subscription: &str) -> ZmqResult<()> {
-	let mut message = ZmqMessage::new();
         let mut buf = BytesMut::with_capacity(subscription.len() + 1);
         buf.put_u8(1);
         buf.extend_from_slice(subscription.as_bytes());
         // let message = format!("\0x1{}", subscription);
-	message.push_back(buf.into());
+	let message: ZmqMessage = ZmqMessage::from(buf.freeze());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
                 .send(Message::Message(message.clone()))
@@ -44,11 +43,10 @@ impl SubSocket {
     }
 
     pub async fn unsubscribe(&mut self, subscription: &str) -> ZmqResult<()> {
-	let mut message = ZmqMessage::new();
         let mut buf = BytesMut::with_capacity(subscription.len() + 1);
         buf.put_u8(0);
         buf.extend_from_slice(subscription.as_bytes());
-	message.push_back(buf.into());
+	let  message = ZmqMessage::from(buf.freeze());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
                 .send(Message::Message(message.clone()))

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -33,7 +33,7 @@ impl SubSocket {
         buf.put_u8(1);
         buf.extend_from_slice(subscription.as_bytes());
         // let message = format!("\0x1{}", subscription);
-	let message: ZmqMessage = ZmqMessage::from(buf.freeze());
+        let message: ZmqMessage = ZmqMessage::from(buf.freeze());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
                 .send(Message::Message(message.clone()))
@@ -46,7 +46,7 @@ impl SubSocket {
         let mut buf = BytesMut::with_capacity(subscription.len() + 1);
         buf.put_u8(0);
         buf.extend_from_slice(subscription.as_bytes());
-	let  message = ZmqMessage::from(buf.freeze());
+        let message = ZmqMessage::from(buf.freeze());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
                 .send(Message::Message(message.clone()))

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -29,25 +29,29 @@ impl Drop for SubSocket {
 
 impl SubSocket {
     pub async fn subscribe(&mut self, subscription: &str) -> ZmqResult<()> {
-        let mut message = BytesMut::with_capacity(subscription.len() + 1);
-        message.put_u8(1);
-        message.extend_from_slice(subscription.as_bytes());
+	let mut message = ZmqMessage::new();
+        let mut buf = BytesMut::with_capacity(subscription.len() + 1);
+        buf.put_u8(1);
+        buf.extend_from_slice(subscription.as_bytes());
         // let message = format!("\0x1{}", subscription);
+	message.push_back(buf.into());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
-                .send(Message::Message(message.clone().into()))
+                .send(Message::Message(message.clone()))
                 .await?;
         }
         Ok(())
     }
 
     pub async fn unsubscribe(&mut self, subscription: &str) -> ZmqResult<()> {
-        let mut message = BytesMut::with_capacity(subscription.len() + 1);
-        message.put_u8(0);
-        message.extend_from_slice(subscription.as_bytes());
+	let mut message = ZmqMessage::new();
+        let mut buf = BytesMut::with_capacity(subscription.len() + 1);
+        buf.put_u8(0);
+        buf.extend_from_slice(subscription.as_bytes());
+	message.push_back(buf.into());
         for mut peer in self.backend.peers.iter_mut() {
             peer.send_queue
-                .send(Message::Message(message.clone().into()))
+                .send(Message::Message(message.clone()))
                 .await?;
         }
         Ok(())

--- a/src/util.rs
+++ b/src/util.rs
@@ -290,9 +290,7 @@ pub(crate) mod tests {
         }
 
         // unexpected message during greetings exchange
-        let message = Ok(Message::Message(ZmqMessage {
-            data: Bytes::from_static(b"hello"),
-        }));
+        let message = Ok(Message::Message(ZmqMessage::new()));
         let actual = negotiate_version(Some(message));
         match actual {
             Err(ZmqError::Other(_)) => {}

--- a/src/util.rs
+++ b/src/util.rs
@@ -290,7 +290,7 @@ pub(crate) mod tests {
         }
 
         // unexpected message during greetings exchange
-        let message = Ok(Message::Message(ZmqMessage::new()));
+        let message = Ok(Message::Message(ZmqMessage::from("")));
         let actual = negotiate_version(Some(message));
         match actual {
             Err(ZmqError::Other(_)) => {}

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -71,8 +71,8 @@ async fn test_pub_sub_sockets() {
                 async_rt::task::sleep(std::time::Duration::from_millis(500)).await;
 
                 for _ in 0..10 {
-                    let mut recv_message = sub_socket.recv().await.unwrap();
-		    let recv_payload = String::from_utf8(recv_message.pop_front().unwrap().to_vec()).unwrap();
+                    let recv_message = sub_socket.recv().await.unwrap();
+		    let recv_payload = String::from_utf8(recv_message.get(0).unwrap().to_vec()).unwrap();
                     assert_eq!(cloned_payload, recv_payload);
                     cloned_sub_sender.send(()).await.unwrap();
                 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -35,8 +35,8 @@ async fn test_pub_sub_sockets() {
                     break;
                 }
 
-		let s: String = cloned_payload.clone();
-		let m = ZmqMessage::from(s);
+                let s: String = cloned_payload.clone();
+                let m = ZmqMessage::from(s);
                 pub_socket.send(m).await.expect("Failed to send");
                 async_rt::task::sleep(Duration::from_millis(1)).await;
             }
@@ -72,7 +72,8 @@ async fn test_pub_sub_sockets() {
 
                 for _ in 0..10 {
                     let recv_message = sub_socket.recv().await.unwrap();
-		    let recv_payload = String::from_utf8(recv_message.get(0).unwrap().to_vec()).unwrap();
+                    let recv_payload =
+                        String::from_utf8(recv_message.get(0).unwrap().to_vec()).unwrap();
                     assert_eq!(cloned_payload, recv_payload);
                     cloned_sub_sender.send(()).await.unwrap();
                 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -1,10 +1,10 @@
 use zeromq::prelude::*;
 use zeromq::Endpoint;
+use zeromq::ZmqMessage;
 use zeromq::__async_rt as async_rt;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{SinkExt, StreamExt};
-use std::convert::TryInto;
 use std::time::Duration;
 
 #[async_rt::test]
@@ -35,10 +35,9 @@ async fn test_pub_sub_sockets() {
                     break;
                 }
 
-                pub_socket
-                    .send(cloned_payload.clone().into())
-                    .await
-                    .expect("Failed to send");
+		let mut m = ZmqMessage::new();
+		m.push_back(cloned_payload.clone().into());
+                pub_socket .send(m).await.expect("Failed to send");
                 async_rt::task::sleep(Duration::from_millis(1)).await;
             }
 
@@ -72,12 +71,8 @@ async fn test_pub_sub_sockets() {
                 async_rt::task::sleep(std::time::Duration::from_millis(500)).await;
 
                 for _ in 0..10 {
-                    let recv_payload: String = sub_socket
-                        .recv()
-                        .await
-                        .expect("Failed to recv")
-                        .try_into()
-                        .expect("Malformed string");
+                    let mut recv_message = sub_socket.recv().await.unwrap();
+		    let recv_payload = String::from_utf8(recv_message.pop_front().unwrap().to_vec()).unwrap();
                     assert_eq!(cloned_payload, recv_payload);
                     cloned_sub_sender.send(()).await.unwrap();
                 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -35,9 +35,9 @@ async fn test_pub_sub_sockets() {
                     break;
                 }
 
-		let mut m = ZmqMessage::new();
-		m.push_back(cloned_payload.clone().into());
-                pub_socket .send(m).await.expect("Failed to send");
+		let s: String = cloned_payload.clone();
+		let m = ZmqMessage::from(s);
+                pub_socket.send(m).await.expect("Failed to send");
                 async_rt::task::sleep(Duration::from_millis(1)).await;
             }
 

--- a/tests/pub_sub_compliant.rs
+++ b/tests/pub_sub_compliant.rs
@@ -50,8 +50,8 @@ async fn run_our_subs(our_subs: Vec<zeromq::SubSocket>, num_to_recv: u32) {
     let join_handles = our_subs.into_iter().map(|mut sub| {
         async_rt::task::spawn(async move {
             for i in 0..num_to_recv {
-                let mut msg = sub.recv().await.expect("Failed to recv");
-                let msg_string = String::from_utf8(msg.pop_front().unwrap().to_vec()).unwrap();
+                let msg = sub.recv().await.expect("Failed to recv");
+                let msg_string = String::from_utf8(msg.get(0).unwrap().to_vec()).unwrap();
                 assert_eq!(msg_string, format!("Their message: {}", i));
             }
         })

--- a/tests/pub_sub_compliant.rs
+++ b/tests/pub_sub_compliant.rs
@@ -50,8 +50,8 @@ async fn run_our_subs(our_subs: Vec<zeromq::SubSocket>, num_to_recv: u32) {
     let join_handles = our_subs.into_iter().map(|mut sub| {
         async_rt::task::spawn(async move {
             for i in 0..num_to_recv {
-                let msg = sub.recv().await.expect("Failed to recv");
-                let msg_string = String::from_utf8(msg.data.to_vec()).unwrap();
+                let mut msg = sub.recv().await.expect("Failed to recv");
+                let msg_string = String::from_utf8(msg.pop_front().unwrap().to_vec()).unwrap();
                 assert_eq!(msg_string, format!("Their message: {}", i));
             }
         })

--- a/tests/req_rep.rs
+++ b/tests/req_rep.rs
@@ -1,20 +1,20 @@
 use zeromq::prelude::*;
-use zeromq::RepSocket;
+use zeromq::{RepSocket, ZmqMessage};
 use zeromq::__async_rt as async_rt;
 
 use futures::StreamExt;
-use std::convert::TryInto;
 use std::error::Error;
 use std::time::Duration;
+use std::str;
 
 async fn run_rep_server(mut rep_socket: RepSocket) -> Result<(), Box<dyn Error>> {
     println!("Started rep server on tcp://127.0.0.1:5557");
 
     for i in 0..10i32 {
-        let mess: String = rep_socket.recv().await?.try_into()?;
-        rep_socket
-            .send(format!("{} Rep - {}", mess, i).into())
-            .await?;
+        let mut mess = rep_socket.recv().await?;
+	let m = format!("{} Rep - {}", str::from_utf8(mess.pop_front().unwrap().as_ref()).unwrap(),i);
+	mess.push_back(m.into());
+        rep_socket.send(mess).await?;
     }
     // yield for a moment to ensure that server has some time to flush socket
     let errs = rep_socket.close().await;
@@ -41,9 +41,11 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
     req_socket.connect(endpoint.to_string().as_str()).await?;
 
     for i in 0..10i32 {
-        req_socket.send(format!("Req - {}", i).into()).await?;
-        let repl: String = req_socket.recv().await?.try_into()?;
-        assert_eq!(format!("Req - {} Rep - {}", i, i), repl)
+	let mut m = ZmqMessage::new();
+	m.push_back(format!("Req - {}", i).into());
+        req_socket.send(m).await?;
+        let mut repl = req_socket.recv().await?;
+        assert_eq!(format!("Req - {} Rep - {}", i, i), String::from_utf8(repl.pop_front().unwrap().to_vec()).unwrap())
     }
     req_socket.close().await;
     let events: Vec<_> = monitor.collect().await;
@@ -68,20 +70,21 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
             req_socket.connect(&cloned_endpoint).await.unwrap();
 
             for j in 0..100i32 {
-                req_socket
-                    .send(format!("Socket {} Req - {}", i, j).into())
-                    .await
-                    .unwrap();
-                let repl: String = req_socket.recv().await.unwrap().try_into().unwrap();
-                assert_eq!(format!("Socket {} Req - {} Rep", i, j), repl)
+		let mut m = ZmqMessage::new();
+		m.push_back(format!("Socket {} Req - {}", i, j).into());
+                req_socket.send(m).await.unwrap();
+                let mut repl = req_socket.recv().await.unwrap();
+                assert_eq!(format!("Socket {} Req - {} Rep", i, j), String::from_utf8(repl.pop_front().unwrap().to_vec()).unwrap());
             }
             drop(req_socket);
         });
     }
 
     for _ in 0..10000i32 {
-        let mess: String = rep_socket.recv().await?.try_into()?;
-        rep_socket.send(format!("{} Rep", mess).into()).await?;
+        let mut mess = rep_socket.recv().await?;
+	let payload = String::from_utf8(mess.pop_front().unwrap().to_vec()).unwrap();
+	mess.push_front(format!("{} Rep", payload).into());
+        rep_socket.send(mess).await?;
     }
     Ok(())
 }

--- a/tests/req_rep.rs
+++ b/tests/req_rep.rs
@@ -41,8 +41,8 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
     req_socket.connect(endpoint.to_string().as_str()).await?;
 
     for i in 0..10i32 {
-	let mut m = ZmqMessage::new();
-	m.push_back(format!("Req - {}", i).into());
+	let ms: String = format!("Req - {}", i);
+	let m = ZmqMessage::from(ms);
         req_socket.send(m).await?;
         let mut repl = req_socket.recv().await?;
         assert_eq!(format!("Req - {} Rep - {}", i, i), String::from_utf8(repl.pop_front().unwrap().to_vec()).unwrap())
@@ -70,8 +70,8 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
             req_socket.connect(&cloned_endpoint).await.unwrap();
 
             for j in 0..100i32 {
-		let mut m = ZmqMessage::new();
-		m.push_back(format!("Socket {} Req - {}", i, j).into());
+		let ms: String = format!("Socket {} Req - {}", i, j);
+		let m = ZmqMessage::from(ms);
                 req_socket.send(m).await.unwrap();
                 let mut repl = req_socket.recv().await.unwrap();
                 assert_eq!(format!("Socket {} Req - {} Rep", i, j), String::from_utf8(repl.pop_front().unwrap().to_vec()).unwrap());

--- a/tests/req_rep.rs
+++ b/tests/req_rep.rs
@@ -1,19 +1,23 @@
+use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::{RepSocket, ZmqMessage};
-use zeromq::__async_rt as async_rt;
 
 use futures::StreamExt;
 use std::error::Error;
-use std::time::Duration;
 use std::str;
+use std::time::Duration;
 
 async fn run_rep_server(mut rep_socket: RepSocket) -> Result<(), Box<dyn Error>> {
     println!("Started rep server on tcp://127.0.0.1:5557");
 
     for i in 0..10i32 {
         let mess = rep_socket.recv().await?;
-	let m = format!("{} Rep - {}", str::from_utf8(mess.get(0).unwrap().as_ref()).unwrap(),i);
-	let repl = ZmqMessage::from(m);
+        let m = format!(
+            "{} Rep - {}",
+            str::from_utf8(mess.get(0).unwrap().as_ref()).unwrap(),
+            i
+        );
+        let repl = ZmqMessage::from(m);
         rep_socket.send(repl).await?;
     }
     // yield for a moment to ensure that server has some time to flush socket
@@ -41,11 +45,14 @@ async fn test_req_rep_sockets() -> Result<(), Box<dyn Error>> {
     req_socket.connect(endpoint.to_string().as_str()).await?;
 
     for i in 0..10i32 {
-	let ms: String = format!("Req - {}", i);
-	let m = ZmqMessage::from(ms);
+        let ms: String = format!("Req - {}", i);
+        let m = ZmqMessage::from(ms);
         req_socket.send(m).await?;
         let repl = req_socket.recv().await?;
-        assert_eq!(format!("Req - {} Rep - {}", i, i), String::from_utf8(repl.get(0).unwrap().to_vec()).unwrap())
+        assert_eq!(
+            format!("Req - {} Rep - {}", i, i),
+            String::from_utf8(repl.get(0).unwrap().to_vec()).unwrap()
+        )
     }
     req_socket.close().await;
     let events: Vec<_> = monitor.collect().await;
@@ -70,11 +77,14 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
             req_socket.connect(&cloned_endpoint).await.unwrap();
 
             for j in 0..100i32 {
-		let ms: String = format!("Socket {} Req - {}", i, j);
-		let m = ZmqMessage::from(ms);
+                let ms: String = format!("Socket {} Req - {}", i, j);
+                let m = ZmqMessage::from(ms);
                 req_socket.send(m).await.unwrap();
                 let repl = req_socket.recv().await.unwrap();
-                assert_eq!(format!("Socket {} Req - {} Rep", i, j), String::from_utf8(repl.get(0).unwrap().to_vec()).unwrap());
+                assert_eq!(
+                    format!("Socket {} Req - {} Rep", i, j),
+                    String::from_utf8(repl.get(0).unwrap().to_vec()).unwrap()
+                );
             }
             drop(req_socket);
         });
@@ -82,11 +92,11 @@ async fn test_many_req_rep_sockets() -> Result<(), Box<dyn Error>> {
 
     for _ in 0..10000i32 {
         let mess = rep_socket.recv().await?;
-	let mut payload = String::from_utf8(mess.get(0).unwrap().to_vec()).unwrap();
-	println!("{}",payload);
-	payload.push_str(" Rep");
-	println!("{}",payload);
-	let repl = ZmqMessage::from(payload);
+        let mut payload = String::from_utf8(mess.get(0).unwrap().to_vec()).unwrap();
+        println!("{}", payload);
+        payload.push_str(" Rep");
+        println!("{}", payload);
+        let repl = ZmqMessage::from(payload);
         rep_socket.send(repl).await?;
     }
     Ok(())

--- a/tests/req_rep_compliant.rs
+++ b/tests/req_rep_compliant.rs
@@ -1,10 +1,10 @@
 mod compliance;
 use compliance::{get_monitor_event, setup_monitor};
 
+use std::convert::TryInto;
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::ZmqMessage;
-use std::convert::TryInto;
 
 /// Returns (socket, bound_endpoint, monitor)
 fn setup_their_rep(bind_endpoint: &str) -> (zmq::Socket, String, zmq::Socket) {
@@ -45,8 +45,8 @@ fn run_their_rep(their_rep: zmq::Socket, num_req: u32) -> std::thread::JoinHandl
 
 async fn run_our_req(our_req: &mut zeromq::ReqSocket, num_req: u32) {
     for i in 0..num_req {
-	let ms: String = format!("Request: {}", i);
-	let message = ZmqMessage::from(ms);
+        let ms: String = format!("Request: {}", i);
+        let message = ZmqMessage::from(ms);
         our_req.send(message).await.expect("Failed to send");
         let reply = our_req.recv().await.expect("Failed to recv");
 

--- a/tests/req_rep_compliant.rs
+++ b/tests/req_rep_compliant.rs
@@ -4,6 +4,7 @@ use compliance::{get_monitor_event, setup_monitor};
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::ZmqMessage;
+use std::convert::TryInto;
 
 /// Returns (socket, bound_endpoint, monitor)
 fn setup_their_rep(bind_endpoint: &str) -> (zmq::Socket, String, zmq::Socket) {
@@ -44,14 +45,14 @@ fn run_their_rep(their_rep: zmq::Socket, num_req: u32) -> std::thread::JoinHandl
 
 async fn run_our_req(our_req: &mut zeromq::ReqSocket, num_req: u32) {
     for i in 0..num_req {
-	let mut message = ZmqMessage::new();
-	message.push_back(format!("Request: {}", i).into());
+	let ms: String = format!("Request: {}", i);
+	let message = ZmqMessage::from(ms);
         our_req.send(message).await.expect("Failed to send");
-        let mut reply = our_req.recv().await.expect("Failed to recv");
+        let reply = our_req.recv().await.expect("Failed to recv");
 
-        let reply = String::from_utf8(reply.pop_front().unwrap().as_ref().into()).unwrap();
-        println!("Received reply: {}", &reply);
-        assert_eq!(reply, format!("Reply: {}", i));
+        let reply_payload: String = reply.try_into().unwrap();
+        println!("Received reply: {}", &reply_payload);
+        assert_eq!(reply_payload, format!("Reply: {}", i));
     }
 }
 


### PR DESCRIPTION
The specification says all messages can contain multiple frames.  This
commit gets rid of the distinction between multipart and non multipart
messages.  It does this by having all user facing methods take and
return ZmqMessage structures.  I also modified that structure to be a
wrapper around a VecDeque of Bytes.

Fixes #119 