### PR TITLE
Added basic SocketOptions struct

### DIFF
--- a/examples/socket_client_with_options.rs
+++ b/examples/socket_client_with_options.rs
@@ -1,0 +1,26 @@
+mod async_helpers;
+
+use std::convert::TryFrom;
+use std::error::Error;
+use zeromq::util::PeerIdentity;
+use zeromq::{Socket, SocketOptions, SocketRecv, SocketSend};
+
+#[async_helpers::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut options = SocketOptions::default();
+    options.peer_identity(PeerIdentity::try_from(Vec::from("SomeCustomId")).unwrap());
+
+    let mut socket = zeromq::ReqSocket::with_options(options);
+    socket
+        .connect("tcp://127.0.0.1:5555")
+        .await
+        .expect("Failed to connect");
+    println!("Connected to server");
+
+    for _ in 0..10u64 {
+        socket.send("Hello".into()).await?;
+        let repl = socket.recv().await?;
+        dbg!(repl);
+    }
+    Ok(())
+}

--- a/src/dealer.rs
+++ b/src/dealer.rs
@@ -4,8 +4,8 @@ use crate::fair_queue::FairQueue;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
-    CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketRecv,
-    SocketSend, SocketType, ZmqMessage, ZmqResult,
+    CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
+    SocketRecv, SocketSend, SocketType, ZmqMessage, ZmqResult,
 };
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -28,12 +28,13 @@ impl Drop for DealerSocket {
 
 #[async_trait]
 impl Socket for DealerSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         let fair_queue = FairQueue::new(true);
         Self {
-            backend: Arc::new(GenericSocketBackend::new(
+            backend: Arc::new(GenericSocketBackend::with_options(
                 Some(fair_queue.inner()),
                 SocketType::DEALER,
+                options,
             )),
             fair_queue,
             binds: HashMap::new(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,23 @@ pub enum SocketEvent {
     Disconnected(PeerIdentity),
 }
 
+pub struct SocketOptions {
+    pub(crate) peer_id: Option<PeerIdentity>,
+}
+
+impl SocketOptions {
+    pub fn peer_identity(&mut self, peer_id: PeerIdentity) -> &mut Self {
+        self.peer_id = Some(peer_id);
+        self
+    }
+}
+
+impl Default for SocketOptions {
+    fn default() -> Self {
+        Self { peer_id: None }
+    }
+}
+
 pub trait MultiPeerBackend: SocketBackend {
     /// This should not be public..
     /// Find a better way of doing this
@@ -135,6 +152,7 @@ pub trait MultiPeerBackend: SocketBackend {
 
 pub trait SocketBackend: Send + Sync {
     fn socket_type(&self) -> SocketType;
+    fn socket_options(&self) -> &SocketOptions;
     fn shutdown(&self);
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>>;
 }
@@ -155,7 +173,11 @@ pub trait CaptureSocket: SocketSend {}
 
 #[async_trait]
 pub trait Socket: Sized + Send {
-    fn new() -> Self;
+    fn new() -> Self {
+        Self::with_options(SocketOptions::default())
+    }
+
+    fn with_options(options: SocketOptions) -> Self;
 
     fn backend(&self) -> Arc<dyn MultiPeerBackend>;
 

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -4,7 +4,8 @@ use crate::fair_queue::FairQueue;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
-    Endpoint, MultiPeerBackend, Socket, SocketEvent, SocketRecv, SocketType, ZmqMessage, ZmqResult,
+    Endpoint, MultiPeerBackend, Socket, SocketEvent, SocketOptions, SocketRecv, SocketType,
+    ZmqMessage, ZmqResult,
 };
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -21,12 +22,13 @@ pub struct PullSocket {
 
 #[async_trait]
 impl Socket for PullSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         let fair_queue = FairQueue::new(true);
         Self {
-            backend: Arc::new(GenericSocketBackend::new(
+            backend: Arc::new(GenericSocketBackend::with_options(
                 Some(fair_queue.inner()),
                 SocketType::PULL,
+                options,
             )),
             fair_queue,
             binds: HashMap::new(),

--- a/src/push.rs
+++ b/src/push.rs
@@ -2,8 +2,8 @@ use crate::backend::GenericSocketBackend;
 use crate::codec::Message;
 use crate::transport::AcceptStopHandle;
 use crate::{
-    CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend,
-    SocketType, ZmqMessage, ZmqResult,
+    CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
+    SocketSend, SocketType, ZmqMessage, ZmqResult,
 };
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -24,9 +24,13 @@ impl Drop for PushSocket {
 
 #[async_trait]
 impl Socket for PushSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         Self {
-            backend: Arc::new(GenericSocketBackend::new(None, SocketType::PUSH)),
+            backend: Arc::new(GenericSocketBackend::with_options(
+                None,
+                SocketType::PUSH,
+                options,
+            )),
             binds: HashMap::new(),
         }
     }

--- a/src/req.rs
+++ b/src/req.rs
@@ -18,6 +18,7 @@ struct ReqSocketBackend {
     pub(crate) peers: DashMap<PeerIdentity, Peer>,
     pub(crate) round_robin: SegQueue<PeerIdentity>,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
+    socket_options: SocketOptions,
 }
 
 pub struct ReqSocket {
@@ -97,12 +98,13 @@ impl SocketRecv for ReqSocket {
 
 #[async_trait]
 impl Socket for ReqSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         Self {
             backend: Arc::new(ReqSocketBackend {
                 peers: DashMap::new(),
                 round_robin: SegQueue::new(),
                 socket_monitor: Mutex::new(None),
+                socket_options: options,
             }),
             current_request: None,
             binds: HashMap::new(),
@@ -146,6 +148,10 @@ impl MultiPeerBackend for ReqSocketBackend {
 impl SocketBackend for ReqSocketBackend {
     fn socket_type(&self) -> SocketType {
         SocketType::REQ
+    }
+
+    fn socket_options(&self) -> &SocketOptions {
+        &self.socket_options
     }
 
     fn shutdown(&self) {

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,7 +12,7 @@ use crate::fair_queue::FairQueue;
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
-use crate::{MultiPeerBackend, SocketEvent, SocketRecv, SocketSend, SocketType};
+use crate::{MultiPeerBackend, SocketEvent, SocketOptions, SocketRecv, SocketSend, SocketType};
 use crate::{Socket, SocketBackend};
 use futures::channel::mpsc;
 use futures::SinkExt;
@@ -31,12 +31,13 @@ impl Drop for RouterSocket {
 
 #[async_trait]
 impl Socket for RouterSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         let fair_queue = FairQueue::new(true);
         Self {
-            backend: Arc::new(GenericSocketBackend::new(
+            backend: Arc::new(GenericSocketBackend::with_options(
                 Some(fair_queue.inner()),
                 SocketType::ROUTER,
+                options,
             )),
             binds: HashMap::new(),
             fair_queue,

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -4,7 +4,9 @@ use crate::error::ZmqResult;
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
-use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketRecv, SocketType};
+use crate::{
+    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketType,
+};
 
 use crate::backend::GenericSocketBackend;
 use crate::fair_queue::FairQueue;
@@ -58,12 +60,13 @@ impl SubSocket {
 
 #[async_trait]
 impl Socket for SubSocket {
-    fn new() -> Self {
+    fn with_options(options: SocketOptions) -> Self {
         let fair_queue = FairQueue::new(true);
         Self {
-            backend: Arc::new(GenericSocketBackend::new(
+            backend: Arc::new(GenericSocketBackend::with_options(
                 Some(fair_queue.inner()),
                 SocketType::SUB,
+                options,
             )),
             fair_queue,
             binds: HashMap::new(),


### PR DESCRIPTION
This is related to #116.

Currently it's only enables user to set custom peer-identity if needed
and passes options all around. Later we can add other options to this
struct.

Some minor changes to ReadyCommand properties were required cause
ZMQ_IDENTITY could be any byte vec and not guaranteed to be valid String