### PR TITLE
Updated dependencies (in particular bytes="1")

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = "0.3"
 async-trait = "0.1"
 parking_lot = "0.11"
 rand = "0.7"
-bytes = "0.5"
+bytes = "1"
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-util = { version = "0.6", features = ["compat"], optional = true }
 num-traits = "0.2"
@@ -33,7 +33,7 @@ uuid = { version = "0.8", features = ["v4"] }
 regex = "1"
 lazy_static = "1"
 log = "0.4"
-futures_codec = "0.4"
+asynchronous-codec = "0.6"
 async-std = { version = "1", features = ["attributes"], optional = true }
 
 [dev-dependencies]

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,5 +1,5 @@
 use crate::codec::ZmqCodec;
-use futures_codec::{FramedRead, FramedWrite};
+use asynchronous_codec::{FramedRead, FramedWrite};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
 pub trait FrameableRead: futures::AsyncRead + Unpin + Send + Sync {}
@@ -7,10 +7,10 @@ impl<T> FrameableRead for T where T: futures::AsyncRead + Unpin + Send + Sync {}
 pub trait FrameableWrite: futures::AsyncWrite + Unpin + Send + Sync {}
 impl<T> FrameableWrite for T where T: futures::AsyncWrite + Unpin + Send + Sync {}
 
-pub(crate) type ZmqFramedRead = futures_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
-pub(crate) type ZmqFramedWrite = futures_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
+pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
+pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
 
-/// Equivalent to [`futures_codec::Framed<T, ZmqCodec>`]
+/// Equivalent to [`asynchronous_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
     pub read_half: ZmqFramedRead,
     pub write_half: ZmqFramedWrite,

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -4,8 +4,8 @@ use super::greeting::ZmqGreeting;
 use super::Message;
 use crate::ZmqMessage;
 
+use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
-use futures_codec::{Decoder, Encoder};
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,9 +45,9 @@ use util::PeerIdentity;
 extern crate enum_primitive_derive;
 
 use async_trait::async_trait;
+use asynchronous_codec::FramedWrite;
 use futures::channel::mpsc;
 use futures::FutureExt;
-use futures_codec::FramedWrite;
 use num_traits::ToPrimitive;
 use parking_lot::Mutex;
 use std::collections::HashMap;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,10 @@
 use crate::codec::{CodecResult, FramedIo};
 use crate::*;
 
+use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures::stream::StreamExt;
 use futures::SinkExt;
-use futures_codec::FramedRead;
 use num_traits::Pow;
 use rand::Rng;
 use std::convert::{TryFrom, TryInto};


### PR DESCRIPTION
The author of `futures_codec` appears to be [awol](https://github.com/matthunz/futures-codec/pull/57), blocking downstream crates from updating to bytes="1", so the repo has been forked and republished as [asynchronous-codec](https://crates.io/crates/asynchronous-codec)

This PR updates `Cargo.toml` and substitutes `futures_codec` for `asynchronous_codec` in src files