### PR TITLE
Using split_off instead of split_at in ZmqMessage.

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -60,24 +60,9 @@ impl ZmqMessage {
         }
     }
 
-    pub fn split_at(&self, mid: usize) -> (ZmqMessage, ZmqMessage) {
-        let mut frames_left = VecDeque::with_capacity(mid);
-        let mut frames_right = VecDeque::with_capacity(self.len() - mid);
-        for (index, frame) in self.iter().enumerate() {
-            if index < mid {
-                frames_left.push_back(frame.clone());
-            } else {
-                frames_right.push_back(frame.clone());
-            }
-        }
-        (
-            ZmqMessage {
-                frames: frames_left,
-            },
-            ZmqMessage {
-                frames: frames_right,
-            },
-        )
+    pub fn split_off(&mut self, at: usize) -> ZmqMessage {
+        let frames = self.frames.split_off(at);
+        ZmqMessage { frames }
     }
 }
 

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -140,19 +140,18 @@ impl SocketRecv for RepSocket {
         loop {
             match self.fair_queue.next().await {
                 Some((peer_id, Ok(message))) => match message {
-                    Message::Message(m) => {
-                        let mut mid = 1;
+                    Message::Message(mut m) => {
+                        assert!(m.len() > 1);
+                        let mut at = 1;
                         for (index, frame) in m.iter().enumerate() {
                             if frame.is_empty() {
                                 // Include delimiter in envelope.
-                                mid = index + 1;
+                                at = index + 1;
                                 break;
                             }
                         }
-                        let (envelope, data) = m.split_at(mid);
-                        if !envelope.is_empty() {
-                            self.envelope = Some(envelope);
-                        }
+                        let data = m.split_off(at);
+                        self.envelope = Some(m);
                         self.current_request = Some(peer_id);
                         return Ok(data);
                     }

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -4,19 +4,19 @@ use std::convert::TryFrom;
 use zeromq::ZmqMessage;
 
 #[test]
-fn test_split_at() {
+fn test_split_off() {
     let mut frames = VecDeque::with_capacity(5);
     frames.push_back(Bytes::from("id1"));
     frames.push_back(Bytes::from("id2"));
     frames.push_back(Bytes::from(""));
     frames.push_back(Bytes::from("data1"));
     frames.push_back(Bytes::from("data2"));
-    let m = ZmqMessage::try_from(frames).unwrap();
-    let (envelope, data) = m.split_at(3);
-    assert_eq!(envelope.len(), 3);
-    assert_eq!(envelope.get(0), Some(&Bytes::from("id1")));
-    assert_eq!(envelope.get(1), Some(&Bytes::from("id2")));
-    assert_eq!(envelope.get(2), Some(&Bytes::from("")));
+    let mut m = ZmqMessage::try_from(frames).unwrap();
+    let data = m.split_off(3);
+    assert_eq!(m.len(), 3);
+    assert_eq!(m.get(0), Some(&Bytes::from("id1")));
+    assert_eq!(m.get(1), Some(&Bytes::from("id2")));
+    assert_eq!(m.get(2), Some(&Bytes::from("")));
     assert_eq!(data.len(), 2);
     assert_eq!(data.get(0), Some(&Bytes::from("data1")));
     assert_eq!(data.get(1), Some(&Bytes::from("data2")));


### PR DESCRIPTION
Minor addition to #136 .