### PR TITLE
Silently ignore send error if a subscriber queue is full

### DIFF
--- a/src/pub.rs
+++ b/src/pub.rs
@@ -181,6 +181,11 @@ impl SocketSend for PubSocket {
                                 dbg!(e);
                             }
                         }
+                        Err(ZmqError::BufferFull(_)) => {
+                            // ignore silently. https://rfc.zeromq.org/spec/29/ says:
+                            // For processing outgoing messages:
+                            //   SHALL silently drop the message if the queue for a subscriber is full.
+                        }
                         Err(e) => {
                             dbg!(e);
                             todo!()


### PR DESCRIPTION
This is a situation which can occur when subscribers read too slow.

Complies to the zmq specification (https://rfc.zeromq.org/spec/29/).

Fixes #145.