### PR TITLE
Handle errors in Pull and Router

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -114,5 +114,11 @@ impl MultiPeerBackend for GenericSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         self.peers.remove(peer_id);
+        match &self.fair_queue_inner {
+            None => {}
+            Some(inner) => {
+                inner.lock().remove(peer_id);
+            }
+        };
     }
 }

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -27,6 +27,10 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
             None => (),
         };
     }
+
+    pub fn remove(&mut self, k: &K) {
+        self.streams.remove(k);
+    }
 }
 
 pub struct FairQueue<S, K: Clone> {

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -58,7 +58,10 @@ impl SocketRecv for PullSocket {
                 Some((_peer_id, Ok(Message::Message(message)))) => {
                     return Ok(message);
                 }
-                Some((_peer_id, _)) => todo!(),
+                Some((_peer_id, Ok(msg))) => todo!("Unimplemented message: {:?}", msg),
+                Some((peer_id, Err(_))) => {
+                    self.backend.peer_disconnected(&peer_id);
+                }
                 None => todo!(),
             };
         }

--- a/src/router.rs
+++ b/src/router.rs
@@ -68,7 +68,10 @@ impl SocketRecv for RouterSocket {
                     message.push_front(peer_id.into());
                     return Ok(message);
                 }
-                Some((_peer_id, _)) => todo!(),
+                Some((_peer_id, Ok(msg))) => todo!("Unimplemented message: {:?}", msg),
+                Some((peer_id, Err(_))) => {
+                    self.backend.peer_disconnected(&peer_id);
+                }
                 None => todo!(),
             };
         }

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -193,7 +193,10 @@ impl SocketRecv for SubSocket {
                 Some((_peer_id, Ok(Message::Message(message)))) => {
                     return Ok(message);
                 }
-                Some((_peer_id, _)) => todo!(),
+                Some((_peer_id, Ok(msg))) => todo!("Unimplemented message: {:?}", msg),
+                Some((peer_id, Err(_))) => {
+                    self.backend.peer_disconnected(&peer_id);
+                }
                 None => todo!(),
             }
         }


### PR DESCRIPTION
ConnectionReset is a common error that occurs here.

Invoking peer_disconnected regardless of the error might be a little coarse but that should be better than raising a panic.