### PR TITLE
[WIP] Feat: Support TCP Keep-alive options

### DIFF
--- a/examples/socket_client_with_options.rs
+++ b/examples/socket_client_with_options.rs
@@ -2,13 +2,20 @@ mod async_helpers;
 
 use std::convert::TryFrom;
 use std::error::Error;
-use zeromq::util::PeerIdentity;
+use zeromq::util::{PeerIdentity, TcpKeepalive};
 use zeromq::{Socket, SocketOptions, SocketRecv, SocketSend};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut options = SocketOptions::default();
-    options.peer_identity(PeerIdentity::try_from(Vec::from("SomeCustomId")).unwrap());
+    options
+        .peer_identity(PeerIdentity::try_from(Vec::from("SomeCustomId")).unwrap())
+        .tcp_keepalive(TcpKeepalive {
+            keepalive: 1,
+            count: 5,
+            idle: 1,
+            interval: 10,
+        });
 
     let mut socket = zeromq::ReqSocket::with_options(options);
     socket

--- a/examples/socket_client_with_options.rs
+++ b/examples/socket_client_with_options.rs
@@ -10,12 +10,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut options = SocketOptions::default();
     options
         .peer_identity(PeerIdentity::try_from(Vec::from("SomeCustomId")).unwrap())
-        .tcp_keepalive(TcpKeepalive {
-            keepalive: 1,
-            count: 5,
-            idle: 1,
-            interval: 10,
-        });
+        .tcp_keepalive(
+            TcpKeepalive::default()
+                .set_idle(1)
+                .set_count(5)
+                .set_interval(10),
+        );
 
     let mut socket = zeromq::ReqSocket::with_options(options);
     socket

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use message::*;
 
 use crate::codec::*;
 use crate::transport::AcceptStopHandle;
-use util::PeerIdentity;
+use util::{PeerIdentity, TcpKeepalive};
 
 #[macro_use]
 extern crate enum_primitive_derive;
@@ -129,11 +129,17 @@ pub enum SocketEvent {
 #[derive(Default)]
 pub struct SocketOptions {
     pub(crate) peer_id: Option<PeerIdentity>,
+    pub(crate) tcp_keepalive: Option<TcpKeepalive>,
 }
 
 impl SocketOptions {
     pub fn peer_identity(&mut self, peer_id: PeerIdentity) -> &mut Self {
         self.peer_id = Some(peer_id);
+        self
+    }
+
+    pub fn tcp_keepalive(&mut self, tcp_keepalive_opt: TcpKeepalive) -> &mut Self {
+        self.tcp_keepalive = Some(tcp_keepalive_opt);
         self
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -216,6 +216,31 @@ pub(crate) async fn connect_forever(endpoint: Endpoint) -> ZmqResult<(FramedIo, 
     }
 }
 
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
+pub struct TcpKeepalive {
+    pub keepalive: i64,
+    pub idle: i64,
+    pub count: i64,
+    pub interval: i64,
+}
+
+impl TcpKeepalive {
+    pub fn new() -> Self {
+        TcpKeepalive {
+            keepalive: -1,
+            idle: -1,
+            count: -1,
+            interval: -1,
+        }
+    }
+}
+
+impl Default for TcpKeepalive {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -218,19 +218,38 @@ pub(crate) async fn connect_forever(endpoint: Endpoint) -> ZmqResult<(FramedIo, 
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
 pub struct TcpKeepalive {
-    pub keepalive: i64,
-    pub idle: i64,
-    pub count: i64,
-    pub interval: i64,
+    pub idle: Option<u64>,
+    pub count: Option<u64>,
+    pub interval: Option<u64>,
 }
 
 impl TcpKeepalive {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         TcpKeepalive {
-            keepalive: -1,
-            idle: -1,
-            count: -1,
-            interval: -1,
+            idle: None,
+            count: None,
+            interval: None,
+        }
+    }
+
+    pub const fn set_idle(self, idle: u64) -> Self {
+        Self {
+            idle: Some(idle),
+            ..self
+        }
+    }
+
+    pub const fn set_count(self, count: u64) -> Self {
+        Self {
+            count: Some(count),
+            ..self
+        }
+    }
+
+    pub const fn set_interval(self, interval: u64) -> Self {
+        Self {
+            interval: Some(interval),
+            ..self
         }
     }
 }


### PR DESCRIPTION
We may need to re-think the design of this option on how each of these options should be supported.

- [ ] Enhancement on basic options, e.g. types / defaults
- [ ] TCP Keep-alive options with examples
- [ ] Tests
- [ ] Docs

Related:
* http://api.zeromq.org/4-0:zmq-setsockopt#toc30
* https://github.com/zeromq/libzmq/blob/master/src/options.cpp#L504

Resolves #155. 