### PR TITLE
Use Bytes inside PeerIdentity

### DIFF
--- a/examples/socket_client_with_options.rs
+++ b/examples/socket_client_with_options.rs
@@ -1,14 +1,14 @@
 mod async_helpers;
 
-use std::convert::TryFrom;
 use std::error::Error;
+use std::str::FromStr;
 use zeromq::util::PeerIdentity;
 use zeromq::{Socket, SocketOptions, SocketRecv, SocketSend};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut options = SocketOptions::default();
-    options.peer_identity(PeerIdentity::try_from(Vec::from("SomeCustomId")).unwrap());
+    options.peer_identity(PeerIdentity::from_str("SomeCustomId")?);
 
     let mut socket = zeromq::ReqSocket::with_options(options);
     socket

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum ZmqError {
     Other(&'static str),
     #[error("No message received")]
     NoMessage,
+    #[error("Invalid peer identity: must be less than 256 bytes in length")]
+    PeerIdentity,
     #[error("Unsupported ZMTP version")]
     UnsupportedVersion(ZmtpVersion),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Clone, Copy, Debug, PartialEq, Primitive)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Primitive)]
 pub enum SocketType {
     PAIR = 0,
     PUB = 1,

--- a/src/router.rs
+++ b/src/router.rs
@@ -82,7 +82,7 @@ impl SocketRecv for RouterSocket {
 impl SocketSend for RouterSocket {
     async fn send(&mut self, mut message: ZmqMessage) -> ZmqResult<()> {
         assert!(message.len() > 1);
-        let peer_id: PeerIdentity = message.pop_front().unwrap().to_vec().try_into()?;
+        let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.backend.peers.get_mut(&peer_id) {
             Some(mut peer) => {
                 peer.send_queue.send(Message::Message(message)).await?;


### PR DESCRIPTION
This makes cloning of PeerIdentity (which is performed quite often) much cheaper.

Also adds a `from_slice` method and a `FromStr` implementation.