### PR TITLE
Clean up futures-* dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ rand = "0.8"
 bytes = "1"
 tokio = { version = "1", features = ["full"], optional = true }
 tokio-util = { version = "0.7", features = ["compat"], optional = true }
+num-traits = "0.2"
 dashmap = "5"
 crossbeam-queue = "0.3"
 uuid = { version = "1", features = ["v4"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ tcp-transport = []
 
 [dependencies]
 thiserror = "1"
-futures = "0.3"
-futures-util = "0.3"
+futures-channel = { version = "0.3", features = ["sink"] }
+futures-io = "0.3"
+futures-task = "0.3"
+futures-util = { version = "0.3", features = ["sink"] }
 async-trait = "0.1"
 parking_lot = "0.12"
 rand = "0.8"
@@ -40,9 +42,8 @@ async-std = { version = "1", features = ["attributes"], optional = true }
 chrono = "0.4"
 criterion = "0.3"
 pretty_env_logger = "0.4"
-zmq2 = "0.5.0"
+zmq2 = "0.5"
 hex = "0.4"
-
 
 [lib]
 bench = false

--- a/examples/task_worker.rs
+++ b/examples/task_worker.rs
@@ -1,6 +1,6 @@
 mod async_helpers;
 
-use futures::FutureExt;
+use futures_util::{select, FutureExt};
 use std::io::Write;
 use std::{error::Error, time::Duration};
 use zeromq::{Socket, SocketRecv, SocketSend};
@@ -22,7 +22,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Process messages from receiver and controller
     loop {
-        futures::select! {
+        select! {
             message = receiver.recv().fuse() => {
                 // Process task
                 let message = message.unwrap();

--- a/src/async_rt/task/join_handle.rs
+++ b/src/async_rt/task/join_handle.rs
@@ -3,11 +3,11 @@ use async_std::task as rt_task;
 #[cfg(feature = "tokio-runtime")]
 use tokio::task as rt_task;
 
+use super::JoinError;
+
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-
-use super::JoinError;
 
 pub struct JoinHandle<T>(rt_task::JoinHandle<T>);
 impl<T> Future for JoinHandle<T> {

--- a/src/async_rt/task/mod.rs
+++ b/src/async_rt/task/mod.rs
@@ -1,8 +1,8 @@
 mod join_handle;
 
-use std::any::Any;
-
 pub use join_handle::JoinHandle;
+
+use std::any::Any;
 use std::future::Future;
 
 pub fn spawn<T>(task: T) -> JoinHandle<T::Output>

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -4,12 +4,14 @@ use crate::util::PeerIdentity;
 use crate::{
     MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, ZmqError, ZmqResult,
 };
+
 use async_trait::async_trait;
 use crossbeam_queue::SegQueue;
 use dashmap::DashMap;
-use futures::channel::mpsc;
-use futures::SinkExt;
+use futures_channel::mpsc;
+use futures_util::SinkExt;
 use parking_lot::Mutex;
+
 use std::sync::Arc;
 
 pub(crate) struct Peer {

--- a/src/codec/command.rs
+++ b/src/codec/command.rs
@@ -2,6 +2,7 @@ use super::error::CodecError;
 use crate::SocketType;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Display;

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,11 +1,13 @@
 use crate::codec::ZmqCodec;
+
 use asynchronous_codec::{FramedRead, FramedWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
-pub trait FrameableRead: futures::AsyncRead + Unpin + Send + Sync {}
-impl<T> FrameableRead for T where T: futures::AsyncRead + Unpin + Send + Sync {}
-pub trait FrameableWrite: futures::AsyncWrite + Unpin + Send + Sync {}
-impl<T> FrameableWrite for T where T: futures::AsyncWrite + Unpin + Send + Sync {}
+pub trait FrameableRead: AsyncRead + Unpin + Send + Sync {}
+impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
+pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {}
+impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
 
 pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;

--- a/src/codec/greeting.rs
+++ b/src/codec/greeting.rs
@@ -2,6 +2,7 @@ use super::error::CodecError;
 use super::mechanism::ZmqMechanism;
 
 use bytes::{Bytes, BytesMut};
+
 use std::convert::TryFrom;
 
 pub type ZmtpVersion = (u8, u8);

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -16,9 +16,12 @@ pub(crate) use zmq_codec::ZmqCodec;
 
 use crate::message::ZmqMessage;
 use crate::{ZmqError, ZmqResult};
-use futures::task::Poll;
-use futures::Sink;
+
+use futures_task::noop_waker;
+use futures_util::Sink;
+
 use std::pin::Pin;
+use std::task::{Context, Poll};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -33,8 +36,8 @@ pub(crate) trait TrySend {
 
 impl TrySend for ZmqFramedWrite {
     fn try_send(mut self: Pin<&mut Self>, item: Message) -> ZmqResult<()> {
-        let waker = futures::task::noop_waker();
-        let mut cx = futures::task::Context::from_waker(&waker);
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
         match self.as_mut().poll_ready(&mut cx) {
             Poll::Ready(Ok(())) => {
                 self.as_mut().start_send(item)?;

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -6,6 +6,7 @@ use crate::ZmqMessage;
 
 use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+
 use std::convert::TryFrom;
 
 #[derive(Debug, Clone, Copy)]

--- a/src/dealer.rs
+++ b/src/dealer.rs
@@ -7,9 +7,11 @@ use crate::{
     CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
     SocketRecv, SocketSend, SocketType, ZmqMessage, ZmqResult,
 };
+
 use async_trait::async_trait;
-use futures::channel::mpsc;
-use futures::StreamExt;
+use futures_channel::mpsc;
+use futures_util::StreamExt;
+
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/endpoint/host.rs
+++ b/src/endpoint/host.rs
@@ -1,10 +1,10 @@
+use super::EndpointError;
+use crate::ZmqError;
+
 use std::convert::TryFrom;
 use std::fmt;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::str::FromStr;
-
-use super::EndpointError;
-use crate::ZmqError;
 
 /// Represents a host address. Does not include the port, and may be either an
 /// ip address or a domain name

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -2,17 +2,17 @@ mod error;
 mod host;
 mod transport;
 
-pub use host::Host;
-pub use transport::Transport;
-
 use once_cell::sync::Lazy;
 use regex::Regex;
+
 use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
 
 pub use error::EndpointError;
+pub use host::Host;
+pub use transport::Transport;
 
 pub type Port = u16;
 

--- a/src/endpoint/transport.rs
+++ b/src/endpoint/transport.rs
@@ -1,8 +1,8 @@
+use super::EndpointError;
+
 use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
-
-use super::EndpointError;
 
 /// The type of transport used by a given endpoint
 #[derive(Debug, Clone, Hash, Copy, PartialEq, Eq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@ use crate::endpoint::EndpointError;
 use crate::task_handle::TaskError;
 use crate::ZmqMessage;
 
+use futures_channel::mpsc;
 use thiserror::Error;
 
 pub type ZmqResult<T> = Result<T, ZmqError>;
@@ -48,14 +49,14 @@ pub enum ZmqError {
     UnsupportedVersion(ZmtpVersion),
 }
 
-impl From<futures::channel::mpsc::TrySendError<Message>> for ZmqError {
-    fn from(_: futures::channel::mpsc::TrySendError<Message>) -> Self {
+impl From<mpsc::TrySendError<Message>> for ZmqError {
+    fn from(_: mpsc::TrySendError<Message>) -> Self {
         ZmqError::BufferFull("Failed to send message. Send queue full/broken")
     }
 }
 
-impl From<futures::channel::mpsc::SendError> for ZmqError {
-    fn from(_: futures::channel::mpsc::SendError) -> Self {
+impl From<mpsc::SendError> for ZmqError {
+    fn from(_: mpsc::SendError) -> Self {
         ZmqError::BufferFull("Failed to send message. Send queue full/broken")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod __async_rt {
 pub use crate::dealer::*;
 pub use crate::endpoint::{Endpoint, Host, Transport, TryIntoEndpoint};
 pub use crate::error::{ZmqError, ZmqResult};
+pub use crate::message::*;
 pub use crate::pull::*;
 pub use crate::push::*;
 pub use crate::r#pub::*;
@@ -35,7 +36,6 @@ pub use crate::rep::*;
 pub use crate::req::*;
 pub use crate::router::*;
 pub use crate::sub::*;
-pub use message::*;
 
 use crate::codec::*;
 use crate::transport::AcceptStopHandle;
@@ -46,10 +46,11 @@ extern crate enum_primitive_derive;
 
 use async_trait::async_trait;
 use asynchronous_codec::FramedWrite;
-use futures::channel::mpsc;
-use futures::FutureExt;
+use futures_channel::mpsc;
+use futures_util::{select, FutureExt};
 use num_traits::ToPrimitive;
 use parking_lot::Mutex;
+
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
@@ -321,7 +322,7 @@ pub async fn proxy<Frontend: SocketSend + SocketRecv, Backend: SocketSend + Sock
     mut capture: Option<Box<dyn CaptureSocket>>,
 ) -> ZmqResult<()> {
     loop {
-        futures::select! {
+        select! {
             frontend_mess = frontend.recv().fuse() => {
                 match frontend_mess {
                     Ok(message) => {

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,5 @@
 use bytes::Bytes;
+
 use std::collections::vec_deque::{Iter, VecDeque};
 use std::convert::{From, TryFrom};
 use std::fmt;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -11,9 +11,10 @@ use crate::{
 
 use async_trait::async_trait;
 use dashmap::DashMap;
-use futures::channel::{mpsc, oneshot};
-use futures::FutureExt;
+use futures_channel::{mpsc, oneshot};
+use futures_util::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
+
 use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::pin::Pin;
@@ -116,10 +117,9 @@ impl MultiPeerBackend for PubSocketBackend {
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
-            use futures::StreamExt;
             let mut stop_receiver = stop_receiver.fuse();
             loop {
-                futures::select! {
+                select! {
                      _ = stop_receiver => {
                          break;
                      },

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -7,9 +7,11 @@ use crate::{
     Endpoint, MultiPeerBackend, Socket, SocketEvent, SocketOptions, SocketRecv, SocketType,
     ZmqMessage, ZmqResult,
 };
+
 use async_trait::async_trait;
-use futures::channel::mpsc;
-use futures::StreamExt;
+use futures_channel::mpsc;
+use futures_util::StreamExt;
+
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/push.rs
+++ b/src/push.rs
@@ -5,8 +5,10 @@ use crate::{
     CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
     SocketSend, SocketType, ZmqMessage, ZmqResult,
 };
+
 use async_trait::async_trait;
-use futures::channel::mpsc;
+use futures_channel::mpsc;
+
 use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -5,11 +5,12 @@ use crate::fair_queue::{FairQueue, QueueInner};
 use crate::transport::AcceptStopHandle;
 use crate::*;
 use crate::{SocketType, ZmqResult};
+
 use async_trait::async_trait;
 use dashmap::DashMap;
-use futures::SinkExt;
-use futures::StreamExt;
+use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/req.rs
+++ b/src/req.rs
@@ -10,7 +10,8 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use crossbeam_queue::SegQueue;
 use dashmap::DashMap;
-use futures::{SinkExt, StreamExt};
+use futures_util::{SinkExt, StreamExt};
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,9 +1,3 @@
-use async_trait::async_trait;
-use futures::stream::StreamExt;
-use std::collections::HashMap;
-use std::convert::TryInto;
-use std::sync::Arc;
-
 use crate::backend::GenericSocketBackend;
 use crate::codec::*;
 use crate::endpoint::Endpoint;
@@ -14,8 +8,14 @@ use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{MultiPeerBackend, SocketEvent, SocketOptions, SocketRecv, SocketSend, SocketType};
 use crate::{Socket, SocketBackend};
-use futures::channel::mpsc;
-use futures::SinkExt;
+
+use async_trait::async_trait;
+use futures_channel::mpsc;
+use futures_util::{SinkExt, StreamExt};
+
+use std::collections::HashMap;
+use std::convert::TryInto;
+use std::sync::Arc;
 
 pub struct RouterSocket {
     backend: Arc<GenericSocketBackend>,

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -1,23 +1,24 @@
-use crate::codec::*;
+use crate::backend::Peer;
+use crate::codec::{FramedIo, Message, ZmqFramedRead};
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
-use crate::message::*;
+use crate::fair_queue::FairQueue;
+use crate::fair_queue::QueueInner;
+use crate::message::ZmqMessage;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
     MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketType,
 };
 
-use crate::backend::Peer;
-use crate::fair_queue::FairQueue;
-use crate::fair_queue::QueueInner;
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
 use crossbeam_queue::SegQueue;
 use dashmap::DashMap;
-use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
+use futures_channel::mpsc;
+use futures_util::{SinkExt, StreamExt};
 use parking_lot::Mutex;
+
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/src/task_handle.rs
+++ b/src/task_handle.rs
@@ -1,6 +1,7 @@
 use crate::async_rt;
 use crate::error::{ZmqError, ZmqResult};
 
+use futures_channel::oneshot;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -25,13 +26,13 @@ impl From<async_rt::task::JoinError> for TaskError {
 
 pub struct TaskHandle<T> {
     // Using options to allow us to move resource without consuming `self`
-    stop_channel: futures::channel::oneshot::Sender<()>,
+    stop_channel: oneshot::Sender<()>,
     join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,
 }
 impl<T> TaskHandle<T> {
     #[allow(unused)]
     pub(crate) fn new(
-        stop_channel: futures::channel::oneshot::Sender<()>,
+        stop_channel: oneshot::Sender<()>,
         join_handle: async_rt::task::JoinHandle<ZmqResult<T>>,
     ) -> Self {
         Self {

--- a/src/transport/ipc.rs
+++ b/src/transport/ipc.rs
@@ -12,7 +12,9 @@ use crate::endpoint::Endpoint;
 use crate::task_handle::TaskHandle;
 use crate::ZmqResult;
 
-use futures::{select, FutureExt};
+use futures_channel::oneshot;
+use futures_util::{select, FutureExt};
+
 use std::path::Path;
 
 pub(crate) async fn connect(path: &Path) -> ZmqResult<(FramedIo, Endpoint)> {
@@ -43,7 +45,7 @@ where
     let resolved_addr = listener.local_addr()?;
     let resolved_addr = resolved_addr.as_pathname().map(|a| a.to_owned());
     let listener_addr = resolved_addr.clone();
-    let (stop_channel, stop_callback) = futures::channel::oneshot::channel::<()>();
+    let (stop_channel, stop_callback) = oneshot::channel::<()>();
     let task_handle = async_rt::task::spawn(async move {
         let mut stop_callback = stop_callback.fuse();
         loop {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -96,9 +96,9 @@ where
 #[cfg(feature = "async-std-runtime")]
 fn make_framed<T>(stream: T) -> FramedIo
 where
-    T: futures::AsyncRead + futures::AsyncWrite + Send + Sync + 'static,
+    T: futures_io::AsyncRead + futures_io::AsyncWrite + Send + Sync + 'static,
 {
-    use futures::AsyncReadExt;
+    use futures_util::AsyncReadExt;
     let (read, write) = stream.split();
     FramedIo::new(Box::new(read), Box::new(write))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,8 +3,7 @@ use crate::*;
 
 use asynchronous_codec::FramedRead;
 use bytes::Bytes;
-use futures::stream::StreamExt;
-use futures::SinkExt;
+use futures_util::{SinkExt, StreamExt};
 use num_traits::Pow;
 use rand::Rng;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,6 @@ use crate::*;
 use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures_util::{SinkExt, StreamExt};
-use num_traits::Pow;
 use rand::Rng;
 
 use std::convert::{TryFrom, TryInto};

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -3,8 +3,8 @@ use zeromq::Endpoint;
 use zeromq::ZmqMessage;
 use zeromq::__async_rt as async_rt;
 
-use futures::channel::{mpsc, oneshot};
-use futures::{SinkExt, StreamExt};
+use futures_channel::{mpsc, oneshot};
+use futures_util::{SinkExt, StreamExt};
 use std::time::Duration;
 
 #[async_rt::test]
@@ -100,5 +100,5 @@ async fn test_pub_sub_sockets() {
         "ipc://asdf.sock",
         "ipc://anothersocket-asdf",
     ];
-    futures::future::join_all(addrs.into_iter().map(helper)).await;
+    futures_util::future::join_all(addrs.into_iter().map(helper)).await;
 }

--- a/tests/req_rep.rs
+++ b/tests/req_rep.rs
@@ -3,7 +3,7 @@ mod helpers;
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::error::Error;
 use std::time::Duration;
 

--- a/tests/req_router_dealer_rep.rs
+++ b/tests/req_router_dealer_rep.rs
@@ -3,7 +3,7 @@ mod helpers;
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 
-use futures::StreamExt;
+use futures_util::StreamExt;
 use std::error::Error;
 use std::time::Duration;
 


### PR DESCRIPTION
Avoids using the parent `futures` crate so that dependencies are clearer, and imports a few things from `std::task` that are aliased in `futures`.