### PR TITLE
Handle codec errors in REQ socket recv

### DIFF
--- a/src/req.rs
+++ b/src/req.rs
@@ -84,7 +84,8 @@ impl SocketRecv for ReqSocket {
                             assert!(m.pop_front().unwrap().is_empty()); // Ensure that we have delimeter as first part
                             Ok(m)
                         }
-                        Some(_) => todo!(),
+                        Some(Ok(_)) => todo!(),
+                        Some(Err(error)) => Err(error.into()),
                         None => Err(ZmqError::NoMessage),
                     }
                 } else {


### PR DESCRIPTION
Hey there. 
This PR handles codec errors when reading from a REQ socket and thus makes the code more resilient to abrupt changes in the underlying tcp connection. In my experience, it was relatively easy to make the panic happen during tests.

Not sure what's planned for the ` Some(Ok(_))` arm, so I've left it as `todo()`.

Hope this helps. Please let me know if I should do anything particular with the PR. Cheers!

