### PR TITLE
Only use required features of regex crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ num-traits = "0.2"
 dashmap = "5"
 crossbeam-queue = "0.3"
 uuid = { version = "1", features = ["v4"] }
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std", "unicode-perl"] }
 once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.6"


### PR DESCRIPTION
This almost halves the time required to compile regex.