### PR TITLE
Automatically derive a Default impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "A native Rust implementation of ZeroMQ"
 license = "MIT"
 repository = "https://github.com/zeromq/zmq.rs"
+rust-version = "1.62.0"
 
 [features]
 default = ["tokio-runtime", "all-transport"]

--- a/src/codec/mechanism.rs
+++ b/src/codec/mechanism.rs
@@ -4,17 +4,12 @@ use std::convert::TryFrom;
 use std::fmt::Display;
 
 #[allow(clippy::upper_case_acronyms)]
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Default)]
 pub enum ZmqMechanism {
+    #[default]
     NULL,
     PLAIN,
     CURVE,
-}
-
-impl Default for ZmqMechanism {
-    fn default() -> Self {
-        ZmqMechanism::NULL
-    }
 }
 
 impl ZmqMechanism {


### PR DESCRIPTION
Deriving Default for enums was stabilized in 1.62.0.