### PR TITLE
Added support for futures-task v0.3.31

### DIFF
--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -86,8 +86,8 @@ where
 impl<S, T, K> Stream for FairQueue<S, K>
 where
     T: Send,
-    S: Stream<Item = T> + Send,
-    K: Eq + Hash + Unpin + Clone + Send + Sync,
+    S: Stream<Item = T> + Send + 'static,
+    K: Eq + Hash + Unpin + Clone + Send + Sync + 'static,
 {
     type Item = (K, T);
 


### PR DESCRIPTION
As described [in the changelog](https://github.com/rust-lang/futures-rs/blob/master/CHANGELOG.md#0331---2024-10-05) and [here](https://github.com/rust-lang/futures-rs/pull/2830) with the latest version of futures-task they update the function `waker_ref` making it 'static. For this, zmq needs also to add 'static to some properties.