### PR TITLE
Simplify match and error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,22 +303,13 @@ pub trait Socket: Sized + Send {
         let backend = self.backend();
         let endpoint = TryIntoEndpoint::try_into(endpoint)?;
 
-        let result = match util::connect_forever(endpoint).await {
-            Ok((socket, endpoint)) => match util::peer_connected(socket, backend).await {
-                Ok(peer_id) => Ok((endpoint, peer_id)),
-                Err(e) => Err(e),
-            },
-            Err(e) => Err(e),
-        };
-        match result {
-            Ok((endpoint, peer_id)) => {
-                if let Some(monitor) = self.backend().monitor().lock().as_mut() {
-                    let _ = monitor.try_send(SocketEvent::Connected(endpoint, peer_id));
-                }
-                Ok(())
-            }
-            Err(e) => Err(e),
+        let (socket, endpoint) = util::connect_forever(endpoint).await?;
+        let peer_id = util::peer_connected(socket, backend).await?;
+
+        if let Some(monitor) = self.backend().monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Connected(endpoint, peer_id));
         }
+        Ok(())
     }
 
     /// Creates and setups new socket monitor


### PR DESCRIPTION
De-nest more `match ZmqResult` segments with use of the `?` operator.