### PR TITLE
handle errors from the fair queue and the case when the queue is empty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,8 +357,8 @@ pub async fn proxy<Frontend: SocketSend + SocketRecv, Backend: SocketSend + Sock
                         }
                         backend.send(message).await?;
                     }
-                    Err(_) => {
-                        todo!()
+                    Err(e) => {
+                        return Err(e);
                     }
                 }
             },
@@ -370,8 +370,8 @@ pub async fn proxy<Frontend: SocketSend + SocketRecv, Backend: SocketSend + Sock
                         }
                         frontend.send(message).await?;
                     }
-                    Err(_) => {
-                        todo!()
+                    Err(e) => {
+                        return Err(e);
                     }
                 }
             }

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -5,7 +5,7 @@ use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
     Endpoint, MultiPeerBackend, Socket, SocketEvent, SocketOptions, SocketRecv, SocketType,
-    ZmqMessage, ZmqResult,
+    ZmqError, ZmqMessage, ZmqResult,
 };
 
 use async_trait::async_trait;
@@ -60,11 +60,19 @@ impl SocketRecv for PullSocket {
                 Some((_peer_id, Ok(Message::Message(message)))) => {
                     return Ok(message);
                 }
-                Some((_peer_id, Ok(msg))) => todo!("Unimplemented message: {:?}", msg),
-                Some((peer_id, Err(_))) => {
-                    self.backend.peer_disconnected(&peer_id);
+                Some((_peer_id, Ok(_msg))) => {
+                    // Ignore non-message frames (Command, Greeting) as PULL sockets are designed to only receive actual messages, not internal protocol frames.
+                    continue;
                 }
-                None => todo!(),
+                Some((peer_id, Err(e))) => {
+                    self.backend.peer_disconnected(&peer_id);
+                    // Handle potential errors from the fair queue
+                    return Err(e.into());
+                }
+                None => {
+                    // The fair queue is empty, which shouldn't happen in normal operation
+                    return Err(ZmqError::NoMessage);
+                }
             };
         }
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -68,11 +68,22 @@ impl SocketRecv for RouterSocket {
                     message.push_front(peer_id.into());
                     return Ok(message);
                 }
-                Some((_peer_id, Ok(msg))) => todo!("Unimplemented message: {:?}", msg),
-                Some((peer_id, Err(_))) => {
-                    self.backend.peer_disconnected(&peer_id);
+                Some((_peer_id, Ok(_msg))) => {
+                    // todo: Log or handle other message types if needed
+                    // We could take an approach of using `tracing` and have that be an optional feature
+                    // tracing::warn!("Received unimplemented message type: {:?}", msg);
+                    continue;
                 }
-                None => todo!(),
+                Some((peer_id, Err(_e))) => {
+                    self.backend.peer_disconnected(&peer_id);
+                    // We could take an approach of using `tracing` and have that be an optional feature
+                    // tracing::error!("Error receiving message from peer {}: {:?}", peer_id, e);
+                    continue;
+                }
+                None => {
+                    // The fair queue is empty, which shouldn't happen in normal operation
+                    return Err(ZmqError::NoMessage);
+                }
             };
         }
     }


### PR DESCRIPTION
Drops `todo!()` from `dealer.rs` and propagates errors from proxied sockets.