### PR TITLE
Propagate None from fair_queue for disconnects.

### DIFF
--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -130,7 +130,7 @@ where
                     inner.streams.insert(event.key, io_stream);
                     return Poll::Ready(item);
                 }
-                Poll::Ready(None) => continue,
+                Poll::Ready(None) => return Poll::Ready(None),
                 Poll::Pending => {
                     let mut inner = fair_queue.inner.lock();
                     inner.streams.insert(event.key, io_stream);

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -203,6 +203,7 @@ impl SocketRecv for SubSocket {
                 }
                 None => {
                     // The fair queue is empty, which shouldn't happen in normal operation
+                    // this can happen if the peer disconnects while we are polling
                     return Err(ZmqError::NoMessage);
                 }
             }


### PR DESCRIPTION
Normal socket behaviour returns 0 bytes when socket owner unbinds. Propagate this event via recv for user logic to handle disconnects.