### PR TITLE
Bump version to 0.5.0-pre.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeromq"
-version = "0.5.0-pre"
+version = "0.5.0-pre.2"
 authors = [
     "Alexei Kornienko <alexei.kornienko@gmail.com>",
     "Ryan Butler <thebutlah@gmail.com>",


### PR DESCRIPTION
Align `Cargo.toml` version with the `v0.5.0-pre.2` release tag so `cargo publish` picks up the right version.