### PR TITLE
Replace panics with proper error returns

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -52,8 +52,12 @@ impl GenericSocketBackend {
             let next_peer_id = match self.round_robin.pop() {
                 Some(peer) => peer,
                 None => match message {
-                    Message::Greeting(_) => panic!("Sending greeting is not supported"),
-                    Message::Command(_) => panic!("Sending commands is not supported"),
+                    Message::Greeting(_) => {
+                        return Err(ZmqError::Socket("Sending greeting is not supported"))
+                    }
+                    Message::Command(_) => {
+                        return Err(ZmqError::Socket("Sending commands is not supported"))
+                    }
                     Message::Message(m) => {
                         return Err(ZmqError::ReturnToSender {
                             reason: "Not connected to peers. Unable to send messages",

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -158,12 +158,16 @@ impl Drop for PubSocket {
 #[async_trait]
 impl SocketSend for PubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        let first_frame = match message.get(0) {
+            Some(frame) => frame,
+            None => return Ok(()), // Empty message, nothing to publish
+        };
         let mut dead_peers = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
         while let Some(mut subscriber) = iter {
             for sub_filter in &subscriber.subscriptions {
-                if sub_filter.len() <= message.get(0).unwrap().len()
-                    && sub_filter.as_slice() == &message.get(0).unwrap()[0..sub_filter.len()]
+                if sub_filter.len() <= first_frame.len()
+                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
                 {
                     let res = subscriber
                         .send_queue

--- a/src/router.rs
+++ b/src/router.rs
@@ -90,7 +90,11 @@ impl SocketRecv for RouterSocket {
 #[async_trait]
 impl SocketSend for RouterSocket {
     async fn send(&mut self, mut message: ZmqMessage) -> ZmqResult<()> {
-        assert!(message.len() > 1);
+        if message.len() <= 1 {
+            return Err(ZmqError::Socket(
+                "ROUTER send requires at least 2 frames: identity frame + message",
+            ));
+        }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
@@ -158,7 +162,11 @@ pub struct RouterRecvHalf {
 #[async_trait]
 impl SocketSend for RouterSendHalf {
     async fn send(&mut self, mut message: ZmqMessage) -> ZmqResult<()> {
-        assert!(message.len() > 1);
+        if message.len() <= 1 {
+            return Err(ZmqError::Socket(
+                "ROUTER send requires at least 2 frames: identity frame + message",
+            ));
+        }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.inner.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -93,7 +93,10 @@ impl MultiPeerBackend for SubSocketBackend {
             .collect();
 
         for message in subs_msgs {
-            send_queue.send(Message::Message(message)).await.unwrap();
+            if let Err(e) = send_queue.send(Message::Message(message)).await {
+                log::error!("Failed to send subscription to peer {:?}: {:?}", peer_id, e);
+                return;
+            }
         }
 
         self.peers

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -134,12 +134,16 @@ impl Drop for XPubSocket {
 #[async_trait]
 impl SocketSend for XPubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        let first_frame = match message.get(0) {
+            Some(frame) => frame,
+            None => return Ok(()), // Empty message, nothing to publish
+        };
         let mut dead_peers = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
         while let Some(mut subscriber) = iter {
             for sub_filter in &subscriber.subscriptions {
-                if sub_filter.len() <= message.get(0).unwrap().len()
-                    && sub_filter.as_slice() == &message.get(0).unwrap()[0..sub_filter.len()]
+                if sub_filter.len() <= first_frame.len()
+                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
                 {
                     let res = subscriber
                         .send_queue

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -1,0 +1,58 @@
+//! Tests for error handling paths that return errors instead of panicking.
+
+#[cfg(test)]
+mod test {
+    use zeromq::__async_rt as async_rt;
+    use zeromq::prelude::*;
+    use zeromq::ZmqMessage;
+
+    use std::time::Duration;
+
+    #[async_rt::test]
+    async fn test_router_send_requires_identity_frame() {
+        pretty_env_logger::try_init().ok();
+
+        let mut router = zeromq::RouterSocket::new();
+        let endpoint = router.bind("tcp://localhost:0").await.unwrap();
+
+        let mut dealer = zeromq::DealerSocket::new();
+        dealer.connect(endpoint.to_string().as_str()).await.unwrap();
+
+        async_rt::task::sleep(Duration::from_millis(100)).await;
+
+        // Sending a single-frame message should fail (needs identity + payload)
+        let result = router.send(ZmqMessage::from("just payload")).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("at least 2 frames"),
+            "Expected error about 2 frames, got: {}",
+            err
+        );
+    }
+
+    #[async_rt::test]
+    async fn test_router_split_send_requires_identity_frame() {
+        pretty_env_logger::try_init().ok();
+
+        let mut router = zeromq::RouterSocket::new();
+        let endpoint = router.bind("tcp://localhost:0").await.unwrap();
+
+        let mut dealer = zeromq::DealerSocket::new();
+        dealer.connect(endpoint.to_string().as_str()).await.unwrap();
+
+        async_rt::task::sleep(Duration::from_millis(100)).await;
+
+        let (mut send_half, _recv_half) = router.split();
+
+        // Sending a single-frame message should fail
+        let result = send_half.send(ZmqMessage::from("just payload")).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(
+            err.to_string().contains("at least 2 frames"),
+            "Expected error about 2 frames, got: {}",
+            err
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Replace production panics with proper error handling to prevent crashes on malformed messages and invalid internal states.

- **router.rs**: Return `ZmqError::Socket` when ROUTER send receives <2 frames (was `assert!`)
- **backend.rs**: Return errors for Greeting/Command message types instead of panicking
- **sub.rs**: Log and handle subscription send failures instead of unwrapping
- **pub.rs, xpub.rs**: Safely validate first frame exists before subscription matching