### PR TITLE
Add libzmq conformance tests

### DIFF
--- a/tests/compliance/mod.rs
+++ b/tests/compliance/mod.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 
 /// NOTE: This will block. Careful when using in async code.
+#[allow(dead_code)]
 pub fn get_monitor_event(monitor: &zmq2::Socket) -> (zmq2::SocketEvent, u32, String) {
     assert_eq!(monitor.get_socket_type().unwrap(), zmq2::PAIR);
     let mut msgs = monitor.recv_multipart(0).expect("Monitor couldn't recv");
@@ -18,6 +19,7 @@ pub fn get_monitor_event(monitor: &zmq2::Socket) -> (zmq2::SocketEvent, u32, Str
 }
 
 /// Configures `their_sock` with a socket monitor, and returns the monitor
+#[allow(dead_code)]
 pub fn setup_monitor(
     ctx: &zmq2::Context,
     their_sock: &zmq2::Socket,

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -1,9 +1,9 @@
 #[cfg(test)]
 mod test {
+    use zeromq::__async_rt as async_rt;
     use zeromq::prelude::*;
     use zeromq::Endpoint;
     use zeromq::ZmqMessage;
-    use zeromq::__async_rt as async_rt;
 
     use futures::channel::{mpsc, oneshot};
     use futures::{SinkExt, StreamExt};

--- a/tests/pub_sub_compliant_reverse.rs
+++ b/tests/pub_sub_compliant_reverse.rs
@@ -1,0 +1,210 @@
+//! Conformance tests for our PUB with their SUB (reverse of pub_sub_compliant.rs).
+//!
+//! Tests that our zmq.rs PUB socket correctly broadcasts to libzmq SUB sockets.
+
+mod compliance;
+
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::ZmqMessage;
+
+use std::time::Duration;
+
+async fn setup_our_pub(bind_endpoint: &str) -> (zeromq::PubSocket, String) {
+    let mut our_pub = zeromq::PubSocket::new();
+    let endpoint = our_pub.bind(bind_endpoint).await.expect("Failed to bind");
+    (our_pub, endpoint.to_string())
+}
+
+fn setup_their_subs(
+    ctx: &zmq2::Context,
+    connect_endpoint: &str,
+    n_subs: usize,
+    subscription: &[u8],
+) -> Vec<zmq2::Socket> {
+    let mut subs = Vec::new();
+    for _ in 0..n_subs {
+        let their_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub socket");
+        their_sub.set_ipv6(true).expect("Failed to enable IPV6");
+        their_sub
+            .connect(connect_endpoint)
+            .expect("Failed to connect");
+        their_sub
+            .set_subscribe(subscription)
+            .expect("Failed to subscribe");
+        subs.push(their_sub);
+    }
+    subs
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[async_rt::test]
+    async fn test_our_pub_their_sub() {
+        pretty_env_logger::try_init().ok();
+
+        const N_SUBS: usize = 4;
+
+        async fn do_test(our_endpoint: &str) {
+            let (mut our_pub, bind_endpoint) = setup_our_pub(our_endpoint).await;
+            println!("Our PUB bound to {}", bind_endpoint);
+
+            let ctx = zmq2::Context::new();
+            let their_subs = setup_their_subs(&ctx, &bind_endpoint, N_SUBS, b"");
+
+            // Set receive timeout to avoid blocking forever
+            for sub in &their_subs {
+                sub.set_rcvtimeo(2000).expect("Failed to set timeout");
+            }
+
+            // Slow joiner: wait for subscriptions to propagate
+            async_rt::task::sleep(Duration::from_millis(300)).await;
+
+            const NUM_MSGS: u32 = 16;
+
+            // Run their subs in threads - collect messages with timeout
+            let sub_handles: Vec<_> = their_subs
+                .into_iter()
+                .enumerate()
+                .map(|(idx, sub)| {
+                    std::thread::spawn(move || {
+                        let mut received = Vec::new();
+                        loop {
+                            match sub.recv_string(0) {
+                                Ok(Ok(msg)) => received.push(msg),
+                                Ok(Err(_)) => break, // Invalid UTF8
+                                Err(_) => break,     // Timeout or error
+                            }
+                        }
+                        (idx, received)
+                    })
+                })
+                .collect();
+
+            // Our pub sends
+            for i in 0..NUM_MSGS {
+                let msg = ZmqMessage::from(format!("Message: {}", i));
+                our_pub.send(msg).await.expect("Failed to send");
+            }
+
+            // Wait a bit for messages to propagate, then verify
+            async_rt::task::sleep(Duration::from_millis(500)).await;
+
+            // Join all subscriber threads and verify they received messages
+            for handle in sub_handles {
+                let (idx, received) = handle.join().expect("Sub thread panicked");
+                // Each sub should receive at least some messages (slow joiner may miss early ones)
+                assert!(
+                    !received.is_empty(),
+                    "Sub {} received no messages",
+                    idx
+                );
+                println!("Sub {} received {} messages", idx, received.len());
+            }
+        }
+
+        let endpoints = vec!["tcp://127.0.0.1:0", "tcp://[::1]:0", "ipc://our_pub_test.sock"];
+
+        for e in endpoints {
+            println!("Testing with endpoint {}", e);
+            do_test(e).await;
+
+            // Clean up IPC socket files
+            if let Some(path) = e.strip_prefix("ipc://") {
+                std::fs::remove_file(path).ok();
+            }
+        }
+    }
+
+    #[async_rt::test]
+    async fn test_our_pub_their_sub_topic_filtering() {
+        pretty_env_logger::try_init().ok();
+
+        let (mut our_pub, bind_endpoint) = setup_our_pub("tcp://127.0.0.1:0").await;
+        println!("Our PUB bound to {}", bind_endpoint);
+
+        let ctx = zmq2::Context::new();
+
+        // Create subs with different topic filters
+        let topic1_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
+        topic1_sub.connect(&bind_endpoint).expect("Failed to connect");
+        topic1_sub.set_subscribe(b"topic1").expect("Failed to subscribe");
+
+        let topic2_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
+        topic2_sub.connect(&bind_endpoint).expect("Failed to connect");
+        topic2_sub.set_subscribe(b"topic2").expect("Failed to subscribe");
+
+        let all_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
+        all_sub.connect(&bind_endpoint).expect("Failed to connect");
+        all_sub.set_subscribe(b"").expect("Failed to subscribe");
+
+        // Wait for subscriptions
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        // Spawn receiver threads with RCVTIMEO to avoid blocking forever
+        topic1_sub
+            .set_rcvtimeo(1000)
+            .expect("Failed to set timeout");
+        topic2_sub
+            .set_rcvtimeo(1000)
+            .expect("Failed to set timeout");
+        all_sub.set_rcvtimeo(1000).expect("Failed to set timeout");
+
+        let topic1_handle = std::thread::spawn(move || {
+            let mut received = Vec::new();
+            while let Ok(msg) = topic1_sub.recv_string(0) {
+                received.push(msg.unwrap());
+            }
+            received
+        });
+
+        let topic2_handle = std::thread::spawn(move || {
+            let mut received = Vec::new();
+            while let Ok(msg) = topic2_sub.recv_string(0) {
+                received.push(msg.unwrap());
+            }
+            received
+        });
+
+        let all_handle = std::thread::spawn(move || {
+            let mut received = Vec::new();
+            while let Ok(msg) = all_sub.recv_string(0) {
+                received.push(msg.unwrap());
+            }
+            received
+        });
+
+        // Send messages with different topics
+        for msg in &[
+            "topic1-message-a",
+            "topic2-message-b",
+            "topic1-message-c",
+            "other-message-d",
+            "topic2-message-e",
+        ] {
+            our_pub
+                .send(ZmqMessage::from(*msg))
+                .await
+                .expect("Failed to send");
+        }
+
+        // Wait and check results
+        let topic1_msgs = topic1_handle.join().expect("topic1 thread panicked");
+        let topic2_msgs = topic2_handle.join().expect("topic2 thread panicked");
+        let all_msgs = all_handle.join().expect("all thread panicked");
+
+        assert_eq!(
+            topic1_msgs,
+            vec!["topic1-message-a", "topic1-message-c"],
+            "topic1 sub should only receive topic1 messages"
+        );
+        assert_eq!(
+            topic2_msgs,
+            vec!["topic2-message-b", "topic2-message-e"],
+            "topic2 sub should only receive topic2 messages"
+        );
+        assert_eq!(all_msgs.len(), 5, "all sub should receive all messages");
+    }
+}

--- a/tests/pub_sub_compliant_reverse.rs
+++ b/tests/pub_sub_compliant_reverse.rs
@@ -1,4 +1,4 @@
-//! Conformance tests for our PUB with their SUB (reverse of pub_sub_compliant.rs).
+//! Conformance tests for our PUB with their SUB (reverse of `pub_sub_compliant.rs`).
 //!
 //! Tests that our zmq.rs PUB socket correctly broadcasts to libzmq SUB sockets.
 
@@ -74,8 +74,7 @@ mod test {
                         loop {
                             match sub.recv_string(0) {
                                 Ok(Ok(msg)) => received.push(msg),
-                                Ok(Err(_)) => break, // Invalid UTF8
-                                Err(_) => break,     // Timeout or error
+                                Ok(Err(_)) | Err(_) => break, // Invalid UTF8, timeout, or error
                             }
                         }
                         (idx, received)
@@ -96,16 +95,16 @@ mod test {
             for handle in sub_handles {
                 let (idx, received) = handle.join().expect("Sub thread panicked");
                 // Each sub should receive at least some messages (slow joiner may miss early ones)
-                assert!(
-                    !received.is_empty(),
-                    "Sub {} received no messages",
-                    idx
-                );
+                assert!(!received.is_empty(), "Sub {} received no messages", idx);
                 println!("Sub {} received {} messages", idx, received.len());
             }
         }
 
-        let endpoints = vec!["tcp://127.0.0.1:0", "tcp://[::1]:0", "ipc://our_pub_test.sock"];
+        let endpoints = vec![
+            "tcp://127.0.0.1:0",
+            "tcp://[::1]:0",
+            "ipc://our_pub_test.sock",
+        ];
 
         for e in endpoints {
             println!("Testing with endpoint {}", e);
@@ -129,12 +128,20 @@ mod test {
 
         // Create subs with different topic filters
         let topic1_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
-        topic1_sub.connect(&bind_endpoint).expect("Failed to connect");
-        topic1_sub.set_subscribe(b"topic1").expect("Failed to subscribe");
+        topic1_sub
+            .connect(&bind_endpoint)
+            .expect("Failed to connect");
+        topic1_sub
+            .set_subscribe(b"topic1")
+            .expect("Failed to subscribe");
 
         let topic2_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
-        topic2_sub.connect(&bind_endpoint).expect("Failed to connect");
-        topic2_sub.set_subscribe(b"topic2").expect("Failed to subscribe");
+        topic2_sub
+            .connect(&bind_endpoint)
+            .expect("Failed to connect");
+        topic2_sub
+            .set_subscribe(b"topic2")
+            .expect("Failed to subscribe");
 
         let all_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub");
         all_sub.connect(&bind_endpoint).expect("Failed to connect");

--- a/tests/pub_sub_compliant_reverse.rs
+++ b/tests/pub_sub_compliant_reverse.rs
@@ -71,11 +71,8 @@ mod test {
                 .map(|(idx, sub)| {
                     std::thread::spawn(move || {
                         let mut received = Vec::new();
-                        loop {
-                            match sub.recv_string(0) {
-                                Ok(Ok(msg)) => received.push(msg),
-                                Ok(Err(_)) | Err(_) => break, // Invalid UTF8, timeout, or error
-                            }
+                        while let Ok(Ok(msg)) = sub.recv_string(0) {
+                            received.push(msg);
                         }
                         (idx, received)
                     })

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -153,7 +153,9 @@ mod test {
         // Their SUB connects
         let ctx = zmq2::Context::new();
         let their_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub socket");
-        their_sub.connect(&bind_endpoint).expect("Failed to connect");
+        their_sub
+            .connect(&bind_endpoint)
+            .expect("Failed to connect");
         their_sub.set_subscribe(b"").expect("Failed to subscribe");
         their_sub.set_rcvtimeo(3000).expect("Failed to set timeout");
         their_sub

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -34,7 +34,7 @@ mod test {
     ///
     /// NOTE: Currently ignored because zmq.rs doesn't fully implement
     /// reconnection with subscription resync. This is a known limitation.
-    /// See: https://github.com/zeromq/zmq.rs/issues/XXX
+    /// See: <https://github.com/zeromq/zmq.rs/issues/XXX>
     #[async_rt::test]
     #[ignore = "zmq.rs reconnection with subscription resync not fully implemented"]
     async fn test_our_sub_reconnects_to_their_restarted_pub() {
@@ -106,7 +106,7 @@ mod test {
                         break;
                     }
                 }
-                _ => continue,
+                _ => {}
             }
         }
 

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -1,0 +1,212 @@
+//! Conformance tests for reconnection behavior.
+//!
+//! Tests that zmq.rs sockets correctly reconnect and resync subscriptions
+//! after the peer restarts.
+
+mod compliance;
+use compliance::setup_monitor;
+
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+
+use std::time::Duration;
+
+fn extract_port(endpoint: &str) -> u16 {
+    // Parse port from endpoint like "tcp://127.0.0.1:12345"
+    endpoint
+        .rsplit(':')
+        .next()
+        .unwrap()
+        .parse()
+        .expect("Failed to parse port")
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// Test that our SUB reconnects when their PUB restarts.
+    ///
+    /// This verifies that:
+    /// 1. Initial connection and subscription works
+    /// 2. After PUB drops and restarts on same port, SUB reconnects
+    /// 3. Subscription is re-established and messages flow again
+    ///
+    /// NOTE: Currently ignored because zmq.rs doesn't fully implement
+    /// reconnection with subscription resync. This is a known limitation.
+    /// See: https://github.com/zeromq/zmq.rs/issues/XXX
+    #[async_rt::test]
+    #[ignore = "zmq.rs reconnection with subscription resync not fully implemented"]
+    async fn test_our_sub_reconnects_to_their_restarted_pub() {
+        pretty_env_logger::try_init().ok();
+
+        // Phase 1: Initial setup - their PUB binds to specific port
+        let ctx = zmq2::Context::new();
+        let their_pub = ctx.socket(zmq2::PUB).expect("Couldn't make pub socket");
+        // Bind to port 0, get actual port
+        their_pub.bind("tcp://127.0.0.1:0").expect("Failed to bind");
+        let bind_endpoint = their_pub.get_last_endpoint().unwrap().unwrap();
+        let port = extract_port(&bind_endpoint);
+        println!("Their PUB initially bound to {}", bind_endpoint);
+
+        // Our SUB connects and subscribes
+        let mut our_sub = zeromq::SubSocket::new();
+        our_sub
+            .connect(&bind_endpoint)
+            .await
+            .expect("Failed to connect");
+        our_sub.subscribe("").await.expect("Failed to subscribe");
+
+        // Wait for subscription to propagate
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        // Phase 2: Verify initial communication works
+        their_pub
+            .send("initial-message", 0)
+            .expect("Failed to send");
+
+        let msg = async_rt::task::timeout(Duration::from_secs(2), our_sub.recv())
+            .await
+            .expect("Timeout waiting for initial message")
+            .expect("Failed to recv");
+        let msg_str = String::from_utf8(msg.get(0).unwrap().to_vec()).unwrap();
+        assert_eq!(msg_str, "initial-message");
+        println!("Phase 2: Initial communication verified");
+
+        // Phase 3: Drop the PUB (simulates crash/restart)
+        drop(their_pub);
+        println!("Phase 3: Their PUB dropped");
+
+        // Small delay for socket cleanup
+        async_rt::task::sleep(Duration::from_millis(300)).await;
+
+        // Phase 4: Restart PUB on same port
+        let their_pub_new = ctx.socket(zmq2::PUB).expect("Couldn't make pub socket");
+        their_pub_new
+            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .expect("Failed to rebind");
+        let their_monitor = setup_monitor(&ctx, &their_pub_new, "inproc://pub-monitor");
+        println!("Phase 4: Their PUB restarted on port {}", port);
+
+        // Phase 5: Wait for reconnection
+        // zmq.rs should auto-reconnect; libzmq will show ACCEPTED + HANDSHAKE_SUCCEEDED
+        // Give it plenty of time - reconnection can take a while
+        let mut reconnected = false;
+        for attempt in 0..50 {
+            async_rt::task::sleep(Duration::from_millis(100)).await;
+
+            // Try to get monitor event without blocking
+            match their_monitor.recv_multipart(zmq2::DONTWAIT) {
+                Ok(msgs) if !msgs.is_empty() => {
+                    let event_bytes: [u8; 2] = msgs[0][..2].try_into().unwrap();
+                    let event = zmq2::SocketEvent::from_raw(u16::from_le_bytes(event_bytes));
+                    println!("Monitor event (attempt {}): {:?}", attempt, event);
+                    if event == zmq2::SocketEvent::HANDSHAKE_SUCCEEDED {
+                        reconnected = true;
+                        break;
+                    }
+                }
+                _ => continue,
+            }
+        }
+
+        if !reconnected {
+            println!("Warning: Didn't observe reconnection event after 5 seconds");
+        }
+
+        // Wait for subscription to re-propagate after reconnect
+        async_rt::task::sleep(Duration::from_millis(500)).await;
+
+        // Phase 6: Verify communication works after reconnect
+        their_pub_new
+            .send("reconnected-message", 0)
+            .expect("Failed to send");
+
+        let msg = async_rt::task::timeout(Duration::from_secs(3), our_sub.recv())
+            .await
+            .expect("Timeout waiting for reconnected message - subscription may not have re-synced")
+            .expect("Failed to recv");
+        let msg_str = String::from_utf8(msg.get(0).unwrap().to_vec()).unwrap();
+        assert_eq!(msg_str, "reconnected-message");
+        println!("Phase 6: Reconnection and subscription verified!");
+    }
+
+    /// Test that their SUB reconnects when our PUB restarts.
+    ///
+    /// NOTE: Currently ignored - reveals issues with reconnection handling
+    /// when our zmq.rs PUB socket restarts.
+    #[async_rt::test]
+    #[ignore = "reconnection to restarted zmq.rs PUB not working correctly"]
+    async fn test_their_sub_reconnects_to_our_restarted_pub() {
+        pretty_env_logger::try_init().ok();
+
+        // Phase 1: Our PUB binds
+        let mut our_pub = zeromq::PubSocket::new();
+        let endpoint = our_pub
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+        let bind_endpoint = endpoint.to_string();
+        let port = extract_port(&bind_endpoint);
+        println!("Our PUB initially bound to {}", bind_endpoint);
+
+        // Their SUB connects
+        let ctx = zmq2::Context::new();
+        let their_sub = ctx.socket(zmq2::SUB).expect("Couldn't make sub socket");
+        their_sub.connect(&bind_endpoint).expect("Failed to connect");
+        their_sub.set_subscribe(b"").expect("Failed to subscribe");
+        their_sub.set_rcvtimeo(3000).expect("Failed to set timeout");
+        their_sub
+            .set_reconnect_ivl(100)
+            .expect("Failed to set reconnect interval");
+
+        // Wait for subscription
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        // Phase 2: Verify initial communication
+        our_pub
+            .send(zeromq::ZmqMessage::from("initial-message"))
+            .await
+            .expect("Failed to send");
+
+        let msg = their_sub
+            .recv_string(0)
+            .expect("Failed to recv")
+            .expect("Invalid UTF8");
+        assert_eq!(msg, "initial-message");
+        println!("Phase 2: Initial communication verified");
+
+        // Phase 3: Drop our PUB
+        drop(our_pub);
+        println!("Phase 3: Our PUB dropped");
+
+        async_rt::task::sleep(Duration::from_millis(300)).await;
+
+        // Phase 4: Restart our PUB on same port
+        let mut our_pub_new = zeromq::PubSocket::new();
+        our_pub_new
+            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .await
+            .expect("Failed to rebind");
+        println!("Phase 4: Our PUB restarted on port {}", port);
+
+        // Phase 5: Wait for reconnection (libzmq SUB should auto-reconnect)
+        async_rt::task::sleep(Duration::from_secs(2)).await;
+
+        // Phase 6: Verify communication after reconnect
+        // Reset recv timeout for the final check
+        their_sub.set_rcvtimeo(5000).expect("Failed to set timeout");
+
+        our_pub_new
+            .send(zeromq::ZmqMessage::from("reconnected-message"))
+            .await
+            .expect("Failed to send");
+
+        let msg = their_sub
+            .recv_string(0)
+            .expect("Failed to recv after reconnect - libzmq SUB may not have reconnected")
+            .expect("Invalid UTF8");
+        assert_eq!(msg, "reconnected-message");
+        println!("Phase 6: Reconnection verified!");
+    }
+}

--- a/tests/router_dealer_compliant.rs
+++ b/tests/router_dealer_compliant.rs
@@ -89,13 +89,7 @@ mod test {
             let recv_identity = msg.get(0).unwrap();
             assert_eq!(recv_identity.as_ref(), identity);
 
-            let payload: String = msg
-                .into_vec()
-                .pop()
-                .unwrap()
-                .to_vec()
-                .pipe(String::from_utf8)
-                .unwrap();
+            let payload = String::from_utf8(msg.into_vec().pop().unwrap().to_vec()).unwrap();
             assert_eq!(payload, format!("Request: {}", i));
 
             // Send reply with identity frame
@@ -169,10 +163,7 @@ mod test {
 
                 // Send reply with identity
                 their_router
-                    .send_multipart(
-                        &[identity.as_slice(), format!("Reply: {}", i).as_bytes()],
-                        0,
-                    )
+                    .send_multipart([identity.as_slice(), format!("Reply: {}", i).as_bytes()], 0)
                     .expect("Failed to send");
             }
             their_router
@@ -257,15 +248,3 @@ mod test {
         }
     }
 }
-
-// Helper trait for chaining
-trait Pipe: Sized {
-    fn pipe<F, R>(self, f: F) -> R
-    where
-        F: FnOnce(Self) -> R,
-    {
-        f(self)
-    }
-}
-
-impl<T> Pipe for T {}

--- a/tests/router_dealer_compliant.rs
+++ b/tests/router_dealer_compliant.rs
@@ -1,0 +1,263 @@
+//! Conformance tests for ROUTER/DEALER sockets against libzmq.
+//!
+//! Tests identity-based routing between zmq.rs and libzmq implementations.
+
+mod compliance;
+use compliance::{get_monitor_event, setup_monitor};
+
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::ZmqMessage;
+
+use std::convert::TryInto;
+use std::time::Duration;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // =========================================================================
+    // Test 1: Our ROUTER binds, their DEALER connects
+    // =========================================================================
+
+    async fn setup_our_router(bind_endpoint: &str) -> (zeromq::RouterSocket, String) {
+        let mut our_router = zeromq::RouterSocket::new();
+        let endpoint = our_router.bind(bind_endpoint).await.expect("Failed to bind");
+        (our_router, endpoint.to_string())
+    }
+
+    fn setup_their_dealer(
+        ctx: &zmq2::Context,
+        connect_endpoint: &str,
+        identity: &[u8],
+    ) -> (zmq2::Socket, zmq2::Socket) {
+        let their_dealer = ctx.socket(zmq2::DEALER).expect("Couldn't make dealer socket");
+        their_dealer
+            .set_identity(identity)
+            .expect("Failed to set identity");
+        their_dealer
+            .connect(connect_endpoint)
+            .expect("Failed to connect");
+
+        let their_monitor = setup_monitor(ctx, &their_dealer, "inproc://dealer-monitor");
+        (their_dealer, their_monitor)
+    }
+
+    #[async_rt::test]
+    async fn test_our_router_their_dealer() {
+        pretty_env_logger::try_init().ok();
+
+        let (mut our_router, bind_endpoint) = setup_our_router("tcp://127.0.0.1:0").await;
+        println!("Our ROUTER bound to {}", bind_endpoint);
+
+        let ctx = zmq2::Context::new();
+        let identity = b"dealer-identity-1";
+        let (their_dealer, _their_monitor) =
+            setup_their_dealer(&ctx, &bind_endpoint, identity);
+
+        // Allow connection and handshake to complete
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        const NUM_MSGS: u32 = 10;
+
+        // Their DEALER sends messages in a thread
+        let dealer_handle = std::thread::spawn(move || {
+            for i in 0..NUM_MSGS {
+                their_dealer
+                    .send(&format!("Request: {}", i), 0)
+                    .expect("Failed to send");
+
+                let reply = their_dealer
+                    .recv_string(0)
+                    .expect("Failed to recv")
+                    .expect("Invalid UTF8");
+                assert_eq!(reply, format!("Reply: {}", i));
+            }
+            their_dealer
+        });
+
+        // Our ROUTER receives and replies
+        for i in 0..NUM_MSGS {
+            let msg = our_router.recv().await.expect("Failed to recv");
+
+            // ROUTER recv prepends identity frame
+            assert_eq!(msg.len(), 2, "Expected [identity, payload]");
+            let recv_identity = msg.get(0).unwrap();
+            assert_eq!(recv_identity.as_ref(), identity);
+
+            let payload: String = msg
+                .into_vec()
+                .pop()
+                .unwrap()
+                .to_vec()
+                .pipe(String::from_utf8)
+                .unwrap();
+            assert_eq!(payload, format!("Request: {}", i));
+
+            // Send reply with identity frame
+            let mut reply = ZmqMessage::from(format!("Reply: {}", i));
+            reply.push_front(identity.to_vec().into());
+            our_router.send(reply).await.expect("Failed to send");
+        }
+
+        dealer_handle.join().expect("Dealer thread panicked");
+    }
+
+    // =========================================================================
+    // Test 2: Their ROUTER binds, our DEALER connects
+    // =========================================================================
+
+    fn setup_their_router(bind_endpoint: &str) -> (zmq2::Socket, String, zmq2::Socket) {
+        let ctx = zmq2::Context::new();
+        let their_router = ctx.socket(zmq2::ROUTER).expect("Couldn't make router socket");
+        their_router.bind(bind_endpoint).expect("Failed to bind");
+
+        let resolved_bind = their_router.get_last_endpoint().unwrap().unwrap();
+        let their_monitor = setup_monitor(&ctx, &their_router, "inproc://router-monitor");
+
+        (their_router, resolved_bind, their_monitor)
+    }
+
+    async fn setup_our_dealer(connect_endpoint: &str) -> zeromq::DealerSocket {
+        let mut our_dealer = zeromq::DealerSocket::new();
+        our_dealer
+            .connect(connect_endpoint)
+            .await
+            .expect("Failed to connect");
+        our_dealer
+    }
+
+    #[async_rt::test]
+    async fn test_their_router_our_dealer() {
+        pretty_env_logger::try_init().ok();
+
+        let (their_router, bind_endpoint, their_monitor) =
+            setup_their_router("tcp://127.0.0.1:0");
+        println!("Their ROUTER bound to {}", bind_endpoint);
+
+        let mut our_dealer = setup_our_dealer(&bind_endpoint).await;
+
+        // Wait for handshake
+        assert_eq!(
+            zmq2::SocketEvent::ACCEPTED,
+            get_monitor_event(&their_monitor).0
+        );
+        assert_eq!(
+            zmq2::SocketEvent::HANDSHAKE_SUCCEEDED,
+            get_monitor_event(&their_monitor).0
+        );
+
+        async_rt::task::sleep(Duration::from_millis(100)).await;
+
+        const NUM_MSGS: u32 = 10;
+
+        // Their ROUTER runs in a thread (blocking recv)
+        let router_handle = std::thread::spawn(move || {
+            for i in 0..NUM_MSGS {
+                // ROUTER recv returns [identity, ...payload]
+                let parts = their_router.recv_multipart(0).expect("Failed to recv");
+                assert_eq!(parts.len(), 2, "Expected [identity, payload]");
+
+                let identity = &parts[0];
+                let payload = String::from_utf8(parts[1].clone()).unwrap();
+                assert_eq!(payload, format!("Request: {}", i));
+
+                // Send reply with identity
+                their_router
+                    .send_multipart(&[identity.as_slice(), format!("Reply: {}", i).as_bytes()], 0)
+                    .expect("Failed to send");
+            }
+            their_router
+        });
+
+        // Our DEALER sends and receives
+        for i in 0..NUM_MSGS {
+            let msg = ZmqMessage::from(format!("Request: {}", i));
+            our_dealer.send(msg).await.expect("Failed to send");
+
+            let reply = our_dealer.recv().await.expect("Failed to recv");
+            let reply_str: String = reply.try_into().unwrap();
+            assert_eq!(reply_str, format!("Reply: {}", i));
+        }
+
+        router_handle.join().expect("Router thread panicked");
+    }
+
+    // =========================================================================
+    // Test 3: Multiple DEALERs to one ROUTER (load balancing)
+    // =========================================================================
+
+    #[async_rt::test]
+    async fn test_our_router_multiple_their_dealers() {
+        pretty_env_logger::try_init().ok();
+
+        let (mut our_router, bind_endpoint) = setup_our_router("tcp://127.0.0.1:0").await;
+        println!("Our ROUTER bound to {}", bind_endpoint);
+
+        const NUM_DEALERS: u32 = 5;
+        const MSGS_PER_DEALER: u32 = 10;
+
+        let ctx = zmq2::Context::new();
+
+        // Connect multiple dealers
+        let mut dealer_handles = Vec::new();
+        for d in 0..NUM_DEALERS {
+            let identity = format!("dealer-{}", d);
+            let their_dealer = ctx.socket(zmq2::DEALER).expect("Couldn't make dealer");
+            their_dealer
+                .set_identity(identity.as_bytes())
+                .expect("Failed to set identity");
+            their_dealer
+                .connect(&bind_endpoint)
+                .expect("Failed to connect");
+
+            let handle = std::thread::spawn(move || {
+                for i in 0..MSGS_PER_DEALER {
+                    their_dealer
+                        .send(&format!("{}:{}", identity, i), 0)
+                        .expect("Failed to send");
+
+                    let reply = their_dealer
+                        .recv_string(0)
+                        .expect("Failed to recv")
+                        .expect("Invalid UTF8");
+                    assert_eq!(reply, format!("ack-{}:{}", identity, i));
+                }
+            });
+            dealer_handles.push(handle);
+        }
+
+        // Allow connections
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        // Router handles all messages
+        for _ in 0..(NUM_DEALERS * MSGS_PER_DEALER) {
+            let msg = our_router.recv().await.expect("Failed to recv");
+            assert_eq!(msg.len(), 2);
+
+            let identity = msg.get(0).unwrap().clone();
+            let payload = String::from_utf8(msg.get(1).unwrap().to_vec()).unwrap();
+
+            // Reply with ack
+            let mut reply = ZmqMessage::from(format!("ack-{}", payload));
+            reply.push_front(identity);
+            our_router.send(reply).await.expect("Failed to send");
+        }
+
+        for handle in dealer_handles {
+            handle.join().expect("Dealer thread panicked");
+        }
+    }
+}
+
+// Helper trait for chaining
+trait Pipe: Sized {
+    fn pipe<F, R>(self, f: F) -> R
+    where
+        F: FnOnce(Self) -> R,
+    {
+        f(self)
+    }
+}
+
+impl<T> Pipe for T {}

--- a/tests/router_dealer_compliant.rs
+++ b/tests/router_dealer_compliant.rs
@@ -22,7 +22,10 @@ mod test {
 
     async fn setup_our_router(bind_endpoint: &str) -> (zeromq::RouterSocket, String) {
         let mut our_router = zeromq::RouterSocket::new();
-        let endpoint = our_router.bind(bind_endpoint).await.expect("Failed to bind");
+        let endpoint = our_router
+            .bind(bind_endpoint)
+            .await
+            .expect("Failed to bind");
         (our_router, endpoint.to_string())
     }
 
@@ -31,7 +34,9 @@ mod test {
         connect_endpoint: &str,
         identity: &[u8],
     ) -> (zmq2::Socket, zmq2::Socket) {
-        let their_dealer = ctx.socket(zmq2::DEALER).expect("Couldn't make dealer socket");
+        let their_dealer = ctx
+            .socket(zmq2::DEALER)
+            .expect("Couldn't make dealer socket");
         their_dealer
             .set_identity(identity)
             .expect("Failed to set identity");
@@ -52,8 +57,7 @@ mod test {
 
         let ctx = zmq2::Context::new();
         let identity = b"dealer-identity-1";
-        let (their_dealer, _their_monitor) =
-            setup_their_dealer(&ctx, &bind_endpoint, identity);
+        let (their_dealer, _their_monitor) = setup_their_dealer(&ctx, &bind_endpoint, identity);
 
         // Allow connection and handshake to complete
         async_rt::task::sleep(Duration::from_millis(200)).await;
@@ -109,7 +113,9 @@ mod test {
 
     fn setup_their_router(bind_endpoint: &str) -> (zmq2::Socket, String, zmq2::Socket) {
         let ctx = zmq2::Context::new();
-        let their_router = ctx.socket(zmq2::ROUTER).expect("Couldn't make router socket");
+        let their_router = ctx
+            .socket(zmq2::ROUTER)
+            .expect("Couldn't make router socket");
         their_router.bind(bind_endpoint).expect("Failed to bind");
 
         let resolved_bind = their_router.get_last_endpoint().unwrap().unwrap();
@@ -131,8 +137,7 @@ mod test {
     async fn test_their_router_our_dealer() {
         pretty_env_logger::try_init().ok();
 
-        let (their_router, bind_endpoint, their_monitor) =
-            setup_their_router("tcp://127.0.0.1:0");
+        let (their_router, bind_endpoint, their_monitor) = setup_their_router("tcp://127.0.0.1:0");
         println!("Their ROUTER bound to {}", bind_endpoint);
 
         let mut our_dealer = setup_our_dealer(&bind_endpoint).await;
@@ -164,7 +169,10 @@ mod test {
 
                 // Send reply with identity
                 their_router
-                    .send_multipart(&[identity.as_slice(), format!("Reply: {}", i).as_bytes()], 0)
+                    .send_multipart(
+                        &[identity.as_slice(), format!("Reply: {}", i).as_bytes()],
+                        0,
+                    )
                     .expect("Failed to send");
             }
             their_router

--- a/tests/xpub_sub.rs
+++ b/tests/xpub_sub.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod test {
+    use zeromq::__async_rt as async_rt;
     use zeromq::prelude::*;
     use zeromq::ZmqMessage;
-    use zeromq::__async_rt as async_rt;
 
     use std::time::Duration;
 


### PR DESCRIPTION
🎉  229 is my favorite prime number! 🎉 

## Summary

Adds more conformance tests that verify wire protocol compatibility between zmq.rs and the reference libzmq implementation.

## Tests Added

- **router_dealer_compliant.rs** (3 tests): Tests ROUTER/DEALER identity-based routing against libzmq, including multi-client scenarios
- **pub_sub_compliant_reverse.rs** (2 tests): Tests our PUB socket with libzmq SUB sockets across TCP and IPC transports with topic filtering
- **reconnection_compliant.rs** (2 tests, currently ignored): Documents reconnection behavior gaps - subscription resync after peer restart not fully implemented

All tests pass except 2 ignored tests that reveal known limitations for future work.