### PR TITLE
Implement auto-reconnection for SUB sockets

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -11,7 +11,11 @@ use futures::channel::mpsc;
 use futures::SinkExt;
 use parking_lot::Mutex;
 
+use std::collections::HashMap;
 use std::sync::Arc;
+
+/// Sender for notifying reconnection tasks when a peer disconnects.
+pub(crate) type DisconnectNotifier = mpsc::Sender<PeerIdentity>;
 
 pub(crate) struct Peer {
     pub(crate) send_queue: ZmqFramedWrite,
@@ -24,6 +28,8 @@ pub(crate) struct GenericSocketBackend {
     socket_type: SocketType,
     socket_options: SocketOptions,
     pub(crate) socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
+    /// Notifiers for reconnection tasks - keyed by `peer_id`
+    disconnect_notifiers: Mutex<HashMap<PeerIdentity, DisconnectNotifier>>,
 }
 
 impl GenericSocketBackend {
@@ -39,7 +45,26 @@ impl GenericSocketBackend {
             socket_type,
             socket_options: options,
             socket_monitor: Mutex::new(None),
+            disconnect_notifiers: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Register a notifier to be called when a peer disconnects.
+    ///
+    /// Used by reconnection tasks to be notified when they should attempt reconnection.
+    #[allow(dead_code)] // Will be used when reconnection is added to more socket types
+    pub(crate) fn register_disconnect_notifier(
+        &self,
+        peer_id: PeerIdentity,
+        notifier: DisconnectNotifier,
+    ) {
+        self.disconnect_notifiers.lock().insert(peer_id, notifier);
+    }
+
+    /// Unregister a disconnect notifier for a peer.
+    #[allow(dead_code)] // Will be used when reconnection is added to more socket types
+    pub(crate) fn unregister_disconnect_notifier(&self, peer_id: &PeerIdentity) {
+        self.disconnect_notifiers.lock().remove(peer_id);
     }
 
     pub(crate) async fn send_round_robin(&self, message: Message) -> ZmqResult<PeerIdentity> {
@@ -95,6 +120,11 @@ impl SocketBackend for GenericSocketBackend {
 
     fn shutdown(&self) {
         self.peers.clear_sync();
+        // Clear fair_queue streams to ensure TCP connections are closed
+        // even when reconnect tasks still hold Arc references to the backend
+        if let Some(inner) = &self.fair_queue_inner {
+            inner.lock().clear();
+        }
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -126,5 +156,12 @@ impl MultiPeerBackend for GenericSocketBackend {
                 inner.lock().remove(peer_id);
             }
         };
+
+        // Notify reconnection task if registered
+        if let Some(mut notifier) = self.disconnect_notifiers.lock().remove(peer_id) {
+            // Use try_send to avoid blocking - if channel is full, the reconnect task
+            // will eventually notice the peer is gone
+            let _ = notifier.try_send(peer_id.clone());
+        }
     }
 }

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -15,6 +15,9 @@ pub(crate) struct QueueInner<S, K: Clone> {
     ready_queue: BinaryHeap<ReadyEvent<K>>,
     streams: HashMap<K, Pin<Box<S>>>,
     waker: Option<Waker>,
+    /// Callback invoked when a stream ends (peer disconnected).
+    /// Wrapped in Arc so it can be cloned and called outside the lock.
+    on_disconnect: Option<Arc<dyn Fn(K) + Send + Sync>>,
 }
 
 impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
@@ -31,6 +34,19 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
 
     pub fn remove(&mut self, k: &K) {
         self.streams.remove(k);
+    }
+
+    /// Clear all streams and the ready queue.
+    ///
+    /// Used during shutdown to ensure TCP connections are closed even when
+    /// other components (like reconnect tasks) hold Arc references to the inner.
+    pub fn clear(&mut self) {
+        self.streams.clear();
+        self.ready_queue.clear();
+        // Wake the waker so any pending poll_next returns
+        if let Some(w) = self.waker.take() {
+            w.wake();
+        }
     }
 }
 
@@ -133,6 +149,16 @@ where
                 }
                 Poll::Ready(None) => {
                     // Peer disconnected. Don't put the stream back.
+                    // Clone the callback Arc so we can call it outside the lock
+                    // (to avoid deadlock if callback accesses inner)
+                    let callback = {
+                        let inner = fair_queue.inner.lock();
+                        inner.on_disconnect.clone()
+                    };
+                    // Call callback outside the lock
+                    if let Some(callback) = callback {
+                        callback(event.key.clone());
+                    }
                     // Continue to poll other streams instead of returning None immediately.
                     continue;
                 }
@@ -155,8 +181,19 @@ impl<S, K: Clone> FairQueue<S, K> {
                 ready_queue: BinaryHeap::new(),
                 streams: HashMap::new(),
                 waker: None,
+                on_disconnect: None,
             })),
         }
+    }
+
+    /// Set a callback to be invoked when a stream ends (peer disconnected).
+    ///
+    /// The callback receives the key of the disconnected stream.
+    pub fn set_on_disconnect<F>(&mut self, callback: F)
+    where
+        F: Fn(K) + Send + Sync + 'static,
+    {
+        self.inner.lock().on_disconnect = Some(Arc::new(callback));
     }
 
     pub(crate) fn inner(&self) -> Arc<Mutex<QueueInner<S, K>>> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod message;
 mod r#pub;
 mod pull;
 mod push;
+mod reconnect;
 mod rep;
 mod req;
 mod router;

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -1,0 +1,232 @@
+//! Reconnection infrastructure for `ZeroMQ` sockets.
+//!
+//! This module provides auto-reconnection capability when connected endpoints
+//! are disconnected. When a peer disconnects, a background task attempts to
+//! reconnect with exponential backoff.
+
+use crate::async_rt::task::{spawn, JoinHandle};
+use crate::backend::DisconnectNotifier;
+use crate::endpoint::Endpoint;
+use crate::transport;
+use crate::util::{greet_exchange, ready_exchange, PeerIdentity};
+use crate::MultiPeerBackend;
+
+use futures::channel::{mpsc, oneshot};
+use futures::StreamExt;
+use rand::Rng;
+
+use std::sync::Arc;
+use std::time::Duration;
+
+/// Configuration for reconnection behavior.
+#[derive(Debug, Clone)]
+pub struct ReconnectConfig {
+    /// Initial delay before first reconnection attempt (default: 100ms)
+    pub initial_interval: Duration,
+    /// Maximum delay between reconnection attempts (default: 30s)
+    pub max_interval: Duration,
+    /// Multiplier for exponential backoff (default: 2.0)
+    pub backoff_multiplier: f64,
+}
+
+impl Default for ReconnectConfig {
+    fn default() -> Self {
+        Self {
+            initial_interval: Duration::from_millis(100),
+            max_interval: Duration::from_secs(30),
+            backoff_multiplier: 2.0,
+        }
+    }
+}
+
+/// Handle to a running reconnection task.
+///
+/// When dropped, the reconnection task continues to run. Call `shutdown()` to
+/// stop the task gracefully.
+pub struct ReconnectHandle {
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    #[allow(dead_code)] // Kept to prevent task from being dropped prematurely
+    task_handle: JoinHandle<()>,
+}
+
+impl ReconnectHandle {
+    /// Request graceful shutdown of the reconnection task.
+    ///
+    /// This signals the task to stop and returns immediately. The task will
+    /// finish its current iteration before stopping.
+    pub fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        // task_handle is dropped, which is fine - we don't need to await it
+    }
+}
+
+/// Type for a function that registers disconnect notifiers with a backend.
+pub type RegisterDisconnectFn = Box<dyn Fn(PeerIdentity, DisconnectNotifier) + Send + Sync>;
+
+/// Spawns a reconnection task for a single endpoint.
+///
+/// The task monitors for disconnect notifications. When a disconnect is received,
+/// it attempts to reconnect with exponential backoff.
+///
+/// On successful reconnection:
+/// - The handshake (greeting + ready exchange) is performed
+/// - `backend.peer_connected()` is called, which triggers subscription resync for SUB sockets
+/// - The new `peer_id` is registered for future disconnect notifications via `register_disconnect_fn`
+///
+/// # Arguments
+/// * `endpoint` - The endpoint to reconnect to
+/// * `backend` - The socket backend (used for handshake and peer registration)
+/// * `initial_peer_id` - The `peer_id` from the initial connection
+/// * `register_disconnect_fn` - Callback to register disconnect notifiers with the backend
+/// * `config` - Reconnection configuration (intervals, backoff)
+///
+/// # Returns
+/// A `ReconnectHandle` to control the task.
+pub fn spawn_reconnect_task(
+    endpoint: Endpoint,
+    backend: Arc<dyn MultiPeerBackend>,
+    initial_peer_id: PeerIdentity,
+    register_disconnect_fn: RegisterDisconnectFn,
+    config: ReconnectConfig,
+) -> ReconnectHandle {
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    // Create the disconnect notification channel - this task owns the receiver
+    let (disconnect_tx, mut disconnect_rx) = mpsc::channel::<PeerIdentity>(1);
+
+    // Register the initial peer_id
+    register_disconnect_fn(initial_peer_id.clone(), disconnect_tx.clone());
+
+    let task_handle = spawn(async move {
+        log::debug!("Reconnect task started for endpoint: {}", endpoint);
+
+        loop {
+            // Wait for a disconnect notification or shutdown signal
+            let peer_id = futures::select! {
+                peer_id = disconnect_rx.next() => {
+                    if let Some(id) = peer_id {
+                        id
+                    } else {
+                        log::debug!("Disconnect channel closed, stopping reconnect task");
+                        return;
+                    }
+                }
+                _ = shutdown_rx => {
+                    log::debug!("Shutdown received, stopping reconnect task");
+                    return;
+                }
+            };
+
+            log::info!(
+                "Peer {:?} disconnected from {}, starting reconnection",
+                peer_id,
+                endpoint
+            );
+
+            // Attempt reconnection with exponential backoff
+            let mut current_interval = config.initial_interval;
+            let mut attempt = 0u32;
+
+            loop {
+                attempt += 1;
+                log::debug!(
+                    "Reconnection attempt {} to {} (waiting {:?})",
+                    attempt,
+                    endpoint,
+                    current_interval
+                );
+
+                // Wait before attempting reconnection
+                crate::async_rt::task::sleep(current_interval).await;
+
+                // Try to connect
+                match try_reconnect(&endpoint, backend.clone()).await {
+                    Ok(new_peer_id) => {
+                        log::info!(
+                            "Successfully reconnected to {} (peer {:?})",
+                            endpoint,
+                            new_peer_id
+                        );
+                        // Register the new peer_id for future disconnect notifications
+                        register_disconnect_fn(new_peer_id, disconnect_tx.clone());
+                        // Reconnection successful, go back to waiting for disconnects
+                        break;
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Reconnection attempt {} to {} failed: {:?}",
+                            attempt,
+                            endpoint,
+                            e
+                        );
+
+                        // Calculate next backoff interval with jitter
+                        let jitter = {
+                            let mut rng = rand::rng();
+                            rng.random_range(0.0..0.1)
+                        };
+                        let next_interval_secs =
+                            current_interval.as_secs_f64() * config.backoff_multiplier + jitter;
+                        current_interval = Duration::from_secs_f64(
+                            next_interval_secs.min(config.max_interval.as_secs_f64()),
+                        );
+                    }
+                }
+            }
+        }
+    });
+
+    ReconnectHandle {
+        shutdown_tx: Some(shutdown_tx),
+        task_handle,
+    }
+}
+
+/// Attempts a single reconnection to the endpoint.
+///
+/// This performs the full connection sequence:
+/// 1. TCP/IPC connection
+/// 2. ZMTP greeting exchange
+/// 3. Ready command exchange
+/// 4. Peer registration via `backend.peer_connected()`
+async fn try_reconnect(
+    endpoint: &Endpoint,
+    backend: Arc<dyn MultiPeerBackend>,
+) -> crate::ZmqResult<PeerIdentity> {
+    // Attempt transport-level connection
+    let (mut raw_socket, _resolved_endpoint) = transport::connect(endpoint).await?;
+
+    // Perform ZMTP handshake
+    greet_exchange(&mut raw_socket).await?;
+
+    // Build properties for ready exchange (include identity if configured)
+    let mut props = None;
+    if let Some(identity) = &backend.socket_options().peer_id {
+        let mut connect_ops = std::collections::HashMap::new();
+        connect_ops.insert("Identity".to_string(), identity.clone().into());
+        props = Some(connect_ops);
+    }
+
+    // Exchange ready commands
+    let peer_id = ready_exchange(&mut raw_socket, backend.socket_type(), props).await?;
+
+    // Register the peer with the backend
+    // This triggers subscription resync for SUB sockets
+    backend.peer_connected(&peer_id, raw_socket).await;
+
+    Ok(peer_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reconnect_config_default() {
+        let config = ReconnectConfig::default();
+        assert_eq!(config.initial_interval, Duration::from_millis(100));
+        assert_eq!(config.max_interval, Duration::from_secs(30));
+        assert!((config.backoff_multiplier - 2.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -12,7 +12,7 @@ use crate::util::{greet_exchange, ready_exchange, PeerIdentity};
 use crate::MultiPeerBackend;
 
 use futures::channel::{mpsc, oneshot};
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use rand::Rng;
 
 use std::sync::Arc;
@@ -91,7 +91,7 @@ pub fn spawn_reconnect_task(
     register_disconnect_fn: RegisterDisconnectFn,
     config: ReconnectConfig,
 ) -> ReconnectHandle {
-    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
     // Create the disconnect notification channel - this task owns the receiver
     let (disconnect_tx, mut disconnect_rx) = mpsc::channel::<PeerIdentity>(1);
 
@@ -100,6 +100,9 @@ pub fn spawn_reconnect_task(
 
     let task_handle = spawn(async move {
         log::debug!("Reconnect task started for endpoint: {}", endpoint);
+
+        // Fuse shutdown_rx so it can be polled multiple times after completion
+        let mut shutdown_rx = shutdown_rx.fuse();
 
         loop {
             // Wait for a disconnect notification or shutdown signal
@@ -128,7 +131,7 @@ pub fn spawn_reconnect_task(
             let mut current_interval = config.initial_interval;
             let mut attempt = 0u32;
 
-            loop {
+            'retry: loop {
                 attempt += 1;
                 log::debug!(
                     "Reconnection attempt {} to {} (waiting {:?})",
@@ -137,21 +140,41 @@ pub fn spawn_reconnect_task(
                     current_interval
                 );
 
-                // Wait before attempting reconnection
-                crate::async_rt::task::sleep(current_interval).await;
+                // Wait before attempting reconnection, but check for shutdown
+                let sleep_fut = crate::async_rt::task::sleep(current_interval).fuse();
+                futures::pin_mut!(sleep_fut);
+
+                futures::select! {
+                    _ = sleep_fut => {
+                        // Sleep completed, proceed to reconnection attempt
+                    }
+                    _ = shutdown_rx => {
+                        log::debug!("Shutdown received during backoff, stopping reconnect task");
+                        return;
+                    }
+                }
 
                 // Try to connect
                 match try_reconnect(&endpoint, backend.clone()).await {
-                    Ok(new_peer_id) => {
+                    Ok((new_peer_id, resolved_endpoint)) => {
                         log::info!(
                             "Successfully reconnected to {} (peer {:?})",
                             endpoint,
                             new_peer_id
                         );
+
+                        // Emit Connected event for monitor consumers
+                        if let Some(monitor) = backend.monitor().lock().as_mut() {
+                            let _ = monitor.try_send(crate::SocketEvent::Connected(
+                                resolved_endpoint,
+                                new_peer_id.clone(),
+                            ));
+                        }
+
                         // Register the new peer_id for future disconnect notifications
                         register_disconnect_fn(new_peer_id, disconnect_tx.clone());
                         // Reconnection successful, go back to waiting for disconnects
-                        break;
+                        break 'retry;
                     }
                     Err(e) => {
                         log::warn!(
@@ -190,12 +213,14 @@ pub fn spawn_reconnect_task(
 /// 2. ZMTP greeting exchange
 /// 3. Ready command exchange
 /// 4. Peer registration via `backend.peer_connected()`
+///
+/// Returns the new `peer_id` and resolved endpoint on success.
 async fn try_reconnect(
     endpoint: &Endpoint,
     backend: Arc<dyn MultiPeerBackend>,
-) -> crate::ZmqResult<PeerIdentity> {
+) -> crate::ZmqResult<(PeerIdentity, Endpoint)> {
     // Attempt transport-level connection
-    let (mut raw_socket, _resolved_endpoint) = transport::connect(endpoint).await?;
+    let (mut raw_socket, resolved_endpoint) = transport::connect(endpoint).await?;
 
     // Perform ZMTP handshake
     greet_exchange(&mut raw_socket).await?;
@@ -215,7 +240,7 @@ async fn try_reconnect(
     // This triggers subscription resync for SUB sockets
     backend.peer_connected(&peer_id, raw_socket).await;
 
-    Ok(peer_id)
+    Ok((peer_id, resolved_endpoint))
 }
 
 #[cfg(test)]

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -1,14 +1,16 @@
-use crate::backend::Peer;
+use crate::backend::{DisconnectNotifier, Peer};
 use crate::codec::{FramedIo, Message, ZmqFramedRead};
 use crate::endpoint::Endpoint;
 use crate::error::{ZmqError, ZmqResult};
 use crate::fair_queue::FairQueue;
 use crate::fair_queue::QueueInner;
 use crate::message::ZmqMessage;
+use crate::reconnect::{ReconnectConfig, ReconnectHandle};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
     MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketType,
+    TryIntoEndpoint,
 };
 
 use async_trait::async_trait;
@@ -34,6 +36,8 @@ pub(crate) struct SubSocketBackend {
     socket_options: SocketOptions,
     pub(crate) socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     subs: Mutex<HashSet<String>>,
+    /// Notifiers for reconnection tasks - keyed by `peer_id`
+    disconnect_notifiers: Mutex<HashMap<PeerIdentity, DisconnectNotifier>>,
 }
 
 impl SubSocketBackend {
@@ -50,6 +54,7 @@ impl SubSocketBackend {
             socket_options: options,
             socket_monitor: Mutex::new(None),
             subs: Mutex::new(HashSet::new()),
+            disconnect_notifiers: Mutex::new(HashMap::new()),
         }
     }
 
@@ -59,6 +64,23 @@ impl SubSocketBackend {
         buf.extend_from_slice(subscription.as_bytes());
 
         buf.freeze().into()
+    }
+
+    /// Register a notifier to be called when a peer disconnects.
+    ///
+    /// Used by reconnection tasks to be notified when they should attempt reconnection.
+    pub(crate) fn register_disconnect_notifier(
+        &self,
+        peer_id: PeerIdentity,
+        notifier: DisconnectNotifier,
+    ) {
+        self.disconnect_notifiers.lock().insert(peer_id, notifier);
+    }
+
+    /// Unregister a disconnect notifier for a peer.
+    #[allow(dead_code)]
+    pub(crate) fn unregister_disconnect_notifier(&self, peer_id: &PeerIdentity) {
+        self.disconnect_notifiers.lock().remove(peer_id);
     }
 }
 
@@ -73,6 +95,11 @@ impl SocketBackend for SubSocketBackend {
 
     fn shutdown(&self) {
         self.peers.clear_sync();
+        // Clear fair_queue streams to ensure TCP connections are closed
+        // even when reconnect tasks still hold Arc references to the backend
+        if let Some(inner) = &self.fair_queue_inner {
+            inner.lock().clear();
+        }
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -116,6 +143,19 @@ impl MultiPeerBackend for SubSocketBackend {
             let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
         }
         self.peers.remove_sync(peer_id);
+        match &self.fair_queue_inner {
+            None => {}
+            Some(inner) => {
+                inner.lock().remove(peer_id);
+            }
+        };
+
+        // Notify reconnection task if registered
+        if let Some(mut notifier) = self.disconnect_notifiers.lock().remove(peer_id) {
+            // Use try_send to avoid blocking - if channel is full, the reconnect task
+            // will eventually notice the peer is gone
+            let _ = notifier.try_send(peer_id.clone());
+        }
     }
 }
 
@@ -123,10 +163,16 @@ pub struct SubSocket {
     backend: Arc<SubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
     binds: HashMap<Endpoint, AcceptStopHandle>,
+    /// Handles to background reconnection tasks
+    reconnect_handles: Vec<ReconnectHandle>,
 }
 
 impl Drop for SubSocket {
     fn drop(&mut self) {
+        // Shutdown all reconnection tasks
+        for handle in self.reconnect_handles.drain(..) {
+            handle.shutdown();
+        }
         self.backend.shutdown();
     }
 }
@@ -165,15 +211,24 @@ impl SubSocket {
 #[async_trait]
 impl Socket for SubSocket {
     fn with_options(options: SocketOptions) -> Self {
-        let fair_queue = FairQueue::new(true);
+        let mut fair_queue = FairQueue::new(true);
+        let backend = Arc::new(SubSocketBackend::with_options(
+            Some(fair_queue.inner()),
+            SocketType::SUB,
+            options,
+        ));
+
+        // Set callback to notify backend when a stream ends (peer disconnected)
+        let backend_for_callback = backend.clone();
+        fair_queue.set_on_disconnect(move |peer_id: PeerIdentity| {
+            backend_for_callback.peer_disconnected(&peer_id);
+        });
+
         Self {
-            backend: Arc::new(SubSocketBackend::with_options(
-                Some(fair_queue.inner()),
-                SocketType::SUB,
-                options,
-            )),
+            backend,
             fair_queue,
             binds: HashMap::new(),
+            reconnect_handles: Vec::new(),
         }
     }
 
@@ -183,6 +238,46 @@ impl Socket for SubSocket {
 
     fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
         &mut self.binds
+    }
+
+    /// Connects to the given endpoint with automatic reconnection support.
+    ///
+    /// Unlike the default `Socket::connect`, this implementation spawns a
+    /// background task that will automatically reconnect if the connection
+    /// is lost. On reconnection, subscriptions are automatically re-sent
+    /// to the peer.
+    async fn connect(&mut self, endpoint: &str) -> ZmqResult<()> {
+        let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+
+        // Initial connection
+        let (socket, resolved_endpoint) = crate::util::connect_forever(endpoint.clone()).await?;
+        let peer_id =
+            crate::util::peer_connected(socket, self.backend.clone() as Arc<dyn MultiPeerBackend>)
+                .await?;
+
+        // Emit Connected event
+        if let Some(monitor) = self.backend.monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Connected(resolved_endpoint, peer_id.clone()));
+        }
+
+        // Create a closure that registers disconnect notifiers with the backend
+        let backend_for_closure = self.backend.clone();
+        let register_fn: crate::reconnect::RegisterDisconnectFn =
+            Box::new(move |peer_id, notifier| {
+                backend_for_closure.register_disconnect_notifier(peer_id, notifier);
+            });
+
+        // Spawn reconnection task
+        let reconnect_handle = crate::reconnect::spawn_reconnect_task(
+            endpoint,
+            self.backend.clone() as Arc<dyn MultiPeerBackend>,
+            peer_id,
+            register_fn,
+            ReconnectConfig::default(),
+        );
+        self.reconnect_handles.push(reconnect_handle);
+
+        Ok(())
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -219,9 +219,12 @@ impl Socket for SubSocket {
         ));
 
         // Set callback to notify backend when a stream ends (peer disconnected)
-        let backend_for_callback = backend.clone();
+        // Use Weak to avoid Arc cycle: backend -> fair_queue_inner -> callback -> backend
+        let backend_weak = Arc::downgrade(&backend);
         fair_queue.set_on_disconnect(move |peer_id: PeerIdentity| {
-            backend_for_callback.peer_disconnected(&peer_id);
+            if let Some(backend) = backend_weak.upgrade() {
+                backend.peer_disconnected(&peer_id);
+            }
         });
 
         Self {

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -31,12 +31,7 @@ mod test {
     /// 1. Initial connection and subscription works
     /// 2. After PUB drops and restarts on same port, SUB reconnects
     /// 3. Subscription is re-established and messages flow again
-    ///
-    /// NOTE: Currently ignored because zmq.rs doesn't fully implement
-    /// reconnection with subscription resync. This is a known limitation.
-    /// See: <https://github.com/zeromq/zmq.rs/issues/XXX>
     #[async_rt::test]
-    #[ignore = "zmq.rs reconnection with subscription resync not fully implemented"]
     async fn test_our_sub_reconnects_to_their_restarted_pub() {
         pretty_env_logger::try_init().ok();
 
@@ -88,11 +83,28 @@ mod test {
         let their_monitor = setup_monitor(&ctx, &their_pub_new, "inproc://pub-monitor");
         println!("Phase 4: Their PUB restarted on port {}", port);
 
-        // Phase 5: Wait for reconnection
-        // zmq.rs should auto-reconnect; libzmq will show ACCEPTED + HANDSHAKE_SUCCEEDED
-        // Give it plenty of time - reconnection can take a while
+        // Phase 5: Trigger disconnect detection and wait for reconnection
+        // Our SUB detects disconnect when it tries to receive. We use a short timeout
+        // recv() to trigger disconnect detection and allow the reconnection task to run.
+        println!("Phase 5: Triggering disconnect detection...");
+
+        // First recv attempt will detect the disconnection and trigger reconnection
+        match async_rt::task::timeout(Duration::from_millis(500), our_sub.recv()).await {
+            Ok(Ok(_msg)) => {
+                println!("Unexpectedly received a message during disconnect detection");
+            }
+            Ok(Err(e)) => {
+                println!("Recv error during disconnect detection (expected): {:?}", e);
+            }
+            Err(_) => {
+                println!("Recv timed out (disconnect detected, reconnection in progress)");
+            }
+        }
+
+        // Wait for reconnection to complete and subscription to re-propagate
+        // The reconnect task uses exponential backoff starting at 100ms
         let mut reconnected = false;
-        for attempt in 0..50 {
+        for attempt in 0..30 {
             async_rt::task::sleep(Duration::from_millis(100)).await;
 
             // Try to get monitor event without blocking
@@ -111,13 +123,14 @@ mod test {
         }
 
         if !reconnected {
-            println!("Warning: Didn't observe reconnection event after 5 seconds");
+            println!("Warning: Didn't observe reconnection event after 3 seconds");
         }
 
-        // Wait for subscription to re-propagate after reconnect
-        async_rt::task::sleep(Duration::from_millis(500)).await;
+        // Wait a bit more for subscription to propagate
+        async_rt::task::sleep(Duration::from_millis(300)).await;
 
         // Phase 6: Verify communication works after reconnect
+        println!("Phase 6: Sending message after reconnection...");
         their_pub_new
             .send("reconnected-message", 0)
             .expect("Failed to send");


### PR DESCRIPTION
## Summary

This PR implements automatic reconnection support for zmq.rs SUB sockets. When a connected peer disconnects, a background task automatically reconnects with exponential backoff, and subscriptions are automatically re-sent on reconnection. This restores standard ZeroMQ behavior where SUB sockets maintain connectivity.

## Implementation Details

- New `src/reconnect.rs` module providing `ReconnectConfig` and `spawn_reconnect_task`
- FairQueue enhancements with on_disconnect callback for detecting peer disconnections  
- Backend shutdown improvements to ensure TCP connections close during cleanup
- SubSocketBackend supports registering disconnect notifiers for reconnection tasks
- SubSocket overrides connect() to spawn background reconnection monitors
- Previously-ignored reconnection_compliant test now passes