### PR TITLE
feat: support `XSubSocket`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Basic ZMTP implementation is working and tested against the reference implementa
 ### Supported socket patterns:
 
 * Request/Response (REQ, REP, DEALER, ROUTER)
-* Publish/Subscribe (PUB, SUB, XPUB)
+* Publish/Subscribe (PUB, SUB, XPUB, XSUB)
 * Pipeline (PUSH, PULL)
 
 ## Usage

--- a/examples/xsub_xpub_proxy.rs
+++ b/examples/xsub_xpub_proxy.rs
@@ -1,0 +1,27 @@
+mod async_helpers;
+
+use zeromq::{proxy, Socket, XPubSocket, XSubSocket};
+
+#[async_helpers::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    pretty_env_logger::try_init().ok();
+
+    let mut frontend = XSubSocket::new();
+    let mut backend = XPubSocket::new();
+
+    let frontend_endpoint = frontend.bind("tcp://127.0.0.1:5557").await?;
+    let backend_endpoint = backend.bind("tcp://127.0.0.1:5558").await?;
+
+    println!("XSUB/XPUB proxy running");
+    println!(
+        "Upstream publishers or brokers connect to {}",
+        frontend_endpoint
+    );
+    println!(
+        "Downstream subscribers or brokers connect to {}",
+        backend_endpoint
+    );
+
+    proxy(frontend, backend, None).await?;
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,12 @@ mod rep;
 mod req;
 mod router;
 mod sub;
+mod sub_backend;
 mod task_handle;
 mod transport;
 pub mod util;
 mod xpub;
+mod xsub;
 
 #[doc(hidden)]
 pub mod __async_rt {
@@ -39,6 +41,7 @@ pub use crate::req::*;
 pub use crate::router::*;
 pub use crate::sub::*;
 pub use crate::xpub::*;
+pub use crate::xsub::*;
 
 use crate::codec::*;
 use crate::transport::AcceptStopHandle;

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -205,15 +205,44 @@ impl SubSocketBackend {
 
     /// Reliably send a message to every connected peer using async send.
     async fn broadcast_control_message(&self, message: ZmqMessage) -> ZmqResult<()> {
+        let mut dead_peers = Vec::new();
+        let mut first_error = None;
         let mut iter = self.peers.begin_async().await;
         while let Some(mut peer) = iter {
-            peer.send_queue
+            let peer_id = peer.key().clone();
+            let result = peer
+                .send_queue
                 .as_mut()
                 .send(Message::Message(message.clone()))
-                .await?;
+                .await;
+            match result {
+                Ok(()) => {}
+                Err(e)
+                    if matches!(
+                        &e,
+                        CodecError::Io(io_error) if io_error.kind() == ErrorKind::BrokenPipe
+                    ) =>
+                {
+                    dead_peers.push(peer_id);
+                    first_error.get_or_insert(e.into());
+                }
+                Err(e) => {
+                    log::error!(
+                        "Error sending control message to peer {:?}: {:?}",
+                        peer_id,
+                        e
+                    );
+                    first_error.get_or_insert(e.into());
+                }
+            }
             iter = peer.next_async().await;
         }
-        Ok(())
+
+        for peer_id in dead_peers {
+            self.peer_disconnected(&peer_id);
+        }
+
+        first_error.map_or(Ok(()), Err)
     }
 }
 

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -1,0 +1,330 @@
+use crate::backend::DisconnectNotifier;
+use crate::codec::{CodecError, FramedIo, Message, TrySend, ZmqFramedRead, ZmqFramedWrite};
+use crate::endpoint::Endpoint;
+use crate::error::{ZmqError, ZmqResult};
+use crate::fair_queue::QueueInner;
+use crate::message::ZmqMessage;
+use crate::reconnect::{ReconnectConfig, ReconnectHandle};
+use crate::transport::AcceptStopHandle;
+use crate::util::PeerIdentity;
+use crate::{
+    MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, TryIntoEndpoint,
+};
+
+use async_trait::async_trait;
+use bytes::{BufMut, BytesMut};
+use futures::channel::mpsc;
+use futures::SinkExt;
+use parking_lot::Mutex;
+
+use std::collections::{HashMap, HashSet};
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Type of subscription message sent from SUB/XSUB to PUB/XPUB.
+/// The discriminant values match the ZMTP wire format.
+pub(crate) enum SubscriptionMessageType {
+    Unsubscribe = 0,
+    Subscribe = 1,
+}
+
+/// A connected peer for SUB/XSUB sockets, holding only the send half
+/// of the framed I/O since receiving is handled through the fair queue.
+pub(crate) struct SubPeer {
+    pub(crate) send_queue: Pin<Box<ZmqFramedWrite>>,
+}
+
+/// Shared backend for [`SubSocket`](crate::SubSocket) and [`XSubSocket`](crate::XSubSocket).
+///
+/// Manages peer connections, subscription state, and disconnect notifications.
+/// When a new peer connects, all current subscriptions are automatically
+/// re-sent to ensure the peer receives the full subscription set.
+pub(crate) struct SubSocketBackend {
+    pub(crate) peers: scc::HashMap<PeerIdentity, SubPeer>,
+    fair_queue_inner: Option<Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>>,
+    socket_type: SocketType,
+    socket_options: SocketOptions,
+    pub(crate) socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
+    subs: Mutex<HashSet<Vec<u8>>>,
+    /// Notifiers for reconnection tasks - keyed by `peer_id`
+    disconnect_notifiers: Mutex<HashMap<PeerIdentity, DisconnectNotifier>>,
+}
+
+impl SubSocketBackend {
+    pub(crate) fn with_options(
+        fair_queue_inner: Option<Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>>,
+        socket_type: SocketType,
+        options: SocketOptions,
+    ) -> Self {
+        Self {
+            peers: scc::HashMap::new(),
+            fair_queue_inner,
+            socket_type,
+            socket_options: options,
+            socket_monitor: Mutex::new(None),
+            subs: Mutex::new(HashSet::new()),
+            disconnect_notifiers: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub(crate) fn create_subs_message(
+        subscription: &[u8],
+        msg_type: SubscriptionMessageType,
+    ) -> ZmqMessage {
+        let mut buf = BytesMut::with_capacity(subscription.len() + 1);
+        buf.put_u8(msg_type as u8);
+        buf.extend_from_slice(subscription);
+        buf.freeze().into()
+    }
+
+    /// Track a subscription locally so it can be re-sent on reconnection.
+    pub(crate) fn remember_subscription(&self, subscription: &[u8]) {
+        self.subs.lock().insert(subscription.to_vec());
+    }
+
+    /// Remove a subscription from local tracking.
+    pub(crate) fn forget_subscription(&self, subscription: &[u8]) {
+        self.subs.lock().remove(subscription);
+    }
+
+    /// Parse a ZMTP subscription message and update local subscription state.
+    ///
+    /// Returns `true` if the message was a valid subscription/unsubscription
+    /// frame (single frame, first byte 0x01 for subscribe or 0x00 for
+    /// unsubscribe, remainder is the subscription prefix).
+    /// Returns `false` for any other message, which should be treated as
+    /// an application-level message.
+    pub(crate) fn apply_subscription_message(&self, message: &ZmqMessage) -> bool {
+        let Some(frame) = message.get(0) else {
+            return false;
+        };
+        if message.len() != 1 || frame.is_empty() {
+            return false;
+        }
+
+        match frame[0] {
+            1 => {
+                self.remember_subscription(&frame[1..]);
+                true
+            }
+            0 => {
+                self.forget_subscription(&frame[1..]);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Register a notifier to be called when a peer disconnects.
+    ///
+    /// Used by reconnection tasks to be notified when they should attempt reconnection.
+    pub(crate) fn register_disconnect_notifier(
+        &self,
+        peer_id: PeerIdentity,
+        notifier: DisconnectNotifier,
+    ) {
+        self.disconnect_notifiers.lock().insert(peer_id, notifier);
+    }
+
+    /// Build and reliably send a subscription/unsubscription message to all peers.
+    pub(crate) async fn broadcast_subscription(
+        &self,
+        subscription: &[u8],
+        msg_type: SubscriptionMessageType,
+    ) -> ZmqResult<()> {
+        let message = Self::create_subs_message(subscription, msg_type);
+        self.broadcast_message_reliably(message).await
+    }
+
+    /// Send a control message to all connected peers, awaiting each send.
+    ///
+    /// Unlike [`fanout_message`](Self::fanout_message), this uses async send
+    /// which applies backpressure and returns errors on failure — suitable for
+    /// subscription messages that must be delivered reliably.
+    pub(crate) async fn broadcast_message_reliably(&self, message: ZmqMessage) -> ZmqResult<()> {
+        self.broadcast_control_message(message).await
+    }
+
+    /// Send an application message to all connected peers using non-blocking
+    /// [`try_send`](crate::codec::TrySend::try_send).
+    ///
+    /// Messages are silently dropped when a peer's buffer is full, matching
+    /// ZMQ's publish semantics. Peers with broken pipes are collected and
+    /// disconnected after the iteration completes.
+    pub(crate) async fn fanout_message(&self, message: ZmqMessage) -> ZmqResult<()> {
+        if message.is_empty() {
+            return Ok(());
+        }
+
+        let mut dead_peers = Vec::new();
+        let mut iter = self.peers.begin_async().await;
+        while let Some(mut peer) = iter {
+            let res = peer
+                .send_queue
+                .as_mut()
+                .try_send(Message::Message(message.clone()));
+            match res {
+                Ok(()) => {}
+                Err(ZmqError::Codec(CodecError::Io(e))) => {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        dead_peers.push(peer.key().clone());
+                    } else {
+                        log::error!("Error sending message: {:?}", e);
+                    }
+                }
+                Err(ZmqError::BufferFull(_)) => {
+                    log::debug!("Queue for subscriber is full");
+                }
+                Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                    return Err(e);
+                }
+            }
+            iter = peer.next_async().await;
+        }
+
+        for peer_id in dead_peers {
+            self.peer_disconnected(&peer_id);
+        }
+
+        Ok(())
+    }
+
+    /// Collect all current subscriptions as ZMTP subscribe messages,
+    /// ready to be sent to a newly connected peer.
+    fn subscription_messages(&self) -> Vec<ZmqMessage> {
+        self.subs
+            .lock()
+            .iter()
+            .map(|subscription| {
+                Self::create_subs_message(subscription, SubscriptionMessageType::Subscribe)
+            })
+            .collect()
+    }
+
+    /// Reliably send a message to every connected peer using async send.
+    async fn broadcast_control_message(&self, message: ZmqMessage) -> ZmqResult<()> {
+        let mut iter = self.peers.begin_async().await;
+        while let Some(mut peer) = iter {
+            peer.send_queue
+                .as_mut()
+                .send(Message::Message(message.clone()))
+                .await?;
+            iter = peer.next_async().await;
+        }
+        Ok(())
+    }
+}
+
+impl SocketBackend for SubSocketBackend {
+    fn socket_type(&self) -> SocketType {
+        self.socket_type
+    }
+
+    fn socket_options(&self) -> &SocketOptions {
+        &self.socket_options
+    }
+
+    fn shutdown(&self) {
+        self.peers.clear_sync();
+        // Clear fair_queue streams to ensure TCP connections are closed
+        // even when reconnect tasks still hold Arc references to the backend
+        if let Some(inner) = &self.fair_queue_inner {
+            inner.lock().clear();
+        }
+    }
+
+    fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
+        &self.socket_monitor
+    }
+}
+
+#[async_trait]
+impl MultiPeerBackend for SubSocketBackend {
+    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+        let (recv_queue, mut send_queue) = io.into_parts();
+
+        for message in self.subscription_messages() {
+            if let Err(e) = send_queue.send(Message::Message(message)).await {
+                log::error!("Failed to send subscription to peer {:?}: {:?}", peer_id, e);
+                return;
+            }
+        }
+
+        self.peers
+            .upsert_async(
+                peer_id.clone(),
+                SubPeer {
+                    send_queue: Box::pin(send_queue),
+                },
+            )
+            .await;
+
+        if let Some(inner) = &self.fair_queue_inner {
+            inner.lock().insert(peer_id.clone(), recv_queue);
+        }
+    }
+
+    fn peer_disconnected(&self, peer_id: &PeerIdentity) {
+        if let Some(monitor) = self.monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
+        }
+
+        self.peers.remove_sync(peer_id);
+        if let Some(inner) = &self.fair_queue_inner {
+            inner.lock().remove(peer_id);
+        }
+
+        // Notify reconnection task if registered
+        if let Some(mut notifier) = self.disconnect_notifiers.lock().remove(peer_id) {
+            // Use try_send to avoid blocking - if channel is full, the reconnect task
+            // will eventually notice the peer is gone
+            let _ = notifier.try_send(peer_id.clone());
+        }
+    }
+}
+
+/// Connects to the given endpoint with automatic reconnection support.
+///
+/// Performs the initial connection, then spawns a background task that will
+/// automatically reconnect if the connection is lost. On reconnection,
+/// subscriptions are automatically re-sent to the peer.
+pub(crate) async fn connect_with_reconnect(
+    backend: Arc<SubSocketBackend>,
+    reconnect_handles: &mut Vec<ReconnectHandle>,
+    endpoint: &str,
+) -> ZmqResult<()> {
+    let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+
+    // Initial connection
+    let (socket, resolved_endpoint) = crate::util::connect_forever(endpoint.clone()).await?;
+    let peer_id =
+        crate::util::peer_connected(socket, backend.clone() as Arc<dyn MultiPeerBackend>).await?;
+
+    // Emit Connected event
+    if let Some(monitor) = backend.monitor().lock().as_mut() {
+        let _ = monitor.try_send(SocketEvent::Connected(resolved_endpoint, peer_id.clone()));
+    }
+
+    // Create a closure that registers disconnect notifiers with the backend
+    let backend_for_closure = backend.clone();
+    let register_fn: crate::reconnect::RegisterDisconnectFn = Box::new(move |peer_id, notifier| {
+        backend_for_closure.register_disconnect_notifier(peer_id, notifier);
+    });
+
+    // Spawn reconnection task
+    let reconnect_handle = crate::reconnect::spawn_reconnect_task(
+        endpoint,
+        backend as Arc<dyn MultiPeerBackend>,
+        peer_id,
+        register_fn,
+        ReconnectConfig::default(),
+    );
+    reconnect_handles.push(reconnect_handle);
+
+    Ok(())
+}
+
+/// Type alias for the bind map shared by SUB and XSUB sockets.
+pub(crate) type SocketBinds = HashMap<Endpoint, AcceptStopHandle>;

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -38,7 +38,6 @@ impl XPubSocketBackend {
         let data = match message {
             Message::Message(m) => {
                 if m.len() != 1 {
-                    log::warn!("Received message with unexpected length: {}", m.len());
                     return;
                 }
                 m.into_vec().pop().unwrap_or_default()
@@ -66,10 +65,7 @@ impl XPubSocketBackend {
                     }
                 }
             }
-            _ => log::warn!(
-                "Received message with unexpected first byte: {:?}",
-                data.first()
-            ),
+            _ => {}
         }
     }
 }

--- a/src/xsub.rs
+++ b/src/xsub.rs
@@ -2,15 +2,14 @@ use crate::codec::{Message, ZmqFramedRead};
 use crate::endpoint::Endpoint;
 use crate::error::{ZmqError, ZmqResult};
 use crate::fair_queue::FairQueue;
-use crate::message::ZmqMessage;
-use crate::reconnect::ReconnectHandle;
 use crate::sub_backend::{
     connect_with_reconnect, SocketBinds, SubSocketBackend, SubscriptionMessageType,
 };
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
-    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketType,
+    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketSend,
+    SocketType,
 };
 
 use async_trait::async_trait;
@@ -20,15 +19,15 @@ use futures::StreamExt;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-pub struct SubSocket {
+pub struct XSubSocket {
     backend: Arc<SubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
     binds: SocketBinds,
     /// Handles to background reconnection tasks
-    reconnect_handles: Vec<ReconnectHandle>,
+    reconnect_handles: Vec<crate::reconnect::ReconnectHandle>,
 }
 
-impl Drop for SubSocket {
+impl Drop for XSubSocket {
     fn drop(&mut self) {
         // Shutdown all reconnection tasks
         for handle in self.reconnect_handles.drain(..) {
@@ -38,7 +37,7 @@ impl Drop for SubSocket {
     }
 }
 
-impl SubSocket {
+impl XSubSocket {
     pub async fn subscribe(&mut self, subscription: &str) -> ZmqResult<()> {
         self.backend.remember_subscription(subscription.as_bytes());
         self.backend
@@ -58,12 +57,12 @@ impl SubSocket {
 }
 
 #[async_trait]
-impl Socket for SubSocket {
+impl Socket for XSubSocket {
     fn with_options(options: SocketOptions) -> Self {
         let mut fair_queue = FairQueue::new(true);
         let backend = Arc::new(SubSocketBackend::with_options(
             Some(fair_queue.inner()),
-            SocketType::SUB,
+            SocketType::XSUB,
             options,
         ));
 
@@ -110,20 +109,16 @@ impl Socket for SubSocket {
 }
 
 #[async_trait]
-impl SocketRecv for SubSocket {
-    async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
+impl SocketRecv for XSubSocket {
+    async fn recv(&mut self) -> ZmqResult<crate::ZmqMessage> {
         loop {
             match self.fair_queue.next().await {
-                Some((_peer_id, Ok(Message::Message(message)))) => {
-                    return Ok(message);
-                }
+                Some((_peer_id, Ok(Message::Message(message)))) => return Ok(message),
                 Some((_peer_id, Ok(_msg))) => {
-                    // Ignore non-message frames. SUB sockets are designed to only receive actual messages,
-                    // not internal protocol frames like commands or greetings.
+                    // Ignore non-message frames (commands, greetings, etc.)
                 }
                 Some((peer_id, Err(e))) => {
                     self.backend.peer_disconnected(&peer_id);
-                    // Handle potential errors from the fair queue
                     return Err(e.into());
                 }
                 None => {
@@ -133,5 +128,50 @@ impl SocketRecv for SubSocket {
                 }
             }
         }
+    }
+}
+
+#[async_trait]
+impl SocketSend for XSubSocket {
+    async fn send(&mut self, message: crate::ZmqMessage) -> ZmqResult<()> {
+        // If the message is a subscription frame (0x01/0x00 prefix), update
+        // local state and send it reliably to all upstream peers.
+        // Otherwise, treat it as a normal application message and fanout.
+        if self.backend.apply_subscription_message(&message) {
+            self.backend.broadcast_message_reliably(message).await
+        } else {
+            self.backend.fanout_message(message).await
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_rt;
+    use crate::util::tests::{
+        test_bind_to_any_port_helper, test_bind_to_unspecified_interface_helper,
+    };
+    use crate::ZmqResult;
+    use std::net::IpAddr;
+
+    #[async_rt::test]
+    async fn test_bind_to_any_port() -> ZmqResult<()> {
+        let s = XSubSocket::new();
+        test_bind_to_any_port_helper(s).await
+    }
+
+    #[async_rt::test]
+    async fn test_bind_to_any_ipv4_interface() -> ZmqResult<()> {
+        let any_ipv4: IpAddr = "0.0.0.0".parse().unwrap();
+        let s = XSubSocket::new();
+        test_bind_to_unspecified_interface_helper(any_ipv4, s, 4040).await
+    }
+
+    #[async_rt::test]
+    async fn test_bind_to_any_ipv6_interface() -> ZmqResult<()> {
+        let any_ipv6: IpAddr = "::".parse().unwrap();
+        let s = XSubSocket::new();
+        test_bind_to_unspecified_interface_helper(any_ipv6, s, 4050).await
     }
 }

--- a/tests/xsub_compliant.rs
+++ b/tests/xsub_compliant.rs
@@ -1,0 +1,90 @@
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::XSubSocket;
+
+use std::time::Duration;
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[async_rt::test]
+    async fn test_their_pub_our_xsub() {
+        pretty_env_logger::try_init().ok();
+
+        let ctx = zmq2::Context::new();
+        let their_pub = ctx.socket(zmq2::PUB).expect("Couldn't make pub socket");
+        their_pub.bind("tcp://127.0.0.1:0").expect("Failed to bind");
+        let endpoint = their_pub.get_last_endpoint().unwrap().unwrap();
+
+        let mut our_xsub = XSubSocket::new();
+        our_xsub
+            .connect(&endpoint)
+            .await
+            .expect("Failed to connect");
+        our_xsub
+            .subscribe("topic")
+            .await
+            .expect("Failed to subscribe");
+
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        their_pub
+            .send("other-message", 0)
+            .expect("Failed to send filtered message");
+        their_pub
+            .send("topic-message", 0)
+            .expect("Failed to send matching message");
+
+        let msg = async_rt::task::timeout(Duration::from_secs(2), our_xsub.recv())
+            .await
+            .expect("Timeout waiting for message")
+            .expect("Failed to receive message");
+        assert_eq!(msg.get(0).unwrap().as_ref(), b"topic-message");
+    }
+
+    #[async_rt::test]
+    async fn test_our_xsub_their_xpub() {
+        pretty_env_logger::try_init().ok();
+
+        let ctx = zmq2::Context::new();
+        let their_xpub = ctx.socket(zmq2::XPUB).expect("Couldn't make xpub socket");
+        their_xpub
+            .set_xpub_verbose(true)
+            .expect("Failed to enable xpub verbose");
+        their_xpub
+            .bind("tcp://127.0.0.1:0")
+            .expect("Failed to bind");
+        let endpoint = their_xpub.get_last_endpoint().unwrap().unwrap();
+
+        let mut our_xsub = XSubSocket::new();
+        our_xsub
+            .connect(&endpoint)
+            .await
+            .expect("Failed to connect");
+        our_xsub.subscribe("").await.expect("Failed to subscribe");
+
+        let sub_msg = their_xpub
+            .recv_bytes(0)
+            .expect("Failed to receive subscribe");
+        assert_eq!(sub_msg.as_slice(), b"\x01");
+
+        our_xsub
+            .send("hello-xpub".into())
+            .await
+            .expect("Failed to send to xpub");
+        let app_msg = their_xpub
+            .recv_bytes(0)
+            .expect("Failed to receive app message");
+        assert_eq!(app_msg.as_slice(), b"hello-xpub");
+
+        their_xpub
+            .send("hello-xsub", 0)
+            .expect("Failed to send to xsub");
+        let reply = async_rt::task::timeout(Duration::from_secs(2), our_xsub.recv())
+            .await
+            .expect("Timeout waiting for xpub reply")
+            .expect("Failed to receive xpub reply");
+        assert_eq!(reply.get(0).unwrap().as_ref(), b"hello-xsub");
+    }
+}

--- a/tests/xsub_xpub.rs
+++ b/tests/xsub_xpub.rs
@@ -1,0 +1,372 @@
+#[cfg(test)]
+mod test {
+    use bytes::Bytes;
+    use futures::{select, FutureExt};
+    use zeromq::__async_rt as async_rt;
+    use zeromq::prelude::*;
+    use zeromq::{proxy, XPubSocket, XSubSocket, ZmqMessage};
+
+    use std::convert::TryFrom;
+    use std::time::Duration;
+
+    fn extract_port(endpoint: &str) -> u16 {
+        endpoint
+            .rsplit(':')
+            .next()
+            .unwrap()
+            .parse()
+            .expect("Failed to parse port")
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_basic_pubsub_and_topic_filter() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = XPubSocket::new();
+        let bound_to = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let bound_addr = bound_to.to_string();
+        let xsub_handle = async_rt::task::spawn(async move {
+            let mut xsub_socket = XSubSocket::new();
+            xsub_socket
+                .connect(&bound_addr)
+                .await
+                .expect("Failed to connect");
+            xsub_socket
+                .subscribe("topic1")
+                .await
+                .expect("Failed to subscribe");
+
+            async_rt::task::sleep(Duration::from_millis(200)).await;
+
+            let msg = xsub_socket.recv().await.expect("Failed to receive");
+            String::from_utf8(msg.get(0).unwrap().to_vec()).unwrap()
+        });
+
+        let sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for subscription")
+            .expect("Failed to receive subscription");
+        let data = sub_msg.get(0).unwrap();
+        assert_eq!(data[0], 1);
+        assert_eq!(&data[1..], b"topic1");
+
+        async_rt::task::sleep(Duration::from_millis(100)).await;
+
+        xpub_socket
+            .send(ZmqMessage::from("topic2-message"))
+            .await
+            .expect("Failed to send");
+        xpub_socket
+            .send(ZmqMessage::from("topic1-message"))
+            .await
+            .expect("Failed to send");
+
+        let received = xsub_handle.await.expect("XSUB task failed");
+        assert_eq!(received, "topic1-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_receives_unsubscribe() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = XPubSocket::new();
+        let bound_to = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let bound_addr = bound_to.to_string();
+        let handle = async_rt::task::spawn(async move {
+            let mut xsub_socket = XSubSocket::new();
+            xsub_socket
+                .connect(&bound_addr)
+                .await
+                .expect("Failed to connect");
+            xsub_socket
+                .subscribe("test")
+                .await
+                .expect("Failed to subscribe");
+            async_rt::task::sleep(Duration::from_millis(100)).await;
+            xsub_socket
+                .unsubscribe("test")
+                .await
+                .expect("Failed to unsubscribe");
+        });
+
+        let sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for subscribe")
+            .expect("Failed to receive subscribe");
+        assert_eq!(sub_msg.get(0).unwrap().as_ref(), b"\x01test");
+
+        let unsub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for unsubscribe")
+            .expect("Failed to receive unsubscribe");
+        assert_eq!(unsub_msg.get(0).unwrap().as_ref(), b"\x00test");
+
+        handle.await.expect("Task failed");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_sends_arbitrary_messages_to_xpub() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut xsub_socket = XSubSocket::new();
+        xsub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect");
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        xsub_socket
+            .send(ZmqMessage::from("plain-message"))
+            .await
+            .expect("Failed to send plain message");
+        let plain = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for plain message")
+            .expect("Failed to receive plain message");
+        assert_eq!(plain.get(0).unwrap().as_ref(), b"plain-message");
+
+        let multipart = ZmqMessage::try_from(vec![
+            Bytes::from_static(b"frame-1"),
+            Bytes::from_static(b"frame-2"),
+        ])
+        .expect("Failed to build multipart message");
+        xsub_socket
+            .send(multipart.clone())
+            .await
+            .expect("Failed to send multipart message");
+        let received = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for multipart message")
+            .expect("Failed to receive multipart message");
+        assert_eq!(received.len(), 2);
+        assert_eq!(received.get(0).unwrap().as_ref(), b"frame-1");
+        assert_eq!(received.get(1).unwrap().as_ref(), b"frame-2");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_fanout_to_multiple_xpub_peers() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_a = XPubSocket::new();
+        let mut xpub_b = XPubSocket::new();
+        let endpoint_a = xpub_a.bind("tcp://127.0.0.1:0").await.expect("bind a");
+        let endpoint_b = xpub_b.bind("tcp://127.0.0.1:0").await.expect("bind b");
+
+        let mut xsub = XSubSocket::new();
+        xsub.connect(&endpoint_a.to_string())
+            .await
+            .expect("connect a");
+        xsub.connect(&endpoint_b.to_string())
+            .await
+            .expect("connect b");
+
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+        xsub.subscribe("fanout").await.expect("subscribe failed");
+
+        let sub_a = async_rt::task::timeout(Duration::from_secs(2), xpub_a.recv())
+            .await
+            .expect("Timeout waiting for subscription on a")
+            .expect("Failed to receive subscription on a");
+        let sub_b = async_rt::task::timeout(Duration::from_secs(2), xpub_b.recv())
+            .await
+            .expect("Timeout waiting for subscription on b")
+            .expect("Failed to receive subscription on b");
+        assert_eq!(sub_a.get(0).unwrap().as_ref(), b"\x01fanout");
+        assert_eq!(sub_b.get(0).unwrap().as_ref(), b"\x01fanout");
+
+        xsub.send(ZmqMessage::from("fanout-message"))
+            .await
+            .expect("Failed to fanout message");
+
+        let msg_a = async_rt::task::timeout(Duration::from_secs(2), xpub_a.recv())
+            .await
+            .expect("Timeout waiting for message on a")
+            .expect("Failed to receive message on a");
+        let msg_b = async_rt::task::timeout(Duration::from_secs(2), xpub_b.recv())
+            .await
+            .expect("Timeout waiting for message on b")
+            .expect("Failed to receive message on b");
+        assert_eq!(msg_a.get(0).unwrap().as_ref(), b"fanout-message");
+        assert_eq!(msg_b.get(0).unwrap().as_ref(), b"fanout-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_reconnects_to_restarted_pub() {
+        pretty_env_logger::try_init().ok();
+
+        let ctx = zmq2::Context::new();
+        let their_pub = ctx.socket(zmq2::PUB).expect("Couldn't make pub socket");
+        their_pub.bind("tcp://127.0.0.1:0").expect("Failed to bind");
+        let bind_endpoint = their_pub.get_last_endpoint().unwrap().unwrap();
+        let port = extract_port(&bind_endpoint);
+
+        let mut our_xsub = XSubSocket::new();
+        our_xsub
+            .connect(&bind_endpoint)
+            .await
+            .expect("Failed to connect");
+        our_xsub.subscribe("").await.expect("Failed to subscribe");
+        async_rt::task::sleep(Duration::from_millis(200)).await;
+
+        their_pub
+            .send("initial-message", 0)
+            .expect("Failed to send initial");
+        let initial = async_rt::task::timeout(Duration::from_secs(2), our_xsub.recv())
+            .await
+            .expect("Timeout waiting for initial message")
+            .expect("Failed to receive initial message");
+        assert_eq!(initial.get(0).unwrap().as_ref(), b"initial-message");
+
+        drop(their_pub);
+        async_rt::task::sleep(Duration::from_millis(300)).await;
+
+        let their_pub_new = ctx.socket(zmq2::PUB).expect("Couldn't make new pub socket");
+        their_pub_new
+            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .expect("Failed to rebind");
+
+        let _ = async_rt::task::timeout(Duration::from_millis(500), our_xsub.recv()).await;
+        async_rt::task::sleep(Duration::from_millis(500)).await;
+
+        their_pub_new
+            .send("reconnected-message", 0)
+            .expect("Failed to send reconnected message");
+        let reconnected = async_rt::task::timeout(Duration::from_secs(3), our_xsub.recv())
+            .await
+            .expect("Timeout waiting for reconnected message")
+            .expect("Failed to receive reconnected message");
+        assert_eq!(reconnected.get(0).unwrap().as_ref(), b"reconnected-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_resubscribes_to_restarted_xpub() {
+        pretty_env_logger::try_init().ok();
+
+        let ctx = zmq2::Context::new();
+        let their_xpub = ctx.socket(zmq2::XPUB).expect("Couldn't make xpub socket");
+        their_xpub
+            .set_xpub_verbose(true)
+            .expect("Failed to enable XPUB verbose");
+        their_xpub
+            .bind("tcp://127.0.0.1:0")
+            .expect("Failed to bind");
+        let bind_endpoint = their_xpub.get_last_endpoint().unwrap().unwrap();
+        let port = extract_port(&bind_endpoint);
+
+        let mut our_xsub = XSubSocket::new();
+        our_xsub
+            .connect(&bind_endpoint)
+            .await
+            .expect("Failed to connect");
+        our_xsub
+            .subscribe("topic")
+            .await
+            .expect("Failed to subscribe");
+
+        let first_sub = their_xpub.recv_bytes(0).expect("Failed to recv first sub");
+        assert_eq!(first_sub.as_slice(), b"\x01topic");
+
+        drop(their_xpub);
+        async_rt::task::sleep(Duration::from_millis(300)).await;
+
+        let their_xpub_new = ctx
+            .socket(zmq2::XPUB)
+            .expect("Couldn't make new xpub socket");
+        their_xpub_new
+            .set_xpub_verbose(true)
+            .expect("Failed to enable XPUB verbose");
+        their_xpub_new
+            .set_rcvtimeo(3000)
+            .expect("Failed to set recv timeout");
+        their_xpub_new
+            .bind(&format!("tcp://127.0.0.1:{}", port))
+            .expect("Failed to rebind");
+
+        let _ = async_rt::task::timeout(Duration::from_millis(500), our_xsub.recv()).await;
+
+        let resent_sub = their_xpub_new
+            .recv_bytes(0)
+            .expect("Failed to recv resent subscription");
+        assert_eq!(resent_sub.as_slice(), b"\x01topic");
+
+        their_xpub_new
+            .send("topic-message", 0)
+            .expect("Failed to send topic message");
+        let msg = async_rt::task::timeout(Duration::from_secs(3), our_xsub.recv())
+            .await
+            .expect("Timeout waiting for topic message")
+            .expect("Failed to receive topic message");
+        assert_eq!(msg.get(0).unwrap().as_ref(), b"topic-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xsub_xpub_proxy_end_to_end() {
+        pretty_env_logger::try_init().ok();
+
+        let mut frontend = XSubSocket::new();
+        let mut backend = XPubSocket::new();
+        let frontend_endpoint = frontend.bind("tcp://127.0.0.1:0").await.expect("bind xsub");
+        let backend_endpoint = backend.bind("tcp://127.0.0.1:0").await.expect("bind xpub");
+
+        let proxy_fut = proxy(frontend, backend, None).fuse();
+        let test_fut = async move {
+            async_rt::task::sleep(Duration::from_millis(100)).await;
+
+            let mut downstream_sub = zeromq::SubSocket::new();
+            downstream_sub
+                .connect(&backend_endpoint.to_string())
+                .await
+                .expect("Failed to connect downstream sub");
+            downstream_sub
+                .subscribe("topic")
+                .await
+                .expect("Failed to subscribe downstream");
+
+            async_rt::task::sleep(Duration::from_millis(100)).await;
+
+            let mut upstream_xpub = XPubSocket::new();
+            upstream_xpub
+                .connect(&frontend_endpoint.to_string())
+                .await
+                .expect("Failed to connect upstream xpub");
+
+            let upstream_sub =
+                async_rt::task::timeout(Duration::from_secs(3), upstream_xpub.recv())
+                    .await
+                    .expect("Timeout waiting for upstream subscription")
+                    .expect("Failed to receive upstream subscription");
+            assert_eq!(upstream_sub.get(0).unwrap().as_ref(), b"\x01topic");
+
+            upstream_xpub
+                .send("topic-through-proxy".into())
+                .await
+                .expect("Failed to send through proxy");
+            let msg = async_rt::task::timeout(Duration::from_secs(3), downstream_sub.recv())
+                .await
+                .expect("Timeout waiting for proxy message")
+                .expect("Failed to receive proxy message");
+            assert_eq!(msg.get(0).unwrap().as_ref(), b"topic-through-proxy");
+        }
+        .fuse();
+
+        futures::pin_mut!(proxy_fut, test_fut);
+        select! {
+            proxy_result = proxy_fut => panic!("proxy exited early: {:?}", proxy_result),
+            _ = test_fut => {}
+        }
+    }
+}


### PR DESCRIPTION
This adds a public `XSubSocket` implementation to match the existing `SocketType::XSUB` support.

The implementation supports bind/connect, recv/send, subscribe/unsubscribe, and reconnect with subscription replay. As part of this, the shared subscription and reconnect logic used by `SUB` and `XSUB` is moved into a common backend while keeping `SubSocket` behavior unchanged. Subscription state is stored as raw bytes so non-UTF8 subscriptions are preserved correctly across unsubscribe and reconnect replay.

The change also adds coverage for basic `XSUB <-> XPUB` behavior, arbitrary `XSUB -> XPUB` sends, fanout, reconnect, proxying, and minimal cross-implementation tests against `libzmq`.

This should address https://github.com/zeromq/zmq.rs/issues/40.