### PR TITLE
Bump MSRV to 1.85 and add checks to CI

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -65,6 +65,60 @@ jobs:
           command: test
           args: --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros
 
+  msrv:
+    name: MSRV Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install libzmq
+        run: sudo apt update && sudo apt install libzmq3-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        run: echo "version=$(grep '^rust-version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')" >> "$GITHUB_OUTPUT"
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - name: Generate lockfile with stable
+        run: cargo +stable generate-lockfile
+      - name: Check default features with MSRV
+        run: cargo +${{ steps.msrv.outputs.version }} check --all
+      - name: Check async-std features with MSRV
+        run: cargo +${{ steps.msrv.outputs.version }} check --all --no-default-features --features async-std-runtime,all-transport
+
+  nightly:
+    name: Nightly Check
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Install libzmq
+        run: sudo apt update && sudo apt install libzmq3-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - name: Check default features with nightly
+        run: cargo +nightly check --all
+      - name: Check async-std features with nightly
+        run: cargo +nightly check --all --no-default-features --features async-std-runtime,all-transport
+
   fmt:
     name: Formatting
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 description = "A native Rust implementation of ZeroMQ"
 license = "MIT"
 repository = "https://github.com/zeromq/zmq.rs"
-rust-version = "1.62.0"
+rust-version = "1.85.0"
 
 [features]
 default = ["tokio-runtime", "all-transport"]


### PR DESCRIPTION
This should remediate #238. I add checks of MSRV to CI for future commits and update`Cargo.toml` to fix the advertisement. With this, we can also extend the check to build zmq.rs against nightly.