### PR TITLE
fix: bound initial connects with timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file.
 - Auto-reconnection for SUB sockets when PUB peer restarts (#230)
 - Socket monitoring via `monitor()` for connection/disconnection events
 - libzmq conformance tests for ROUTER/DEALER and PUB/SUB (#229)
+- Configurable connect timeout via `SocketOptions`, defaulting to 30 seconds
 
 ### Fixed
 - Subscription resync after reconnection (#231)
+- Retry IPC connects while the socket file does not exist yet
 - Replace panics with proper error returns in test utilities (#228)
 
 ## [0.5.0] - 2026-02-09

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use crate::ZmqMessage;
 use futures::channel::mpsc;
 use thiserror::Error;
 
+use std::time::Duration;
+
 pub type ZmqResult<T> = Result<T, ZmqError>;
 
 #[derive(Error, Debug)]
@@ -47,6 +49,8 @@ pub enum ZmqError {
     PeerIdentity,
     #[error("Unsupported ZMTP version")]
     UnsupportedVersion(ZmtpVersion),
+    #[error("Connect timed out after {0:?}")]
+    ConnectTimeout(Duration),
 }
 
 impl From<mpsc::TrySendError<Message>> for ZmqError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,12 +326,13 @@ pub trait Socket: Sized + Send {
         let endpoint = TryIntoEndpoint::try_into(endpoint)?;
         let connect_timeout = backend.socket_options().connect_timeout;
 
-        let (endpoint, peer_id) = util::run_with_timeout(connect_timeout, async {
-            let (socket, endpoint) = util::connect_forever(endpoint).await?;
-            let peer_id = util::peer_connected(socket, backend.clone()).await?;
-            Ok((endpoint, peer_id))
+        let (socket, endpoint, peer_id) = util::run_with_timeout(connect_timeout, async {
+            let (mut socket, endpoint) = util::connect_forever(endpoint).await?;
+            let peer_id = util::peer_handshake(&mut socket, backend.clone()).await?;
+            Ok((socket, endpoint, peer_id))
         })
         .await?;
+        backend.peer_connected(&peer_id, socket).await;
 
         if let Some(monitor) = self.backend().monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Connected(endpoint, peer_id));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ use std::convert::TryFrom;
 use std::fmt::{Debug, Display};
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 
 const COMPATIBILITY_MATRIX: [u8; 121] = [
     // PAIR, PUB, SUB, REQ, REP, DEALER, ROUTER, PULL, PUSH, XPUB, XSUB
@@ -175,14 +176,35 @@ pub enum SocketEvent {
     Disconnected(PeerIdentity),
 }
 
-#[derive(Default)]
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub struct SocketOptions {
     pub(crate) peer_id: Option<PeerIdentity>,
+    pub(crate) connect_timeout: Option<Duration>,
+}
+
+impl Default for SocketOptions {
+    fn default() -> Self {
+        Self {
+            peer_id: None,
+            connect_timeout: Some(DEFAULT_CONNECT_TIMEOUT),
+        }
+    }
 }
 
 impl SocketOptions {
     pub fn peer_identity(&mut self, peer_id: PeerIdentity) -> &mut Self {
         self.peer_id = Some(peer_id);
+        self
+    }
+
+    pub fn connect_timeout(&mut self, timeout: Duration) -> &mut Self {
+        self.connect_timeout = Some(timeout);
+        self
+    }
+
+    pub fn no_connect_timeout(&mut self) -> &mut Self {
+        self.connect_timeout = None;
         self
     }
 }
@@ -302,9 +324,14 @@ pub trait Socket: Sized + Send {
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()> {
         let backend = self.backend();
         let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let connect_timeout = backend.socket_options().connect_timeout;
 
-        let (socket, endpoint) = util::connect_forever(endpoint).await?;
-        let peer_id = util::peer_connected(socket, backend).await?;
+        let (endpoint, peer_id) = util::run_with_timeout(connect_timeout, async {
+            let (socket, endpoint) = util::connect_forever(endpoint).await?;
+            let peer_id = util::peer_connected(socket, backend.clone()).await?;
+            Ok((endpoint, peer_id))
+        })
+        .await?;
 
         if let Some(monitor) = self.backend().monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Connected(endpoint, peer_id));

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -328,14 +328,19 @@ pub(crate) async fn connect_with_reconnect(
     let connect_timeout = backend.socket_options().connect_timeout;
 
     // Initial connection
-    let (resolved_endpoint, peer_id) = crate::util::run_with_timeout(connect_timeout, async {
-        let (socket, resolved_endpoint) = crate::util::connect_forever(endpoint.clone()).await?;
-        let peer_id =
-            crate::util::peer_connected(socket, backend.clone() as Arc<dyn MultiPeerBackend>)
-                .await?;
-        Ok((resolved_endpoint, peer_id))
-    })
-    .await?;
+    let (socket, resolved_endpoint, peer_id) =
+        crate::util::run_with_timeout(connect_timeout, async {
+            let (mut socket, resolved_endpoint) =
+                crate::util::connect_forever(endpoint.clone()).await?;
+            let peer_id = crate::util::peer_handshake(
+                &mut socket,
+                backend.clone() as Arc<dyn MultiPeerBackend>,
+            )
+            .await?;
+            Ok((socket, resolved_endpoint, peer_id))
+        })
+        .await?;
+    backend.clone().peer_connected(&peer_id, socket).await;
 
     // Emit Connected event
     if let Some(monitor) = backend.monitor().lock().as_mut() {

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -325,11 +325,17 @@ pub(crate) async fn connect_with_reconnect(
     endpoint: &str,
 ) -> ZmqResult<()> {
     let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+    let connect_timeout = backend.socket_options().connect_timeout;
 
     // Initial connection
-    let (socket, resolved_endpoint) = crate::util::connect_forever(endpoint.clone()).await?;
-    let peer_id =
-        crate::util::peer_connected(socket, backend.clone() as Arc<dyn MultiPeerBackend>).await?;
+    let (resolved_endpoint, peer_id) = crate::util::run_with_timeout(connect_timeout, async {
+        let (socket, resolved_endpoint) = crate::util::connect_forever(endpoint.clone()).await?;
+        let peer_id =
+            crate::util::peer_connected(socket, backend.clone() as Arc<dyn MultiPeerBackend>)
+                .await?;
+        Ok((resolved_endpoint, peer_id))
+    })
+    .await?;
 
     // Emit Connected event
     if let Some(monitor) = backend.monitor().lock().as_mut() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -369,4 +369,25 @@ pub(crate) mod tests {
             _ => panic!("Unexpected result"),
         }
     }
+
+    #[test]
+    fn retryable_connect_errors_include_refused_and_missing_ipc_socket() {
+        let tcp = Endpoint::Tcp(Host::Ipv4("127.0.0.1".parse().unwrap()), 5555);
+        let ipc = Endpoint::Ipc(Some("missing.sock".into()));
+        let missing_tcp = ZmqError::Network(std::io::Error::from(ErrorKind::NotFound));
+
+        assert!(is_retryable_connect_error(
+            &tcp,
+            &ZmqError::Network(std::io::Error::from(ErrorKind::ConnectionRefused))
+        ));
+        assert!(is_retryable_connect_error(
+            &ipc,
+            &ZmqError::Network(std::io::Error::from(ErrorKind::ConnectionRefused))
+        ));
+        assert!(is_retryable_connect_error(
+            &ipc,
+            &ZmqError::Network(std::io::Error::from(ErrorKind::NotFound))
+        ));
+        assert!(!is_retryable_connect_error(&tcp, &missing_tcp));
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -192,16 +192,23 @@ pub(crate) async fn peer_connected(
     mut raw_socket: FramedIo,
     backend: Arc<dyn MultiPeerBackend>,
 ) -> ZmqResult<PeerIdentity> {
-    greet_exchange(&mut raw_socket).await?;
+    let peer_id = peer_handshake(&mut raw_socket, backend.clone()).await?;
+    backend.peer_connected(&peer_id, raw_socket).await;
+    Ok(peer_id)
+}
+
+pub(crate) async fn peer_handshake(
+    raw_socket: &mut FramedIo,
+    backend: Arc<dyn MultiPeerBackend>,
+) -> ZmqResult<PeerIdentity> {
+    greet_exchange(raw_socket).await?;
     let mut props = None;
     if let Some(identity) = &backend.socket_options().peer_id {
         let mut connect_ops = HashMap::new();
         connect_ops.insert("Identity".to_string(), identity.clone().into());
         props = Some(connect_ops);
     }
-    let peer_id = ready_exchange(&mut raw_socket, backend.socket_type(), props).await?;
-    backend.peer_connected(&peer_id, raw_socket).await;
-    Ok(peer_id)
+    ready_exchange(raw_socket, backend.socket_type(), props).await
 }
 
 pub(crate) async fn run_with_timeout<T, F>(duration: Option<Duration>, future: F) -> ZmqResult<T>

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,9 +7,12 @@ use futures::{SinkExt, StreamExt};
 use rand::Rng;
 
 use std::convert::{TryFrom, TryInto};
+use std::future::Future;
+use std::io::ErrorKind;
 use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
@@ -201,12 +204,37 @@ pub(crate) async fn peer_connected(
     Ok(peer_id)
 }
 
+pub(crate) async fn run_with_timeout<T, F>(duration: Option<Duration>, future: F) -> ZmqResult<T>
+where
+    F: Future<Output = ZmqResult<T>>,
+{
+    match duration {
+        Some(duration) => match async_rt::task::timeout(duration, future).await {
+            Ok(result) => result,
+            Err(_) => Err(ZmqError::ConnectTimeout(duration)),
+        },
+        None => future.await,
+    }
+}
+
+fn is_retryable_connect_error(endpoint: &Endpoint, error: &ZmqError) -> bool {
+    match error {
+        ZmqError::Network(error) if error.kind() == ErrorKind::ConnectionRefused => true,
+        ZmqError::Network(error)
+            if endpoint.transport() == Transport::Ipc && error.kind() == ErrorKind::NotFound =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
 pub(crate) async fn connect_forever(endpoint: Endpoint) -> ZmqResult<(FramedIo, Endpoint)> {
     let mut try_num: u64 = 0;
     loop {
         match transport::connect(&endpoint).await {
             Ok(res) => return Ok(res),
-            Err(ZmqError::Network(e)) if e.kind() == std::io::ErrorKind::ConnectionRefused => {
+            Err(e) if is_retryable_connect_error(&endpoint, &e) => {
                 if try_num < 5 {
                     try_num += 1;
                 }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -2,21 +2,21 @@ use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::{SocketOptions, ZmqError, ZmqMessage};
 
+use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-fn unique_ipc_endpoint(name: &str) -> String {
+fn unique_ipc_endpoint(name: &str) -> (String, PathBuf) {
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .expect("system time before unix epoch")
         .as_nanos();
-    let path =
-        std::path::Path::new("/tmp").join(format!("z-{name}-{}-{nanos}.sock", std::process::id()));
-    format!("ipc://{}", path.display())
+    let path = Path::new("/tmp").join(format!("z-{name}-{}-{nanos}.sock", std::process::id()));
+    (format!("ipc://{}", path.display()), path)
 }
 
 #[async_rt::test]
 async fn ipc_connect_before_bind_retries_until_bind() {
-    let endpoint = unique_ipc_endpoint("connect-before-bind");
+    let (endpoint, path) = unique_ipc_endpoint("connect-before-bind");
     let subscriber_endpoint = endpoint.clone();
     let payload = b"connect-before-bind".to_vec();
 
@@ -59,11 +59,12 @@ async fn ipc_connect_before_bind_retries_until_bind() {
 
     let errs = pub_socket.close().await;
     assert!(errs.is_empty(), "Could not unbind socket: {:?}", errs);
+    let _ = std::fs::remove_file(path);
 }
 
 #[async_rt::test]
 async fn connect_timeout_expires_for_missing_ipc_socket() {
-    let endpoint = unique_ipc_endpoint("missing");
+    let (endpoint, _path) = unique_ipc_endpoint("missing");
     let mut options = SocketOptions::default();
     options.connect_timeout(Duration::from_millis(50));
 
@@ -74,4 +75,51 @@ async fn connect_timeout_expires_for_missing_ipc_socket() {
         .expect_err("connect should time out");
 
     assert!(matches!(err, ZmqError::ConnectTimeout(_)), "{err:?}");
+}
+
+#[async_rt::test]
+async fn connect_timeout_bounds_tcp_connection_refused_retry() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+
+    let mut options = SocketOptions::default();
+    options.connect_timeout(Duration::from_millis(50));
+
+    let mut socket = zeromq::DealerSocket::with_options(options);
+    let err = socket
+        .connect(&format!("tcp://127.0.0.1:{port}"))
+        .await
+        .expect_err("connect should time out");
+
+    assert!(matches!(err, ZmqError::ConnectTimeout(_)), "{err:?}");
+}
+
+#[async_rt::test]
+async fn no_connect_timeout_allows_delayed_ipc_bind() {
+    let (endpoint, path) = unique_ipc_endpoint("no-timeout");
+    let dealer_endpoint = endpoint.clone();
+
+    let (connected_tx, connected_rx) = futures::channel::oneshot::channel();
+    async_rt::task::spawn(async move {
+        let mut options = SocketOptions::default();
+        options.no_connect_timeout();
+        let mut dealer = zeromq::DealerSocket::with_options(options);
+        dealer.connect(&dealer_endpoint).await.unwrap();
+        let _ = connected_tx.send(());
+    });
+
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let mut router = zeromq::RouterSocket::new();
+    router.bind(&endpoint).await.unwrap();
+
+    async_rt::task::timeout(Duration::from_secs(5), connected_rx)
+        .await
+        .expect("timeout waiting for delayed IPC connect")
+        .expect("connect task dropped");
+
+    let errs = router.close().await;
+    assert!(errs.is_empty(), "Could not unbind socket: {:?}", errs);
+    let _ = std::fs::remove_file(path);
 }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -78,24 +78,6 @@ async fn connect_timeout_expires_for_missing_ipc_socket() {
 }
 
 #[async_rt::test]
-async fn connect_timeout_bounds_tcp_connection_refused_retry() {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let port = listener.local_addr().unwrap().port();
-    drop(listener);
-
-    let mut options = SocketOptions::default();
-    options.connect_timeout(Duration::from_millis(50));
-
-    let mut socket = zeromq::DealerSocket::with_options(options);
-    let err = socket
-        .connect(&format!("tcp://127.0.0.1:{port}"))
-        .await
-        .expect_err("connect should time out");
-
-    assert!(matches!(err, ZmqError::ConnectTimeout(_)), "{err:?}");
-}
-
-#[async_rt::test]
 async fn no_connect_timeout_allows_delayed_ipc_bind() {
     let (endpoint, path) = unique_ipc_endpoint("no-timeout");
     let dealer_endpoint = endpoint.clone();

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -1,0 +1,77 @@
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{SocketOptions, ZmqError, ZmqMessage};
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+fn unique_ipc_endpoint(name: &str) -> String {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let path =
+        std::path::Path::new("/tmp").join(format!("z-{name}-{}-{nanos}.sock", std::process::id()));
+    format!("ipc://{}", path.display())
+}
+
+#[async_rt::test]
+async fn ipc_connect_before_bind_retries_until_bind() {
+    let endpoint = unique_ipc_endpoint("connect-before-bind");
+    let subscriber_endpoint = endpoint.clone();
+    let payload = b"connect-before-bind".to_vec();
+
+    let (connected_tx, connected_rx) = futures::channel::oneshot::channel();
+    let (received_tx, received_rx) = futures::channel::oneshot::channel();
+    async_rt::task::spawn(async move {
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket.subscribe("").await.unwrap();
+        sub_socket.connect(&subscriber_endpoint).await.unwrap();
+        let _ = connected_tx.send(());
+
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for message")
+            .unwrap();
+        let _ = received_tx.send(message.get(0).unwrap().to_vec());
+    });
+
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let mut pub_socket = zeromq::PubSocket::new();
+    pub_socket.bind(&endpoint).await.unwrap();
+
+    async_rt::task::timeout(Duration::from_secs(5), connected_rx)
+        .await
+        .expect("timeout waiting for connect")
+        .expect("connect task dropped");
+
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+    pub_socket
+        .send(ZmqMessage::from(payload.clone()))
+        .await
+        .unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), received_rx)
+        .await
+        .expect("timeout waiting for received payload")
+        .expect("receiver task dropped");
+    assert_eq!(received, payload);
+
+    let errs = pub_socket.close().await;
+    assert!(errs.is_empty(), "Could not unbind socket: {:?}", errs);
+}
+
+#[async_rt::test]
+async fn connect_timeout_expires_for_missing_ipc_socket() {
+    let endpoint = unique_ipc_endpoint("missing");
+    let mut options = SocketOptions::default();
+    options.connect_timeout(Duration::from_millis(50));
+
+    let mut socket = zeromq::DealerSocket::with_options(options);
+    let err = socket
+        .connect(&endpoint)
+        .await
+        .expect_err("connect should time out");
+
+    assert!(matches!(err, ZmqError::ConnectTimeout(_)), "{err:?}");
+}


### PR DESCRIPTION
## Summary
- retry IPC connects while the socket file does not exist yet
- add SocketOptions connect timeout with a 30s default and opt-out
- keep backend peer registration outside the timeout window