### PR TITLE
fix: await pub fanout writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Subscription resync after reconnection (#231)
 - Retry IPC connects while the socket file does not exist yet
+- Deliver large PUB/XPUB/XSUB messages that require multiple transport writes
 - Replace panics with proper error returns in test utilities (#228)
 
 ## [0.5.0] - 2026-02-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 - libzmq conformance tests for ROUTER/DEALER and PUB/SUB (#229)
 - Configurable connect timeout via `SocketOptions`, defaulting to 30 seconds
 
+### Changed
+- PUB/XPUB/XSUB fan-out now awaits transport progress instead of dropping when a message needs multiple writes
+
 ### Fixed
 - Subscription resync after reconnection (#231)
 - Retry IPC connects while the socket file does not exist yet

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -15,12 +15,6 @@ pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub(crate) use zmq_codec::ZmqCodec;
 
 use crate::message::ZmqMessage;
-use crate::{ZmqError, ZmqResult};
-use futures::task::noop_waker;
-use futures::Sink;
-
-use std::pin::Pin;
-use std::task::{Context, Poll};
 
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone)]
@@ -28,24 +22,4 @@ pub enum Message {
     Greeting(ZmqGreeting),
     Command(ZmqCommand),
     Message(ZmqMessage),
-}
-
-pub(crate) trait TrySend {
-    fn try_send(self: Pin<&mut Self>, item: Message) -> ZmqResult<()>;
-}
-
-impl TrySend for ZmqFramedWrite {
-    fn try_send(mut self: Pin<&mut Self>, item: Message) -> ZmqResult<()> {
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-        match self.as_mut().poll_ready(&mut cx) {
-            Poll::Ready(Ok(())) => {
-                self.as_mut().start_send(item)?;
-                let _ = self.as_mut().poll_flush(&mut cx); // ignore result just hope that it flush eventually
-                Ok(())
-            }
-            Poll::Ready(Err(e)) => Err(e.into()),
-            Poll::Pending => Err(ZmqError::BufferFull("Sink is full")),
-        }
-    }
 }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -5,13 +5,11 @@ use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{async_rt, CaptureSocket, SocketOptions};
-use crate::{
-    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, SocketType, ZmqError,
-};
+use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, SocketType};
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
-use futures::{select, FutureExt, StreamExt};
+use futures::{select, FutureExt, SinkExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
@@ -172,25 +170,20 @@ impl SocketSend for PubSocket {
                     let res = subscriber
                         .send_queue
                         .as_mut()
-                        .try_send(Message::Message(message.clone()));
+                        .send(Message::Message(message.clone()))
+                        .await;
                     match res {
                         Ok(()) => {}
-                        Err(ZmqError::Codec(CodecError::Io(e))) => {
+                        Err(CodecError::Io(e)) => {
                             if e.kind() == ErrorKind::BrokenPipe {
                                 dead_peers.push(subscriber.key().clone());
                             } else {
-                                log::error!("Error receiving message: {:?}", e);
+                                log::error!("Error sending message: {:?}", e);
                             }
                         }
-                        Err(ZmqError::BufferFull(_)) => {
-                            // ignore silently. https://rfc.zeromq.org/spec/29/ says:
-                            // For processing outgoing messages:
-                            //   SHALL silently drop the message if the queue for a subscriber is full.
-                            log::debug!("Queue for subscriber is full",);
-                        }
                         Err(e) => {
-                            log::error!("Error receiving message: {:?}", e);
-                            return Err(e);
+                            log::error!("Error sending message: {:?}", e);
+                            return Err(e.into());
                         }
                     }
                     break;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -9,6 +9,7 @@ use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, So
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
+use futures::lock::Mutex as AsyncMutex;
 use futures::{select, FutureExt, SinkExt, StreamExt};
 use parking_lot::Mutex;
 
@@ -19,7 +20,7 @@ use std::sync::Arc;
 
 pub(crate) struct Subscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Pin<Box<ZmqFramedWrite>>,
+    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
@@ -99,7 +100,7 @@ impl MultiPeerBackend for PubSocketBackend {
                 peer_id.clone(),
                 Subscriber {
                     subscriptions: vec![],
-                    send_queue: Box::pin(send_queue),
+                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
                     _subscription_coro_stop: sender,
                 },
             )
@@ -160,36 +161,40 @@ impl SocketSend for PubSocket {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut dead_peers = Vec::new();
+        let mut targets = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(mut subscriber) = iter {
-            for sub_filter in &subscriber.subscriptions {
-                if sub_filter.len() <= first_frame.len()
+        while let Some(subscriber) = iter {
+            if subscriber.subscriptions.iter().any(|sub_filter| {
+                sub_filter.len() <= first_frame.len()
                     && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-                {
-                    let res = subscriber
-                        .send_queue
-                        .as_mut()
-                        .send(Message::Message(message.clone()))
-                        .await;
-                    match res {
-                        Ok(()) => {}
-                        Err(CodecError::Io(e)) => {
-                            if e.kind() == ErrorKind::BrokenPipe {
-                                dead_peers.push(subscriber.key().clone());
-                            } else {
-                                log::error!("Error sending message: {:?}", e);
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("Error sending message: {:?}", e);
-                            return Err(e.into());
-                        }
-                    }
-                    break;
-                }
+            }) {
+                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
             }
             iter = subscriber.next_async().await;
+        }
+
+        let mut dead_peers = Vec::new();
+        for (peer_id, send_queue) in targets {
+            let res = send_queue
+                .lock()
+                .await
+                .as_mut()
+                .send(Message::Message(message.clone()))
+                .await;
+            match res {
+                Ok(()) => {}
+                Err(CodecError::Io(e)) => {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        dead_peers.push(peer_id);
+                    } else {
+                        log::error!("Error sending message: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                    return Err(e.into());
+                }
+            }
         }
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -14,6 +14,7 @@ use crate::{
 use async_trait::async_trait;
 use bytes::{BufMut, BytesMut};
 use futures::channel::mpsc;
+use futures::lock::Mutex as AsyncMutex;
 use futures::SinkExt;
 use parking_lot::Mutex;
 
@@ -32,7 +33,7 @@ pub(crate) enum SubscriptionMessageType {
 /// A connected peer for SUB/XSUB sockets, holding only the send half
 /// of the framed I/O since receiving is handled through the fair queue.
 pub(crate) struct SubPeer {
-    pub(crate) send_queue: Pin<Box<ZmqFramedWrite>>,
+    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
 }
 
 /// Shared backend for [`SubSocket`](crate::SubSocket) and [`XSubSocket`](crate::XSubSocket).
@@ -155,11 +156,18 @@ impl SubSocketBackend {
             return Ok(());
         }
 
-        let mut dead_peers = Vec::new();
+        let mut targets = Vec::new();
         let mut iter = self.peers.begin_async().await;
-        while let Some(mut peer) = iter {
-            let res = peer
-                .send_queue
+        while let Some(peer) = iter {
+            targets.push((peer.key().clone(), peer.send_queue.clone()));
+            iter = peer.next_async().await;
+        }
+
+        let mut dead_peers = Vec::new();
+        for (peer_id, send_queue) in targets {
+            let res = send_queue
+                .lock()
+                .await
                 .as_mut()
                 .send(Message::Message(message.clone()))
                 .await;
@@ -167,7 +175,7 @@ impl SubSocketBackend {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {
                     if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer.key().clone());
+                        dead_peers.push(peer_id);
                     } else {
                         log::error!("Error sending message: {:?}", e);
                     }
@@ -177,7 +185,6 @@ impl SubSocketBackend {
                     return Err(e.into());
                 }
             }
-            iter = peer.next_async().await;
         }
 
         for peer_id in dead_peers {
@@ -201,13 +208,19 @@ impl SubSocketBackend {
 
     /// Reliably send a message to every connected peer using async send.
     async fn broadcast_control_message(&self, message: ZmqMessage) -> ZmqResult<()> {
+        let mut targets = Vec::new();
+        let mut iter = self.peers.begin_async().await;
+        while let Some(peer) = iter {
+            targets.push((peer.key().clone(), peer.send_queue.clone()));
+            iter = peer.next_async().await;
+        }
+
         let mut dead_peers = Vec::new();
         let mut first_error = None;
-        let mut iter = self.peers.begin_async().await;
-        while let Some(mut peer) = iter {
-            let peer_id = peer.key().clone();
-            let result = peer
-                .send_queue
+        for (peer_id, send_queue) in targets {
+            let result = send_queue
+                .lock()
+                .await
                 .as_mut()
                 .send(Message::Message(message.clone()))
                 .await;
@@ -231,7 +244,6 @@ impl SubSocketBackend {
                     first_error.get_or_insert(e.into());
                 }
             }
-            iter = peer.next_async().await;
         }
 
         for peer_id in dead_peers {
@@ -281,7 +293,7 @@ impl MultiPeerBackend for SubSocketBackend {
             .upsert_async(
                 peer_id.clone(),
                 SubPeer {
-                    send_queue: Box::pin(send_queue),
+                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
                 },
             )
             .await;

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -1,7 +1,7 @@
 use crate::backend::DisconnectNotifier;
-use crate::codec::{CodecError, FramedIo, Message, TrySend, ZmqFramedRead, ZmqFramedWrite};
+use crate::codec::{CodecError, FramedIo, Message, ZmqFramedRead, ZmqFramedWrite};
 use crate::endpoint::Endpoint;
-use crate::error::{ZmqError, ZmqResult};
+use crate::error::ZmqResult;
 use crate::fair_queue::QueueInner;
 use crate::message::ZmqMessage;
 use crate::reconnect::{ReconnectConfig, ReconnectHandle};
@@ -146,12 +146,10 @@ impl SubSocketBackend {
         self.broadcast_control_message(message).await
     }
 
-    /// Send an application message to all connected peers using non-blocking
-    /// [`try_send`](crate::codec::TrySend::try_send).
+    /// Send an application message to all connected peers.
     ///
-    /// Messages are silently dropped when a peer's buffer is full, matching
-    /// ZMQ's publish semantics. Peers with broken pipes are collected and
-    /// disconnected after the iteration completes.
+    /// Peers with broken pipes are collected and disconnected after the
+    /// iteration completes.
     pub(crate) async fn fanout_message(&self, message: ZmqMessage) -> ZmqResult<()> {
         if message.is_empty() {
             return Ok(());
@@ -163,22 +161,20 @@ impl SubSocketBackend {
             let res = peer
                 .send_queue
                 .as_mut()
-                .try_send(Message::Message(message.clone()));
+                .send(Message::Message(message.clone()))
+                .await;
             match res {
                 Ok(()) => {}
-                Err(ZmqError::Codec(CodecError::Io(e))) => {
+                Err(CodecError::Io(e)) => {
                     if e.kind() == ErrorKind::BrokenPipe {
                         dead_peers.push(peer.key().clone());
                     } else {
                         log::error!("Error sending message: {:?}", e);
                     }
                 }
-                Err(ZmqError::BufferFull(_)) => {
-                    log::debug!("Queue for subscriber is full");
-                }
                 Err(e) => {
                     log::error!("Error sending message: {:?}", e);
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
             iter = peer.next_async().await;

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
@@ -144,24 +144,20 @@ impl SocketSend for XPubSocket {
                     let res = subscriber
                         .send_queue
                         .as_mut()
-                        .try_send(Message::Message(message.clone()));
+                        .send(Message::Message(message.clone()))
+                        .await;
                     match res {
                         Ok(()) => {}
-                        Err(ZmqError::Codec(CodecError::Io(e))) => {
+                        Err(CodecError::Io(e)) => {
                             if e.kind() == ErrorKind::BrokenPipe {
                                 dead_peers.push(subscriber.key().clone());
                             } else {
                                 log::error!("Error sending message: {:?}", e);
                             }
                         }
-                        Err(ZmqError::BufferFull(_)) => {
-                            // Silently drop the message if the queue for a subscriber is full.
-                            // https://rfc.zeromq.org/spec/29/
-                            log::debug!("Queue for subscriber is full");
-                        }
                         Err(e) => {
                             log::error!("Error sending message: {:?}", e);
-                            return Err(e);
+                            return Err(e.into());
                         }
                     }
                     break;

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -13,6 +13,7 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
+use futures::lock::Mutex as AsyncMutex;
 use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 
@@ -23,7 +24,7 @@ use std::sync::Arc;
 
 pub(crate) struct XPubSubscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Pin<Box<ZmqFramedWrite>>,
+    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
 }
 
 pub(crate) struct XPubSocketBackend {
@@ -98,7 +99,7 @@ impl MultiPeerBackend for XPubSocketBackend {
                 peer_id.clone(),
                 XPubSubscriber {
                     subscriptions: vec![],
-                    send_queue: Box::pin(send_queue),
+                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
                 },
             )
             .await;
@@ -134,36 +135,40 @@ impl SocketSend for XPubSocket {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut dead_peers = Vec::new();
+        let mut targets = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(mut subscriber) = iter {
-            for sub_filter in &subscriber.subscriptions {
-                if sub_filter.len() <= first_frame.len()
+        while let Some(subscriber) = iter {
+            if subscriber.subscriptions.iter().any(|sub_filter| {
+                sub_filter.len() <= first_frame.len()
                     && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-                {
-                    let res = subscriber
-                        .send_queue
-                        .as_mut()
-                        .send(Message::Message(message.clone()))
-                        .await;
-                    match res {
-                        Ok(()) => {}
-                        Err(CodecError::Io(e)) => {
-                            if e.kind() == ErrorKind::BrokenPipe {
-                                dead_peers.push(subscriber.key().clone());
-                            } else {
-                                log::error!("Error sending message: {:?}", e);
-                            }
-                        }
-                        Err(e) => {
-                            log::error!("Error sending message: {:?}", e);
-                            return Err(e.into());
-                        }
-                    }
-                    break;
-                }
+            }) {
+                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
             }
             iter = subscriber.next_async().await;
+        }
+
+        let mut dead_peers = Vec::new();
+        for (peer_id, send_queue) in targets {
+            let res = send_queue
+                .lock()
+                .await
+                .as_mut()
+                .send(Message::Message(message.clone()))
+                .await;
+            match res {
+                Ok(()) => {}
+                Err(CodecError::Io(e)) => {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        dead_peers.push(peer_id);
+                    } else {
+                        log::error!("Error sending message: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                    return Err(e.into());
+                }
+            }
         }
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);

--- a/tests/large_message.rs
+++ b/tests/large_message.rs
@@ -62,3 +62,26 @@ async fn xpub_sub_delivers_large_message() {
         .unwrap();
     assert_eq!(received.get(0).unwrap().as_ref(), payload.as_slice());
 }
+
+#[async_rt::test]
+async fn xsub_xpub_delivers_large_message() {
+    let payload = vec![0xEF; 300_000];
+
+    let mut xpub_socket = zeromq::XPubSocket::new();
+    let endpoint = tcp_endpoint(xpub_socket.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut xsub_socket = zeromq::XSubSocket::new();
+    xsub_socket.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    xsub_socket
+        .send(ZmqMessage::from(payload.clone()))
+        .await
+        .unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+        .await
+        .expect("timeout waiting for large XSUB message")
+        .unwrap();
+    assert_eq!(received.get(0).unwrap().as_ref(), payload.as_slice());
+}

--- a/tests/large_message.rs
+++ b/tests/large_message.rs
@@ -1,0 +1,64 @@
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{Endpoint, ZmqMessage};
+
+use std::time::Duration;
+
+fn tcp_endpoint(endpoint: Endpoint) -> String {
+    match endpoint {
+        Endpoint::Tcp(_, port) => format!("tcp://127.0.0.1:{port}"),
+        _ => unreachable!("expected tcp endpoint"),
+    }
+}
+
+#[async_rt::test]
+async fn pub_sub_delivers_large_message() {
+    let payload = vec![0xAB; 300_000];
+
+    let mut sub_socket = zeromq::SubSocket::new();
+    let endpoint = tcp_endpoint(sub_socket.bind("tcp://127.0.0.1:0").await.unwrap());
+    sub_socket.subscribe("").await.unwrap();
+
+    let mut pub_socket = zeromq::PubSocket::new();
+    pub_socket.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    pub_socket
+        .send(ZmqMessage::from(payload.clone()))
+        .await
+        .unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+        .await
+        .expect("timeout waiting for large PUB message")
+        .unwrap();
+    assert_eq!(received.get(0).unwrap().as_ref(), payload.as_slice());
+}
+
+#[async_rt::test]
+async fn xpub_sub_delivers_large_message() {
+    let payload = vec![0xCD; 300_000];
+
+    let mut xpub_socket = zeromq::XPubSocket::new();
+    let endpoint = tcp_endpoint(xpub_socket.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut sub_socket = zeromq::SubSocket::new();
+    sub_socket.connect(&endpoint).await.unwrap();
+    sub_socket.subscribe("").await.unwrap();
+
+    let _subscription = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+        .await
+        .expect("timeout waiting for subscription")
+        .unwrap();
+
+    xpub_socket
+        .send(ZmqMessage::from(payload.clone()))
+        .await
+        .unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+        .await
+        .expect("timeout waiting for large XPUB message")
+        .unwrap();
+    assert_eq!(received.get(0).unwrap().as_ref(), payload.as_slice());
+}


### PR DESCRIPTION
## Summary
- replace the framed-writer try_send/noop-waker path with awaited sends for PUB, XPUB, and XSUB fanout
- keep scc map guards out of transport awaits by cloning per-peer send handles first
- add large-message coverage for PUB/SUB, XPUB/SUB, and XSUB/XPUB