### PR TITLE
feat: enable IPC transport on Windows

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -65,6 +65,24 @@ jobs:
           command: test
           args: --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros
 
+  windows-ipc:
+    name: Windows IPC (${{ matrix.toolchain }})
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        toolchain: [stable, "1.85.0"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - name: Check Windows IPC
+        run: cargo check --lib --no-default-features --features tokio-runtime,ipc-transport,tcp-transport
+      - name: Test Windows IPC
+        run: cargo test --no-default-features --features tokio-runtime,ipc-transport,tcp-transport
+
   msrv:
     name: MSRV Check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Subscription resync after reconnection (#231)
 - Retry IPC connects while the socket file does not exist yet
 - Deliver large PUB/XPUB/XSUB messages that require multiple transport writes
+- Enable IPC transport on Windows
 - Replace panics with proper error returns in test utilities (#228)
 
 ## [0.5.0] - 2026-02-09

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ async-std-runtime = ["async-std"]
 async-dispatcher-runtime = ["async-std", "async-dispatcher"]
 async-dispatcher-macros = ["async-dispatcher/macros"]
 all-transport = ["ipc-transport", "tcp-transport"]
-ipc-transport = []
+ipc-transport = ["dep:win_uds"]
 tcp-transport = []
 
 [dependencies]
@@ -44,6 +44,9 @@ once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
 async-std = { version = "1", features = ["attributes"], optional = true }
+
+[target.'cfg(windows)'.dependencies]
+win_uds = { version = "=0.2.2", features = ["async"], optional = true }
 
 [dev-dependencies]
 async-dispatcher = { version = "0.1", features = ["macros"] }

--- a/src/transport/ipc.rs
+++ b/src/transport/ipc.rs
@@ -1,9 +1,16 @@
-#[cfg(feature = "tokio-runtime")]
+#[cfg(all(feature = "tokio-runtime", target_family = "unix"))]
 use tokio::net::{UnixListener, UnixStream};
 
-#[cfg(any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"))]
+#[cfg(all(
+    any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"),
+    target_family = "unix"
+))]
 use async_std::os::unix::net::{UnixListener, UnixStream};
 
+#[cfg(windows)]
+use win_uds::net::{AsyncListener as UnixListener, AsyncStream as UnixStream};
+
+#[cfg(target_family = "unix")]
 use super::make_framed;
 use super::AcceptStopHandle;
 use crate::async_rt;
@@ -17,10 +24,50 @@ use futures::{select, FutureExt};
 
 use std::path::Path;
 
+#[cfg(target_family = "unix")]
+fn pathname_from_unix_addr(addr: impl UnixSocketAddrExt) -> Option<std::path::PathBuf> {
+    addr.as_pathname().map(|a| a.to_owned())
+}
+
+#[cfg(target_family = "unix")]
+trait UnixSocketAddrExt {
+    fn as_pathname(&self) -> Option<&Path>;
+}
+
+#[cfg(all(feature = "tokio-runtime", target_family = "unix"))]
+impl UnixSocketAddrExt for tokio::net::unix::SocketAddr {
+    fn as_pathname(&self) -> Option<&Path> {
+        self.as_pathname()
+    }
+}
+
+#[cfg(all(
+    any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"),
+    target_family = "unix"
+))]
+impl UnixSocketAddrExt for async_std::os::unix::net::SocketAddr {
+    fn as_pathname(&self) -> Option<&Path> {
+        self.as_pathname()
+    }
+}
+
+#[cfg(windows)]
+fn make_framed(stream: UnixStream) -> FramedIo {
+    use futures::AsyncReadExt;
+    let (read, write) = stream.split();
+    FramedIo::new(Box::new(read), Box::new(write))
+}
+
 pub(crate) async fn connect(path: &Path) -> ZmqResult<(FramedIo, Endpoint)> {
     let raw_socket = UnixStream::connect(path).await?;
+
+    #[cfg(target_family = "unix")]
     let peer_addr = raw_socket.peer_addr()?;
-    let peer_addr = peer_addr.as_pathname().map(|a| a.to_owned());
+    #[cfg(target_family = "unix")]
+    let peer_addr = pathname_from_unix_addr(peer_addr);
+
+    #[cfg(windows)]
+    let peer_addr = Some(path.to_owned());
 
     Ok((make_framed(raw_socket), Endpoint::Ipc(peer_addr)))
 }
@@ -37,13 +84,24 @@ where
         todo!("Need to implement support for wildcard paths!");
     }
 
-    #[cfg(feature = "tokio-runtime")]
+    #[cfg(all(feature = "tokio-runtime", target_family = "unix"))]
     let listener = UnixListener::bind(path)?;
-    #[cfg(any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"))]
+    #[cfg(all(
+        any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"),
+        target_family = "unix"
+    ))]
     let listener = UnixListener::bind(path).await?;
+    #[cfg(windows)]
+    let listener = UnixListener::bind(path)?;
 
+    #[cfg(target_family = "unix")]
     let resolved_addr = listener.local_addr()?;
-    let resolved_addr = resolved_addr.as_pathname().map(|a| a.to_owned());
+    #[cfg(target_family = "unix")]
+    let resolved_addr = pathname_from_unix_addr(resolved_addr);
+
+    #[cfg(windows)]
+    let resolved_addr = Some(path.to_owned());
+
     let listener_addr = resolved_addr.clone();
     let (stop_channel, stop_callback) = oneshot::channel::<()>();
     let task_handle = async_rt::task::spawn(async move {
@@ -52,7 +110,13 @@ where
             select! {
                 incoming = listener.accept().fuse() => {
                     let maybe_accepted: Result<_, _> = incoming.map(|(raw_socket, peer_addr)| {
-                        let peer_addr = peer_addr.as_pathname().map(|a| a.to_owned());
+                        #[cfg(target_family = "unix")]
+                        let peer_addr = pathname_from_unix_addr(peer_addr);
+                        #[cfg(windows)]
+                        let peer_addr = {
+                            let _ = peer_addr;
+                            None
+                        };
                         (make_framed(raw_socket), Endpoint::Ipc(peer_addr))
                     }).map_err(|err| err.into());
                     async_rt::task::spawn(cback(maybe_accepted));
@@ -65,9 +129,22 @@ where
         }
         drop(listener);
         if let Some(listener_addr) = listener_addr {
-            #[cfg(any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"))]
+            #[cfg(any(
+                all(
+                    any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"),
+                    target_family = "unix"
+                ),
+                all(
+                    any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"),
+                    windows
+                )
+            ))]
             use async_std::fs::remove_file;
-            #[cfg(feature = "tokio-runtime")]
+            #[cfg(all(
+                feature = "tokio-runtime",
+                any(target_family = "unix", windows),
+                not(any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"))
+            ))]
             use tokio::fs::remove_file;
 
             if let Err(err) = remove_file(&listener_addr).await {

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(all(feature = "ipc-transport", target_family = "unix"))]
+#[cfg(all(feature = "ipc-transport", any(target_family = "unix", windows)))]
 mod ipc;
 #[cfg(feature = "tcp-transport")]
 mod tcp;
@@ -30,7 +30,7 @@ pub(crate) async fn connect(endpoint: &Endpoint) -> ZmqResult<(FramedIo, Endpoin
             do_if_enabled!("tcp-transport", tcp::connect(_host, *_port).await)
         }
         Endpoint::Ipc(_path) => {
-            #[cfg(all(feature = "ipc-transport", target_family = "unix"))]
+            #[cfg(all(feature = "ipc-transport", any(target_family = "unix", windows)))]
             {
                 if let Some(path) = _path {
                     ipc::connect(path).await
@@ -40,7 +40,7 @@ pub(crate) async fn connect(endpoint: &Endpoint) -> ZmqResult<(FramedIo, Endpoin
                     ))
                 }
             }
-            #[cfg(not(all(feature = "ipc-transport", target_family = "unix")))]
+            #[cfg(not(all(feature = "ipc-transport", any(target_family = "unix", windows))))]
             panic!("IPC transport is not available on this platform")
         }
     }
@@ -73,7 +73,7 @@ where
             tcp::begin_accept(_host, _port, _cback).await
         ),
         Endpoint::Ipc(_path) => {
-            #[cfg(all(feature = "ipc-transport", target_family = "unix"))]
+            #[cfg(all(feature = "ipc-transport", any(target_family = "unix", windows)))]
             {
                 if let Some(path) = _path {
                     ipc::begin_accept(&path, _cback).await
@@ -83,7 +83,7 @@ where
                     ))
                 }
             }
-            #[cfg(not(all(feature = "ipc-transport", target_family = "unix")))]
+            #[cfg(not(all(feature = "ipc-transport", any(target_family = "unix", windows))))]
             panic!("IPC transport is not available on this platform")
         }
     }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -2,7 +2,7 @@ use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::{SocketOptions, ZmqError, ZmqMessage};
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 fn unique_ipc_endpoint(name: &str) -> (String, PathBuf) {
@@ -10,7 +10,7 @@ fn unique_ipc_endpoint(name: &str) -> (String, PathBuf) {
         .duration_since(UNIX_EPOCH)
         .expect("system time before unix epoch")
         .as_nanos();
-    let path = Path::new("/tmp").join(format!("z-{name}-{}-{nanos}.sock", std::process::id()));
+    let path = std::env::temp_dir().join(format!("z-{name}-{}-{nanos}.sock", std::process::id()));
     (format!("ipc://{}", path.display()), path)
 }
 

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -78,6 +78,30 @@ async fn connect_timeout_expires_for_missing_ipc_socket() {
 }
 
 #[async_rt::test]
+async fn ipc_close_allows_rebinding_same_path() {
+    let (endpoint, path) = unique_ipc_endpoint("rebind");
+
+    let mut first = zeromq::RouterSocket::new();
+    let first_bound = first.bind(&endpoint).await.unwrap();
+    assert_eq!(first_bound.to_string(), endpoint);
+
+    let errs = first.close().await;
+    assert!(errs.is_empty(), "Could not unbind first socket: {:?}", errs);
+
+    let mut second = zeromq::RouterSocket::new();
+    let second_bound = second.bind(&endpoint).await.unwrap();
+    assert_eq!(second_bound.to_string(), endpoint);
+
+    let errs = second.close().await;
+    assert!(
+        errs.is_empty(),
+        "Could not unbind second socket: {:?}",
+        errs
+    );
+    let _ = std::fs::remove_file(path);
+}
+
+#[async_rt::test]
 async fn no_connect_timeout_allows_delayed_ipc_bind() {
     let (endpoint, path) = unique_ipc_endpoint("no-timeout");
     let dealer_endpoint = endpoint.clone();


### PR DESCRIPTION
## Summary
- enable the IPC transport cfg on Windows and wire it through win_uds
- keep Unix Tokio/async-std behavior intact while adding Windows framing/address handling
- add Windows CI coverage for stable and MSRV 1.85.0, running the full Tokio IPC/TCP test suite

## Verification
- cargo fmt --check
- cargo check --lib --target x86_64-pc-windows-msvc --no-default-features --features tokio-runtime,ipc-transport,tcp-transport
- cargo check --lib --target x86_64-pc-windows-msvc --no-default-features --features async-std-runtime,ipc-transport,tcp-transport
- cargo check --lib --target x86_64-pc-windows-msvc --no-default-features --features async-dispatcher-runtime,ipc-transport,tcp-transport
- cargo test --no-default-features --features tokio-runtime,ipc-transport,tcp-transport
- winlab2: cargo test --no-default-features --features tokio-runtime,ipc-transport,tcp-transport
- winlab2: cargo check --lib --no-default-features --features async-std-runtime,ipc-transport,tcp-transport
- winlab2: cargo check --lib --no-default-features --features async-dispatcher-runtime,ipc-transport,tcp-transport

## Review
- Bedrock review pass found broader Windows CI and direct win_uds pinning follow-ups; both are fixed here.
- A second Bedrock pass hung without output and was stopped; no review output was produced by that second invocation.
