### PR TITLE
prepare 0.6.0-pre.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,31 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0-pre.2] - 2026-04-29
+
 ### Added
-- Auto-reconnection for SUB sockets when PUB peer restarts (#230)
-- Socket monitoring via `monitor()` for connection/disconnection events
-- libzmq conformance tests for ROUTER/DEALER and PUB/SUB (#229)
-- Configurable connect timeout via `SocketOptions`, defaulting to 30 seconds
+- XSUB socket support (#236)
+- `Clone` impl for `RouterSendHalf` (#235)
+- IPC transport on Windows (#244)
+- Configurable connect timeout via `SocketOptions`, defaulting to 30 seconds (#241)
+- Monitor `Disconnected` events for DEALER, PULL, REP, ROUTER, and XPUB (#234)
 
 ### Changed
-- PUB/XPUB/XSUB fan-out now awaits transport progress instead of dropping when a message needs multiple writes
+- Bumped MSRV to 1.85 and added MSRV + nightly CI checks (#239)
+- PUB/XPUB/XSUB fan-out now awaits transport progress instead of dropping when a message needs multiple writes (#243)
+
+### Fixed
+- Deliver large PUB/XPUB/XSUB messages that require multiple transport writes (#243)
+- Retry IPC connects while the socket file does not exist yet (#241)
+
+## [0.6.0-pre.1] - 2026-03-04
+
+### Added
+- Auto-reconnection for SUB sockets when PUB peer restarts (#230)
+- libzmq conformance tests for ROUTER/DEALER and PUB/SUB (#229)
 
 ### Fixed
 - Subscription resync after reconnection (#231)
-- Retry IPC connects while the socket file does not exist yet
-- Deliver large PUB/XPUB/XSUB messages that require multiple transport writes
-- Enable IPC transport on Windows
 - Replace panics with proper error returns in test utilities (#228)
 
 ## [0.5.0] - 2026-02-09

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeromq"
-version = "0.6.0-pre.1"
+version = "0.6.0-pre.2"
 authors = [
     "Alexei Kornienko <alexei.kornienko@gmail.com>",
     "Ryan Butler <thebutlah@gmail.com>",


### PR DESCRIPTION
Bumps version to `0.6.0-pre.2` and reconciles `CHANGELOG.md`.

`[Unreleased]` was stale — it still contained entries that shipped in `v0.6.0-pre.1` (the automated changelog rollover didn't run for that tag). Split the section into:

- `[0.6.0-pre.2] - 2026-04-29` — new changes since pre.1 (#234, #235, #236, #239, #241, #243, #244)
- `[0.6.0-pre.1] - 2026-03-04` — retroactive section for #228, #229, #230, #231
- empty `[Unreleased]`

_PR submitted by @rgbkrk's agent Quill, via Zed_