### PR TITLE
Fix fair queue spin when pending streams wake themselves

### DIFF
--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use parking_lot::Mutex;
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::hash::Hash;
 use std::pin::Pin;
 use std::sync::atomic;
@@ -13,6 +13,7 @@ use std::task::{Context, Poll, Waker};
 pub(crate) struct QueueInner<S, K: Clone> {
     counter: atomic::AtomicUsize,
     ready_queue: BinaryHeap<ReadyEvent<K>>,
+    queued: HashSet<K>,
     streams: HashMap<K, Pin<Box<S>>>,
     waker: Option<Waker>,
     /// Callback invoked when a stream ends (peer disconnected).
@@ -23,10 +24,7 @@ pub(crate) struct QueueInner<S, K: Clone> {
 impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     pub fn insert(&mut self, k: K, s: S) {
         self.streams.insert(k.clone(), Box::pin(s));
-        self.ready_queue.push(ReadyEvent {
-            priority: self.counter.fetch_add(1, atomic::Ordering::Relaxed),
-            key: k,
-        });
+        self.push_ready(k);
         if let Some(w) = &self.waker {
             w.wake_by_ref();
         }
@@ -34,6 +32,7 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
 
     pub fn remove(&mut self, k: &K) {
         self.streams.remove(k);
+        self.queued.remove(k);
     }
 
     /// Clear all streams and the ready queue.
@@ -43,9 +42,19 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     pub fn clear(&mut self) {
         self.streams.clear();
         self.ready_queue.clear();
+        self.queued.clear();
         // Wake the waker so any pending poll_next returns
         if let Some(w) = self.waker.take() {
             w.wake();
+        }
+    }
+
+    fn push_ready(&mut self, k: K) {
+        if self.queued.insert(k.clone()) {
+            self.ready_queue.push(ReadyEvent {
+                priority: self.counter.fetch_add(1, atomic::Ordering::Relaxed),
+                key: k,
+            });
         }
     }
 }
@@ -87,11 +96,11 @@ struct StreamWaker<S, K: Clone> {
 impl<S, K> ArcWake for StreamWaker<S, K>
 where
     S: Send,
-    K: Clone + Send + Sync,
+    K: Clone + Eq + Hash + Send + Sync,
 {
     fn wake_by_ref(arc_self: &Arc<Self>) {
         let mut inner = arc_self.inner.lock();
-        inner.ready_queue.push(arc_self.event.clone());
+        inner.push_ready(arc_self.event.key.clone());
         if let Some(waker) = inner.waker.take() {
             waker.wake_by_ref();
         }
@@ -109,7 +118,14 @@ where
     #[allow(clippy::needless_continue)]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let fair_queue = self.get_mut();
-        loop {
+        let mut remaining_ready = {
+            let mut inner = fair_queue.inner.lock();
+            inner.waker = Some(cx.waker().clone());
+            inner.ready_queue.len()
+        };
+
+        while remaining_ready > 0 {
+            remaining_ready -= 1;
             let (event, mut io_stream) = {
                 let mut inner = fair_queue.inner.lock();
                 inner.waker = Some(cx.waker().clone());
@@ -123,6 +139,7 @@ where
                         }
                     }
                 };
+                inner.queued.remove(&event.key);
                 match inner.streams.remove(&event.key) {
                     Some(stream) => (event, stream),
                     None => continue,
@@ -137,14 +154,11 @@ where
             let mut cx = Context::from_waker(&waker_ref);
             match io_stream.as_mut().poll_next(&mut cx) {
                 Poll::Ready(Some(res)) => {
-                    let item = Some((event.key.clone(), res));
+                    let key = event.key.clone();
+                    let item = Some((key.clone(), res));
                     let mut inner = fair_queue.inner.lock();
-                    let priority = inner.counter.fetch_add(1, atomic::Ordering::Relaxed);
-                    inner.ready_queue.push(ReadyEvent {
-                        priority,
-                        key: event.key.clone(),
-                    });
                     inner.streams.insert(event.key, io_stream);
+                    inner.push_ready(key);
                     return Poll::Ready(item);
                 }
                 Poll::Ready(None) => {
@@ -169,6 +183,21 @@ where
                 }
             }
         }
+
+        let mut inner = fair_queue.inner.lock();
+        inner.waker = Some(cx.waker().clone());
+        let should_wake = !inner.ready_queue.is_empty();
+        let result = if !inner.streams.is_empty() || fair_queue.block_on_no_clients {
+            Poll::Pending
+        } else {
+            Poll::Ready(None)
+        };
+        drop(inner);
+
+        if should_wake {
+            cx.waker().wake_by_ref();
+        }
+        result
     }
 }
 
@@ -179,6 +208,7 @@ impl<S, K: Clone> FairQueue<S, K> {
             inner: Arc::new(Mutex::new(QueueInner {
                 counter: atomic::AtomicUsize::new(0),
                 ready_queue: BinaryHeap::new(),
+                queued: HashSet::new(),
                 streams: HashMap::new(),
                 waker: None,
                 on_disconnect: None,
@@ -217,6 +247,14 @@ mod test {
         messages: VecDeque<&'static str>,
     }
 
+    struct CountPendingStream {
+        poll_count: usize,
+    }
+
+    struct WakePendingStream {
+        poll_count: usize,
+    }
+
     impl TestStream {
         fn new(pending_polls: usize, messages: &[&'static str]) -> Self {
             Self {
@@ -231,6 +269,25 @@ mod test {
 
         fn pending_once(messages: &[&'static str]) -> Self {
             Self::new(1, messages)
+        }
+    }
+
+    impl Stream for CountPendingStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.get_mut().poll_count += 1;
+            Poll::Pending
+        }
+    }
+
+    impl Stream for WakePendingStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            self.get_mut().poll_count += 1;
+            cx.waker().wake_by_ref();
+            Poll::Pending
         }
     }
 
@@ -249,6 +306,8 @@ mod test {
 
     enum UnifiedStream {
         Test(TestStream),
+        CountPending(CountPendingStream),
+        WakePending(WakePendingStream),
     }
 
     impl Stream for UnifiedStream {
@@ -257,6 +316,8 @@ mod test {
         fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
             match self.get_mut() {
                 UnifiedStream::Test(stream) => Pin::new(stream).poll_next(cx),
+                UnifiedStream::CountPending(stream) => Pin::new(stream).poll_next(cx),
+                UnifiedStream::WakePending(stream) => Pin::new(stream).poll_next(cx),
             }
         }
     }
@@ -425,6 +486,96 @@ mod test {
             fast_messages >= 1,
             "Fast stream was starved: {:?}",
             messages
+        );
+    }
+
+    #[test]
+    fn test_fair_queue_polls_ready_set_before_yielding_pending() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<UnifiedStream, &str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "pending-1",
+                UnifiedStream::CountPending(CountPendingStream { poll_count: 0 }),
+            );
+            lock.insert(
+                "pending-2",
+                UnifiedStream::CountPending(CountPendingStream { poll_count: 0 }),
+            );
+            lock.insert(
+                "pending-3",
+                UnifiedStream::CountPending(CountPendingStream { poll_count: 0 }),
+            );
+        }
+
+        let result = Pin::new(&mut fair_queue).poll_next(&mut cx);
+        assert!(
+            matches!(result, Poll::Pending),
+            "expected FairQueue to yield Pending, got {result:?}"
+        );
+
+        let inner = fair_queue.inner();
+        let mut lock = inner.lock();
+        let poll_count: usize = lock
+            .streams
+            .values_mut()
+            .map(|stream| {
+                let UnifiedStream::CountPending(stream) = stream.as_mut().get_mut() else {
+                    panic!("unexpected stream type");
+                };
+                stream.poll_count
+            })
+            .sum();
+        assert_eq!(
+            poll_count, 3,
+            "FairQueue should poll all initially ready streams before yielding Pending"
+        );
+    }
+
+    #[test]
+    fn test_fair_queue_defers_ready_events_generated_during_poll() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<UnifiedStream, &str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "pending",
+                UnifiedStream::WakePending(WakePendingStream { poll_count: 0 }),
+            );
+        }
+
+        let result = Pin::new(&mut fair_queue).poll_next(&mut cx);
+        assert!(
+            matches!(result, Poll::Pending),
+            "expected FairQueue to yield Pending, got {result:?}"
+        );
+
+        let inner = fair_queue.inner();
+        let mut lock = inner.lock();
+        assert_eq!(
+            lock.ready_queue.len(),
+            1,
+            "wake generated during poll should remain queued for a later poll"
+        );
+        assert_eq!(
+            lock.queued.len(),
+            1,
+            "wake generated during poll should be tracked as queued"
+        );
+        let stream = lock.streams.get_mut("pending").unwrap();
+        let UnifiedStream::WakePending(stream) = stream.as_mut().get_mut() else {
+            panic!("unexpected stream type");
+        };
+        assert_eq!(
+            stream.poll_count, 1,
+            "FairQueue should not consume same-poll wake events immediately"
         );
     }
 }

--- a/tests/push_pull_timeout.rs
+++ b/tests/push_pull_timeout.rs
@@ -1,0 +1,175 @@
+use bytes::Bytes;
+use zeromq::prelude::*;
+use zeromq::ZmqMessage;
+
+use std::net::TcpListener;
+use std::process::Stdio;
+use std::time::{Duration, Instant};
+
+const REPRO_CHILD_TEST_NAME: &str = "issue_248_repro_child_process";
+const REPRO_ROLE_ENV: &str = "ZMQ_RS_ISSUE_248_ROLE";
+const REPRO_ENDPOINT_ENV: &str = "ZMQ_RS_ISSUE_248_ENDPOINT";
+
+#[cfg(feature = "tokio-runtime")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
+    const TEST_WINDOW: Duration = Duration::from_secs(3);
+    const WATCHDOG: Duration = Duration::from_secs(5);
+
+    let mut push = zeromq::PushSocket::new();
+    let endpoint = push.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut pull = zeromq::PullSocket::new();
+    pull.connect(&endpoint).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(250)).await;
+
+    let sender = tokio::spawn(async move {
+        let payload = Bytes::from(vec![b'x'; 128]);
+        loop {
+            match push.send(ZmqMessage::from(payload.clone())).await {
+                Ok(()) => {}
+                Err(_) => tokio::task::yield_now().await,
+            }
+        }
+    });
+
+    let received = tokio::time::timeout(WATCHDOG, async {
+        let start = Instant::now();
+        let deadline = start + TEST_WINDOW;
+        let mut count = 0;
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break count;
+            }
+            match tokio::time::timeout(remaining, pull.recv()).await {
+                Ok(Ok(_)) => count += 1,
+                Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
+                Err(_) => panic!("per-call timeout fired after {count} messages"),
+            }
+        }
+    })
+    .await;
+
+    sender.abort();
+    let _ = sender.await;
+
+    let count = received.expect("PullSocket::recv stopped making progress when wrapped in timeout");
+    println!("received {count} messages");
+    assert!(
+        count > 10_000,
+        "received too few messages before deadline: {count}"
+    );
+}
+
+#[cfg(feature = "tokio-runtime")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pull_recv_with_per_call_timeout_keeps_making_progress_across_processes() {
+    let endpoint = unused_tcp_endpoint();
+    let test_exe = std::env::current_exe().unwrap();
+    let child_args = ["--exact", REPRO_CHILD_TEST_NAME, "--nocapture"];
+
+    let mut push = tokio::process::Command::new(&test_exe)
+        .args(child_args)
+        .env(REPRO_ROLE_ENV, "push")
+        .env(REPRO_ENDPOINT_ENV, &endpoint)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let mut pull = tokio::process::Command::new(&test_exe)
+        .args(child_args)
+        .env(REPRO_ROLE_ENV, "pull")
+        .env(REPRO_ENDPOINT_ENV, &endpoint)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let pull_status = tokio::time::timeout(Duration::from_secs(6), pull.wait()).await;
+    push.start_kill().unwrap();
+    let _ = push.wait().await;
+
+    let pull_status = pull_status
+        .expect("PullSocket::recv stopped making progress when wrapped in timeout")
+        .unwrap();
+    assert!(
+        pull_status.success(),
+        "pull child exited with {pull_status}"
+    );
+}
+
+#[cfg(feature = "tokio-runtime")]
+#[test]
+fn issue_248_repro_child_process() {
+    let Some(role) = std::env::var(REPRO_ROLE_ENV).ok() else {
+        return;
+    };
+    let endpoint = std::env::var(REPRO_ENDPOINT_ENV).unwrap();
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    runtime.block_on(async move {
+        match role.as_str() {
+            "push" => run_issue_248_push_child(&endpoint).await,
+            "pull" => run_issue_248_pull_child(&endpoint).await,
+            other => panic!("unknown repro role: {other}"),
+        }
+    });
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn run_issue_248_push_child(endpoint: &str) {
+    let mut socket = zeromq::PushSocket::new();
+    socket.bind(endpoint).await.unwrap();
+    let payload = Bytes::from(vec![b'x'; 128]);
+    loop {
+        if socket
+            .send(ZmqMessage::from(payload.clone()))
+            .await
+            .is_err()
+        {
+            tokio::task::yield_now().await;
+        }
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+async fn run_issue_248_pull_child(endpoint: &str) {
+    let mut socket = zeromq::PullSocket::new();
+    socket.connect(endpoint).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    let start = Instant::now();
+    let deadline = start + Duration::from_secs(3);
+    let mut count = 0;
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, socket.recv()).await {
+            Ok(Ok(_)) => count += 1,
+            Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
+            Err(_) => panic!("per-call timeout fired after {count} messages"),
+        }
+    }
+    assert!(
+        count > 10_000,
+        "received too few messages before deadline: {count}"
+    );
+}
+
+fn unused_tcp_endpoint() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    drop(listener);
+    format!("tcp://127.0.0.1:{port}")
+}

--- a/tests/push_pull_timeout.rs
+++ b/tests/push_pull_timeout.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "tokio-runtime")]
+
 use bytes::Bytes;
 use zeromq::prelude::*;
 use zeromq::ZmqMessage;
@@ -10,7 +12,6 @@ const REPRO_CHILD_TEST_NAME: &str = "issue_248_repro_child_process";
 const REPRO_ROLE_ENV: &str = "ZMQ_RS_ISSUE_248_ROLE";
 const REPRO_ENDPOINT_ENV: &str = "ZMQ_RS_ISSUE_248_ENDPOINT";
 
-#[cfg(feature = "tokio-runtime")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
     const TEST_WINDOW: Duration = Duration::from_secs(3);
@@ -45,7 +46,7 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
             match tokio::time::timeout(remaining, pull.recv()).await {
                 Ok(Ok(_)) => count += 1,
                 Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-                Err(_) => panic!("per-call timeout fired after {count} messages"),
+                Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
             }
         }
     })
@@ -62,7 +63,6 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
     );
 }
 
-#[cfg(feature = "tokio-runtime")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pull_recv_with_per_call_timeout_keeps_making_progress_across_processes() {
     let endpoint = unused_tcp_endpoint();
@@ -104,7 +104,6 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress_across_processes(
     );
 }
 
-#[cfg(feature = "tokio-runtime")]
 #[test]
 fn issue_248_repro_child_process() {
     let Some(role) = std::env::var(REPRO_ROLE_ENV).ok() else {
@@ -125,7 +124,6 @@ fn issue_248_repro_child_process() {
     });
 }
 
-#[cfg(feature = "tokio-runtime")]
 async fn run_issue_248_push_child(endpoint: &str) {
     let mut socket = zeromq::PushSocket::new();
     socket.bind(endpoint).await.unwrap();
@@ -141,7 +139,6 @@ async fn run_issue_248_push_child(endpoint: &str) {
     }
 }
 
-#[cfg(feature = "tokio-runtime")]
 async fn run_issue_248_pull_child(endpoint: &str) {
     let mut socket = zeromq::PullSocket::new();
     socket.connect(endpoint).await.unwrap();
@@ -158,7 +155,7 @@ async fn run_issue_248_pull_child(endpoint: &str) {
         match tokio::time::timeout(remaining, socket.recv()).await {
             Ok(Ok(_)) => count += 1,
             Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-            Err(_) => panic!("per-call timeout fired after {count} messages"),
+            Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
         }
     }
     assert!(


### PR DESCRIPTION
## Summary

- Bound each `FairQueue::poll_next` call to the ready events present at poll entry so wake events generated during polling are deferred to the executor's next poll.
- Deduplicate queued ready events by peer key to avoid repeatedly polling the same pending stream in one outer poll.
- Add focused unit coverage for the wake-then-pending path and integration coverage for `PullSocket::recv()` wrapped in `tokio::time::timeout`.

This cherry-picks Alexei Kornienko's fix from `alex/issue-248` with original authorship preserved.

Fixes #248.

## Testing

- `cargo test fair_queue -- --nocapture`
- `cargo test pull_recv_with_per_call_timeout_keeps_making_progress -- --nocapture`
- `cargo clippy --all --all-targets -- --deny warnings`
- `cargo clippy --all --all-targets --no-default-features --features async-std-runtime,all-transport,async-dispatcher-macros -- --deny warnings`
- `git diff --check HEAD^ HEAD`

Note: local full `cargo fmt --check` currently reports an import-order diff in pre-existing `benches/codec.rs` from `origin/master`, outside this patch. GitHub's nightly formatting check passed on the first PR run.
