### PR TITLE
Fan out peer sends concurrently

### DIFF
--- a/docs/OMQ_INTEGRATION.md
+++ b/docs/OMQ_INTEGRATION.md
@@ -1,0 +1,36 @@
+# OMQ.rs Integration Notes
+
+Issue #240 tracks interest in pulling the useful parts of
+`github.com/paddor/omq.rs` into this crate without forcing a wholesale
+rewrite. OMQ is not a fork, so most pieces need to come across as narrow
+architectural changes rather than file-level copies.
+
+## Incorporated
+
+- Fanout sends now collect eligible peers and await their writes
+  concurrently. This follows the performance direction discussed in the issue:
+  a slow subscriber should not make PUB, XPUB, or XSUB application fanout wait
+  on every other peer sequentially.
+- The FairQueue recv primitive has a cancel-safety regression test. A pending
+  recv future can be dropped after polling without consuming the next message.
+
+## Good Next Slices
+
+- Move ZMTP framing toward a sans-I/O core that can be driven by each runtime
+  backend. OMQ keeps protocol state independent from file descriptors, which
+  makes tests and backend experiments much cheaper.
+- Add gather-write encoding for large frames. The current codec still copies
+  each payload into `BytesMut` before the writer sees it; OMQ's writev path
+  avoids that copy for large messages.
+- Add a bounded outbound queue abstraction with explicit block/drop-newest/drop-
+  oldest behavior. OMQ's routing queues make mute behavior local and testable.
+- Keep runtime-backend experiments behind the existing runtime feature boundary.
+  A compio or monoio backend should not change the public socket API.
+- Port feature work as isolated PRs: inproc transport, PLAIN/CURVE/ZAP,
+  additional draft socket types, and broader compatibility tests.
+
+## Code-Use Boundary
+
+OMQ is licensed ISC while this crate is MIT. Prefer implementing ideas from the
+architecture and performance notes with fresh code unless a future change
+explicitly carries the right attribution and license review.

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -236,7 +236,7 @@ mod test {
     use crate::async_rt;
     use crate::fair_queue::FairQueue;
     use futures::task::noop_waker;
-    use futures::{stream, Stream, StreamExt};
+    use futures::{stream, Future, Stream, StreamExt};
     use std::collections::VecDeque;
     use std::pin::Pin;
     use std::task::{Context, Poll};
@@ -253,6 +253,11 @@ mod test {
 
     struct WakePendingStream {
         poll_count: usize,
+    }
+
+    struct WakeThenReadyStream {
+        polled: bool,
+        message: Option<&'static str>,
     }
 
     impl TestStream {
@@ -291,6 +296,20 @@ mod test {
         }
     }
 
+    impl Stream for WakeThenReadyStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            if !this.polled {
+                this.polled = true;
+                cx.waker().wake_by_ref();
+                return Poll::Pending;
+            }
+            Poll::Ready(this.message.take())
+        }
+    }
+
     impl Stream for TestStream {
         type Item = &'static str;
 
@@ -308,6 +327,7 @@ mod test {
         Test(TestStream),
         CountPending(CountPendingStream),
         WakePending(WakePendingStream),
+        WakeThenReady(WakeThenReadyStream),
     }
 
     impl Stream for UnifiedStream {
@@ -318,6 +338,7 @@ mod test {
                 UnifiedStream::Test(stream) => Pin::new(stream).poll_next(cx),
                 UnifiedStream::CountPending(stream) => Pin::new(stream).poll_next(cx),
                 UnifiedStream::WakePending(stream) => Pin::new(stream).poll_next(cx),
+                UnifiedStream::WakeThenReady(stream) => Pin::new(stream).poll_next(cx),
             }
         }
     }
@@ -577,5 +598,34 @@ mod test {
             stream.poll_count, 1,
             "FairQueue should not consume same-poll wake events immediately"
         );
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_recv_is_cancel_safe_after_pending_poll() {
+        let mut fair_queue: FairQueue<UnifiedStream, &str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "peer",
+                UnifiedStream::WakeThenReady(WakeThenReadyStream {
+                    polled: false,
+                    message: Some("m1"),
+                }),
+            );
+        }
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        {
+            let mut pending_recv = Box::pin(fair_queue.next());
+            assert!(
+                matches!(pending_recv.as_mut().poll(&mut cx), Poll::Pending),
+                "first recv poll should park before the message is ready"
+            );
+        }
+
+        let next = fair_queue.next().await;
+        assert_eq!(next, Some(("peer", "m1")));
     }
 }

--- a/src/fanout.rs
+++ b/src/fanout.rs
@@ -1,0 +1,31 @@
+use crate::codec::{CodecError, Message, ZmqFramedWrite};
+use crate::util::PeerIdentity;
+use crate::ZmqMessage;
+
+use futures::future::join_all;
+use futures::lock::Mutex as AsyncMutex;
+use futures::SinkExt;
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+pub(crate) type SharedSendQueue = Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>;
+
+pub(crate) async fn send_message_to_targets(
+    targets: Vec<(PeerIdentity, SharedSendQueue)>,
+    message: ZmqMessage,
+) -> Vec<(PeerIdentity, Result<(), CodecError>)> {
+    join_all(targets.into_iter().map(|(peer_id, send_queue)| {
+        let message = message.clone();
+        async move {
+            let result = send_queue
+                .lock()
+                .await
+                .as_mut()
+                .send(Message::Message(message))
+                .await;
+            (peer_id, result)
+        }
+    }))
+    .await
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod dealer;
 mod endpoint;
 mod error;
 mod fair_queue;
+mod fanout;
 mod message;
 mod r#pub;
 mod pull;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -1,6 +1,7 @@
 use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
+use crate::fanout::{send_message_to_targets, SharedSendQueue};
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
@@ -10,17 +11,16 @@ use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, So
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
 use futures::lock::Mutex as AsyncMutex;
-use futures::{select, FutureExt, SinkExt, StreamExt};
+use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
 pub(crate) struct Subscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) send_queue: SharedSendQueue,
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
@@ -174,13 +174,7 @@ impl SocketSend for PubSocket {
         }
 
         let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+        for (peer_id, res) in send_message_to_targets(targets, message).await {
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -1,8 +1,9 @@
 use crate::backend::DisconnectNotifier;
-use crate::codec::{CodecError, FramedIo, Message, ZmqFramedRead, ZmqFramedWrite};
+use crate::codec::{CodecError, FramedIo, Message, ZmqFramedRead};
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::QueueInner;
+use crate::fanout::{send_message_to_targets, SharedSendQueue};
 use crate::message::ZmqMessage;
 use crate::reconnect::{ReconnectConfig, ReconnectHandle};
 use crate::transport::AcceptStopHandle;
@@ -20,7 +21,6 @@ use parking_lot::Mutex;
 
 use std::collections::{HashMap, HashSet};
 use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
 /// Type of subscription message sent from SUB/XSUB to PUB/XPUB.
@@ -33,7 +33,7 @@ pub(crate) enum SubscriptionMessageType {
 /// A connected peer for SUB/XSUB sockets, holding only the send half
 /// of the framed I/O since receiving is handled through the fair queue.
 pub(crate) struct SubPeer {
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) send_queue: SharedSendQueue,
 }
 
 /// Shared backend for [`SubSocket`](crate::SubSocket) and [`XSubSocket`](crate::XSubSocket).
@@ -164,13 +164,7 @@ impl SubSocketBackend {
         }
 
         let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+        for (peer_id, res) in send_message_to_targets(targets, message).await {
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {
@@ -217,13 +211,7 @@ impl SubSocketBackend {
 
         let mut dead_peers = Vec::new();
         let mut first_error = None;
-        for (peer_id, send_queue) in targets {
-            let result = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+        for (peer_id, result) in send_message_to_targets(targets, message).await {
             match result {
                 Ok(()) => {}
                 Err(e)

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -2,6 +2,7 @@ use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::{FairQueue, QueueInner};
+use crate::fanout::{send_message_to_targets, SharedSendQueue};
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
@@ -14,17 +15,16 @@ use crate::{
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::lock::Mutex as AsyncMutex;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
 use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
 pub(crate) struct XPubSubscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) send_queue: SharedSendQueue,
 }
 
 pub(crate) struct XPubSocketBackend {
@@ -148,13 +148,7 @@ impl SocketSend for XPubSocket {
         }
 
         let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+        for (peer_id, res) in send_message_to_targets(targets, message).await {
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {


### PR DESCRIPTION
## Summary

- add a shared fanout helper that sends to matched peer queues concurrently
- use it for PUB, XPUB, and SUB/XSUB backend fanout/control broadcasts
- document the first OMQ integration slice and likely next chunks
- add a FairQueue cancel-safety regression test for pending recv futures

## Verification

- `cargo test test_fair_queue_recv_is_cancel_safe_after_pending_poll --lib`
- `cargo check --all-targets`
- `cargo test --test pub_sub`
- `cargo test --test xpub_sub`
- `cargo test --test xsub_xpub`

## CI Follow-up

- The first GitHub Formatting run failed on `benches/codec.rs` import order;
  this branch was amended to match the workflow's nightly rustfmt output.
