### PR TITLE
Add performance roadmap benchmark suite

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -65,6 +65,30 @@ jobs:
           command: test
           args: --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros
 
+  perf-smoke:
+    name: Performance Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install libzmq
+        run: sudo apt update && sudo apt install libzmq3-dev
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cache cargo dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/
+          key: cache-cargo-deps-${{ runner.os }}-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - name: Compile benchmark targets
+        run: cargo bench --no-run
+      - name: Check perf suite dry run
+        run: python3 scripts/run_perf_suite.py --profile smoke --impl zmqrs,libzmq --transport tcp --run-id ci-dry-run --dry-run
+      - name: Run perf suite smoke
+        run: python3 scripts/run_perf_suite.py --profile smoke --impl zmqrs,libzmq --transport tcp --run-id ci-smoke
+
   windows-ipc:
     name: Windows IPC (${{ matrix.toolchain }})
     runs-on: windows-latest

--- a/benches/bench_runtime.rs
+++ b/benches/bench_runtime.rs
@@ -1,4 +1,7 @@
 use std::future::Future;
+use std::time::Duration;
+
+use criterion::{measurement::WallTime, BenchmarkGroup};
 
 #[cfg(feature = "tokio-runtime")]
 use tokio::runtime::{Builder, Runtime};
@@ -21,7 +24,10 @@ impl BenchRuntime {
             }
         }
 
-        #[cfg(all(not(feature = "tokio-runtime"), feature = "async-std-runtime"))]
+        #[cfg(all(
+            not(feature = "tokio-runtime"),
+            any(feature = "async-std-runtime", feature = "async-dispatcher-runtime")
+        ))]
         {
             Self {}
         }
@@ -37,7 +43,10 @@ impl BenchRuntime {
             self.inner.block_on(future)
         }
 
-        #[cfg(all(not(feature = "tokio-runtime"), feature = "async-std-runtime"))]
+        #[cfg(all(
+            not(feature = "tokio-runtime"),
+            any(feature = "async-std-runtime", feature = "async-dispatcher-runtime")
+        ))]
         {
             async_std::task::block_on(future)
         }
@@ -48,4 +57,30 @@ impl Default for BenchRuntime {
     fn default() -> Self {
         Self::new()
     }
+}
+
+pub fn configure_group(group: &mut BenchmarkGroup<'_, WallTime>) {
+    group.sample_size(env_usize("ZMQRS_BENCH_SAMPLE_SIZE", 10));
+    group.measurement_time(Duration::from_millis(env_u64(
+        "ZMQRS_BENCH_MEASUREMENT_MS",
+        10_000,
+    )));
+    group.warm_up_time(Duration::from_millis(env_u64(
+        "ZMQRS_BENCH_WARMUP_MS",
+        2_000,
+    )));
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
 }

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -5,8 +5,8 @@ use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use zeromq::{
-    ZmqMessage,
     __bench::{Message, ZmqCodec},
+    ZmqMessage,
 };
 
 const FRAME_SIZES: &[usize] = &[16, 256, 4096, 65536];

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -5,8 +5,8 @@ use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 
 use zeromq::{
-    __bench::{Message, ZmqCodec},
     ZmqMessage,
+    __bench::{Message, ZmqCodec},
 };
 
 const FRAME_SIZES: &[usize] = &[16, 256, 4096, 65536];

--- a/benches/compare_libzmq.rs
+++ b/benches/compare_libzmq.rs
@@ -47,9 +47,7 @@ fn bench_libzmq_pub_sub(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("libzmq/pub_sub/{transport}/subs={n_subs}"));
-            group.sample_size(10);
-            group.measurement_time(Duration::from_secs(10));
-            group.warm_up_time(Duration::from_secs(2));
+            bench_runtime::configure_group(&mut group);
             for &msg_size in MSG_SIZES {
                 group.throughput(Throughput::Bytes((msg_size * n_subs) as u64));
                 group.bench_with_input(
@@ -132,9 +130,7 @@ fn bench_zmqrs_pub_sub(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("zmqrs/pub_sub/{transport}/subs={n_subs}"));
-            group.sample_size(10);
-            group.measurement_time(Duration::from_secs(10));
-            group.warm_up_time(Duration::from_secs(2));
+            bench_runtime::configure_group(&mut group);
             for &msg_size in MSG_SIZES {
                 if n_subs == 64 && msg_size == 65536 {
                     continue;
@@ -197,9 +193,7 @@ fn bench_zmqrs_pub_sub_one(
 fn bench_libzmq_req_rep(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("libzmq/req_rep/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -250,9 +244,7 @@ fn bench_zmqrs_req_rep(c: &mut Criterion) {
     let rt = build_rt();
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("zmqrs/req_rep/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -301,9 +293,7 @@ fn bench_zmqrs_req_rep_one(
 fn bench_libzmq_push_pull(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("libzmq/push_pull/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -337,9 +327,7 @@ fn bench_zmqrs_push_pull(c: &mut Criterion) {
     let rt = build_rt();
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("zmqrs/push_pull/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -383,9 +371,7 @@ fn bench_zmqrs_push_pull_one(
 fn bench_libzmq_dealer_router(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("libzmq/dealer_router/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -437,9 +423,7 @@ fn bench_zmqrs_dealer_router(c: &mut Criterion) {
     let rt = build_rt();
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("zmqrs/dealer_router/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
             group.throughput(Throughput::Bytes(msg_size as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -44,9 +44,7 @@ fn bench_zmqrs_pub_pipelined(c: &mut Criterion) {
             let mut group = c.benchmark_group(format!(
                 "zmqrs/throughput/pub_fanout/{transport}/subs={n_subs}"
             ));
-            group.sample_size(10);
-            group.measurement_time(Duration::from_secs(10));
-            group.warm_up_time(Duration::from_secs(2));
+            bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
                 let bytes = (BATCH_SIZE * msg_size * n_subs) as u64;
                 group.throughput(Throughput::Bytes(bytes));
@@ -143,9 +141,7 @@ fn bench_libzmq_pub_pipelined(c: &mut Criterion) {
             let mut group = c.benchmark_group(format!(
                 "libzmq/throughput/pub_fanout/{transport}/subs={n_subs}"
             ));
-            group.sample_size(10);
-            group.measurement_time(Duration::from_secs(10));
-            group.warm_up_time(Duration::from_secs(2));
+            bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
                 let bytes = (BATCH_SIZE * msg_size * n_subs) as u64;
                 group.throughput(Throughput::Bytes(bytes));
@@ -239,9 +235,7 @@ fn bench_zmqrs_dealer_router_pipelined(c: &mut Criterion) {
     let rt = build_rt();
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("zmqrs/throughput/dealer_router/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
             group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
@@ -306,9 +300,7 @@ fn bench_zmqrs_dealer_router_one(
 fn bench_libzmq_dealer_router_pipelined(c: &mut Criterion) {
     for &transport in TRANSPORTS {
         let mut group = c.benchmark_group(format!("libzmq/throughput/dealer_router/{transport}"));
-        group.sample_size(10);
-        group.measurement_time(Duration::from_secs(10));
-        group.warm_up_time(Duration::from_secs(2));
+        bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
             group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
             group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -4,6 +4,43 @@ Criterion benches live in [`benches/`](../benches/). This branch carries a
 master-compatible subset of the newer benchmark suite so local results can be
 compared against the performance branch without pulling in branch-only APIs.
 
+## Performance Suite
+
+The suite in [`scripts/run_perf_suite.py`](../scripts/run_perf_suite.py)
+orchestrates existing Criterion benches, normalizes the results, and can compare
+against a pinned OMQ clone.
+
+```sh
+python3 scripts/run_perf_suite.py --profile smoke --impl zmqrs,libzmq --transport tcp
+python3 scripts/report_perf_suite.py target/perf-runs/<run-id>
+```
+
+OMQ is not vendored. When selected, it is cloned into
+`target/perf-deps/omq.rs` at the pinned revision in
+[`perf-suite.json`](../perf-suite.json), or at `--omq-rev <sha>`:
+
+```sh
+python3 scripts/run_perf_suite.py --profile smoke --impl omq --transport tcp
+```
+
+If the pinned OMQ dependencies need a newer installed toolchain than the local
+default, pass it explicitly:
+
+```sh
+python3 scripts/run_perf_suite.py --profile smoke --impl omq --transport tcp --toolchain 1.94.1
+```
+
+For a decision-making local run:
+
+```sh
+python3 scripts/run_perf_suite.py --profile standard --impl zmqrs,libzmq,omq --transport tcp,ipc
+```
+
+Each run writes `manifest.json`, `results.jsonl`, `summary.md`, and
+`summary.html` under `target/perf-runs/<run-id>/`. Use
+`--candidate-path <path>` to compare another checkout without changing this
+suite.
+
 ## Running Locally
 
 ```sh

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -39,7 +39,8 @@ python3 scripts/run_perf_suite.py --profile standard --impl zmqrs,libzmq,omq --t
 Each run writes `manifest.json`, `results.jsonl`, `summary.md`, and
 `summary.html` under `target/perf-runs/<run-id>/`. Use
 `--candidate-path <path>` to compare another checkout without changing this
-suite.
+suite. See [`BENCHMARK_RESULTS.md`](BENCHMARK_RESULTS.md) for the standard way
+to package and share runs without committing generated data.
 
 ## Running Locally
 

--- a/docs/BENCHMARK_RESULTS.md
+++ b/docs/BENCHMARK_RESULTS.md
@@ -1,0 +1,68 @@
+# Benchmark Results
+
+The canonical unit for a performance result is one run directory under
+`target/perf-runs/<run-id>/`. These directories are generated artifacts and are
+not committed to the repository.
+
+## Sharing Runs
+
+Use the run directory for local analysis, then publish a compressed archive when
+the data needs to be shared across machines, pull requests, or issue comments:
+
+```sh
+python3 scripts/run_perf_suite.py --profile standard --impl zmqrs,libzmq,omq --transport tcp,ipc --run-id <run-id>
+python3 scripts/package_perf_run.py target/perf-runs/<run-id>
+```
+
+The package script writes `target/perf-archives/zmqrs-perf-<run-id>.tar.gz` and
+a matching `.sha256` file. By default it includes:
+
+- `manifest.json`
+- `results.jsonl`
+- `summary.md`
+- `summary.html`
+
+Use `--include-artifacts` only when raw Criterion directories or external bench
+outputs are needed for debugging. Full artifacts are useful, but they are too
+large for routine sharing.
+
+## Run IDs
+
+Use stable, searchable run IDs:
+
+```text
+<host>-<profile>-<candidate-sha>-<YYYYMMDDTHHMMSSZ>
+```
+
+Examples:
+
+```text
+macbook-standard-16ae7d1-20260514T190000Z
+c7g-4xlarge-standard-16ae7d1-20260514T190000Z
+```
+
+The manifest already captures exact git SHAs, tool versions, OS, CPU metadata,
+profile, transports, implementations, runtimes, OMQ revision, and commands.
+The run ID is for quick human scanning.
+
+## Posting Results
+
+For GitHub discussions or PR comments, post:
+
+- The `summary.md` table.
+- The candidate git SHA from `manifest.json`.
+- The host CPU/OS from `manifest.json`.
+- The archive location and SHA256 checksum.
+- Any non-default flags such as `--toolchain`.
+
+For distributed agent runs, store archives outside the repo, for example as
+GitHub Actions artifacts or under an S3 prefix such as:
+
+```text
+s3://<bucket>/zmq.rs/perf-runs/<run-id>/zmqrs-perf-<run-id>.tar.gz
+```
+
+If we later need durable cross-run history in git, commit only a small curated
+index such as `benchmarks/results.jsonl` containing one normalized row per
+workload/runtime/transport/size. Do not commit complete `target/perf-runs`
+directories or raw Criterion artifacts.

--- a/docs/PERFORMANCE_ROADMAP.md
+++ b/docs/PERFORMANCE_ROADMAP.md
@@ -1,8 +1,7 @@
 # Performance Roadmap
 
-This branch supersedes PR #251 as the official performance path. It stays
-focused on measurement and planning: no runtime internals, socket hot paths, or
-public crate APIs are changed here.
+This roadmap focuses on measurement and planning: no runtime internals, socket
+hot paths, or public crate APIs are changed here.
 
 ## Benchmark Contract
 

--- a/docs/PERFORMANCE_ROADMAP.md
+++ b/docs/PERFORMANCE_ROADMAP.md
@@ -1,0 +1,101 @@
+# Performance Roadmap
+
+This branch supersedes PR #251 as the official performance path. It stays
+focused on measurement and planning: no runtime internals, socket hot paths, or
+public crate APIs are changed here.
+
+## Benchmark Contract
+
+Run data lives under `target/perf-runs/<run-id>/` and contains:
+
+- `manifest.json`: git SHA, tool versions, OS/CPU metadata, selected profile,
+  transports, implementations, runtimes, commands, and the pinned OMQ revision.
+- `results.jsonl`: normalized benchmark rows from Criterion and OMQ.
+- `summary.md` and `summary.html`: ratios against `zmq.rs` Tokio for matching
+  workload, transport, peer count, and message size.
+- `artifacts/`: copied Criterion directories and OMQ JSONL outputs.
+
+OMQ is cloned into `target/perf-deps/omq.rs` at the pinned revision. The source
+is not vendored and is not a submodule. OMQ cargo commands run with
+`--manifest-path` from a neutral working directory so local `zmq.rs` Cargo
+configuration does not leak into the external benchmark build.
+
+## Work Packages
+
+1. Benchmark harness and baseline capture
+   - Goal: keep `scripts/run_perf_suite.py` and `scripts/report_perf_suite.py`
+     reproducible from a fresh checkout.
+   - Expected movement: none; this establishes the oracle.
+   - Correctness checks: `cargo check --all-targets`, `cargo bench --no-run`,
+     smoke suite for `zmq.rs` and libzmq, and OMQ smoke when the external clone
+     is available.
+
+2. By-reference send and clone reduction
+   - Goal: avoid cloning message frames on send paths where the transport can
+     borrow or share immutable bytes.
+   - Expected movement: codec encode, PUSH/PULL, DEALER/ROUTER, and large
+     multipart throughput improve without API churn.
+   - Correctness checks: multipart send/recv tests, large message tests,
+     codec roundtrip tests, and cancellation probes around in-flight sends.
+
+3. PUB/XPUB fanout state cleanup
+   - Goal: remove steady-state per-subscriber queue/lock pressure. Fanout
+     should check connection/subscription state when state changes, then send
+     without a lock per subscriber on every message.
+   - Expected movement: PUB/SUB 8- and 64-subscriber fanout closes most of the
+     OMQ gap.
+   - Correctness checks: subscription propagation, XPUB/XSUB compliance,
+     late subscriber behavior, and slow subscriber isolation.
+
+4. Sans-I/O ZMTP core boundary
+   - Goal: separate protocol parsing/framing/state from runtime I/O so Tokio
+     remains first-class while transport code gets smaller and easier to test.
+   - Expected movement: indirect at first; enables safer writev, recv-copy, and
+     runtime policy work.
+   - Correctness checks: protocol fixture tests, greeting/mechanism tests,
+     interop with libzmq, and no public socket API changes.
+
+5. Gather-write and `writev` large-frame path
+   - Goal: send multipart and large frames with vectored writes where the
+     runtime/transport supports it.
+   - Expected movement: large message, multipart codec, and DEALER/ROUTER
+     throughput improve.
+   - Correctness checks: partial write simulation, large multipart interop,
+     IPC/TCP parity, and benchmark confirmation across Tokio first.
+
+6. Recv copy reduction and cancel-safety validation
+   - Goal: reduce receive-side copies while guaranteeing that canceled `recv`
+     calls do not drop or corrupt queued frames.
+   - Expected movement: REQ/REP latency, PUSH/PULL throughput, and codec decode
+     improve; cancel-safety bugs remain blocked by tests.
+   - Correctness checks: timeout/cancel loops, FairQueue regression tests,
+     large receive tests, and randomized receive cancellation.
+
+7. Inproc transport
+   - Goal: add an in-process transport after the core boundaries are clear.
+   - Expected movement: OMQ/libzmq inproc becomes directly comparable with
+     `zmq.rs`; local actor-style use cases get a meaningful fast path.
+   - Correctness checks: socket lifecycle, endpoint reuse, teardown ordering,
+     and multi-peer routing.
+
+8. Runtime policy decision
+   - Goal: keep Tokio mandatory and first-class. Measure async-std and
+     async-dispatcher before deciding whether to keep, deprecate, or remove
+     either legacy runtime path.
+   - Expected movement: none by itself; reduces maintenance drag only after the
+     data supports a decision.
+   - Correctness checks: runtime-specific compile gates, benchmark smoke, and a
+     migration note for any removed feature.
+
+## Agent-Sized Goals
+
+- `/goal` Capture a standard baseline on current `origin/master` and attach the
+  generated summary.
+- `/goal` Port by-reference send from the OMQ/Alexei branches into a small
+  candidate branch and compare only codec, PUSH/PULL, and DEALER/ROUTER.
+- `/goal` Prototype lock-light PUB fanout state on a candidate branch and
+  compare only PUB/SUB fanout for 1, 8, and 64 subscribers.
+- `/goal` Write cancel-safety stress tests for `recv` without production
+  changes.
+- `/goal` Audit runtime feature coverage and produce a keep/deprecate/remove
+  recommendation after one standard run per runtime.

--- a/perf-suite.json
+++ b/perf-suite.json
@@ -1,0 +1,124 @@
+{
+  "schema": 1,
+  "omq": {
+    "repository": "https://github.com/paddor/omq.rs.git",
+    "revision": "a46c1f7"
+  },
+  "profiles": {
+    "smoke": {
+      "description": "Fast CI/local sanity profile. Runs one PUSH/PULL TCP point for zmq.rs and libzmq, and one OMQ PUSH/PULL point when OMQ is selected.",
+      "criterion_args": ["--sample-size", "10", "--measurement-time", "1", "--warm-up-time", "1"],
+      "zmqrs_runtimes": ["tokio-runtime"],
+      "benches": [
+        {
+          "name": "compare_libzmq",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": ["{impl}/push_pull/{transport}/16"]
+        }
+      ],
+      "omq": {
+        "packages": ["omq-tokio"],
+        "benches": ["push_pull"],
+        "sizes": [128],
+        "peers": [1],
+        "round_ms": 100,
+        "rounds": 1
+      }
+    },
+    "standard": {
+      "description": "Day-to-day comparison profile for decision making before and after hot-path changes.",
+      "criterion_args": ["--sample-size", "10", "--measurement-time", "3", "--warm-up-time", "1"],
+      "zmqrs_runtimes": ["tokio-runtime", "async-std-runtime", "async-dispatcher-runtime"],
+      "benches": [
+        {
+          "name": "compare_libzmq",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/push_pull/{transport}/{size}",
+            "{impl}/req_rep/{transport}/{size}",
+            "{impl}/dealer_router/{transport}/{size}",
+            "{impl}/pub_sub/{transport}/subs={subs}/{size}"
+          ],
+          "sizes": [16, 256, 4096],
+          "subs": [1, 8]
+        },
+        {
+          "name": "throughput",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/throughput/dealer_router/{transport}/{size}",
+            "{impl}/throughput/pub_fanout/{transport}/subs={subs}/{size}"
+          ],
+          "sizes": [256, 4096],
+          "subs": [1, 8]
+        },
+        {
+          "name": "codec",
+          "implementations": ["zmqrs"],
+          "templates": [
+            "codec/encode/frames={frames}/{size}",
+            "codec/decode/frames={frames}/{size}"
+          ],
+          "sizes": [16, 4096, 65536],
+          "frames": [1, 8]
+        }
+      ],
+      "omq": {
+        "packages": ["omq-tokio", "omq-compio"],
+        "benches": ["push_pull", "req_rep", "router_dealer", "pub_sub"],
+        "sizes": [128, 2048, 8192],
+        "peers": [1, 8],
+        "round_ms": 300,
+        "rounds": 2
+      }
+    },
+    "full": {
+      "description": "Long local/manual run. Use this before claiming performance wins.",
+      "criterion_args": ["--sample-size", "20", "--measurement-time", "10", "--warm-up-time", "2"],
+      "zmqrs_runtimes": ["tokio-runtime", "async-std-runtime", "async-dispatcher-runtime"],
+      "benches": [
+        {
+          "name": "compare_libzmq",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/push_pull/{transport}/{size}",
+            "{impl}/req_rep/{transport}/{size}",
+            "{impl}/dealer_router/{transport}/{size}",
+            "{impl}/pub_sub/{transport}/subs={subs}/{size}"
+          ],
+          "sizes": [16, 256, 4096, 65536],
+          "subs": [1, 8, 64]
+        },
+        {
+          "name": "throughput",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/throughput/dealer_router/{transport}/{size}",
+            "{impl}/throughput/pub_fanout/{transport}/subs={subs}/{size}"
+          ],
+          "sizes": [256, 4096],
+          "subs": [1, 8, 64]
+        },
+        {
+          "name": "codec",
+          "implementations": ["zmqrs"],
+          "templates": [
+            "codec/encode/frames={frames}/{size}",
+            "codec/decode/frames={frames}/{size}"
+          ],
+          "sizes": [16, 256, 4096, 65536],
+          "frames": [1, 2, 8]
+        }
+      ],
+      "omq": {
+        "packages": ["omq-tokio", "omq-compio"],
+        "benches": ["push_pull", "req_rep", "router_dealer", "pub_sub", "latency"],
+        "sizes": [32, 128, 512, 2048, 8192, 32768, 131072],
+        "peers": [1, 3, 8],
+        "round_ms": 500,
+        "rounds": 3,
+        "include_inproc": true
+      }
+    }
+  }
+}

--- a/scripts/package_perf_run.py
+++ b/scripts/package_perf_run.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Package a perf run directory for sharing without committing generated data."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tarfile
+from pathlib import Path
+
+
+DEFAULT_FILES = ("manifest.json", "results.jsonl", "summary.md", "summary.html")
+
+
+def main() -> int:
+    args = parse_args()
+    run_dir = Path(args.run_dir).resolve()
+    if not run_dir.is_dir():
+        raise SystemExit(f"run directory does not exist: {run_dir}")
+
+    manifest_path = run_dir / "manifest.json"
+    if not manifest_path.exists():
+        raise SystemExit(f"missing manifest.json in {run_dir}")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    run_id = str(manifest.get("run_id") or run_dir.name)
+
+    out_dir = Path(args.out_dir).resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    archive = out_dir / f"zmqrs-perf-{safe_name(run_id)}.tar.gz"
+
+    with tarfile.open(archive, "w:gz") as tar:
+        for name in DEFAULT_FILES:
+            path = run_dir / name
+            if path.exists():
+                tar.add(path, arcname=f"{run_dir.name}/{name}")
+        if args.include_artifacts:
+            artifacts = run_dir / "artifacts"
+            if artifacts.exists():
+                tar.add(artifacts, arcname=f"{run_dir.name}/artifacts")
+
+    digest = sha256_file(archive)
+    checksum = archive.with_suffix(archive.suffix + ".sha256")
+    checksum.write_text(f"{digest}  {archive.name}\n", encoding="utf-8")
+    print(archive)
+    print(checksum)
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir")
+    parser.add_argument("--out-dir", default="target/perf-archives")
+    parser.add_argument(
+        "--include-artifacts",
+        action="store_true",
+        help="Include raw Criterion and external benchmark artifacts.",
+    )
+    return parser.parse_args()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def safe_name(value: str) -> str:
+    return "".join(c if c.isalnum() or c in "._-" else "-" for c in value).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/report_perf_suite.py
+++ b/scripts/report_perf_suite.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Generate Markdown and HTML summaries for run_perf_suite.py output."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+from pathlib import Path
+from typing import Any
+
+
+def main() -> int:
+    args = parse_args()
+    run_dir = Path(args.run_dir).resolve()
+    manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+    rows = load_rows(run_dir / "results.jsonl")
+    summary = build_summary(rows)
+    (run_dir / "summary.md").write_text(render_markdown(manifest, summary), encoding="utf-8")
+    (run_dir / "summary.html").write_text(render_html(manifest, summary), encoding="utf-8")
+    print(f"wrote {run_dir / 'summary.md'}")
+    print(f"wrote {run_dir / 'summary.html'}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir")
+    return parser.parse_args()
+
+
+def load_rows(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def build_summary(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    baseline = {
+        row_key(row): row
+        for row in rows
+        if row.get("implementation") == "zmqrs" and row.get("runtime") == "tokio"
+    }
+    summary = []
+    for row in rows:
+        item = dict(row)
+        base = baseline.get(row_key(row))
+        item["ratio_vs_zmqrs_tokio"] = ratio_against(row, base)
+        summary.append(item)
+    return sorted(summary, key=sort_key)
+
+
+def ratio_against(row: dict[str, Any], base: dict[str, Any] | None) -> float | None:
+    if base is None:
+        return None
+    value = row.get("throughput_bytes_per_second")
+    base_value = base.get("throughput_bytes_per_second")
+    if isinstance(value, (int, float)) and isinstance(base_value, (int, float)) and base_value > 0:
+        return value / base_value
+    latency = row.get("latency_ns_per_iter")
+    base_latency = base.get("latency_ns_per_iter")
+    if isinstance(latency, (int, float)) and isinstance(base_latency, (int, float)) and latency > 0:
+        return base_latency / latency
+    return None
+
+
+def row_key(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        row.get("workload"),
+        row.get("transport"),
+        row.get("peers"),
+        row.get("message_size"),
+    )
+
+
+def sort_key(row: dict[str, Any]) -> tuple[Any, ...]:
+    return (
+        str(row.get("workload")),
+        str(row.get("transport")),
+        int(row.get("peers") or 0),
+        int(row.get("message_size") or 0),
+        str(row.get("implementation")),
+        str(row.get("runtime")),
+    )
+
+
+def render_markdown(manifest: dict[str, Any], rows: list[dict[str, Any]]) -> str:
+    lines = [
+        f"# Performance Run {manifest.get('run_id')}",
+        "",
+        f"- status: `{manifest.get('status')}`",
+        f"- profile: `{manifest.get('profile')}`",
+        f"- candidate: `{manifest.get('candidate_path')}`",
+        f"- candidate git: `{(manifest.get('git') or {}).get('candidate', {}).get('sha')}`",
+        f"- transports: `{', '.join(manifest.get('transports', []))}`",
+        f"- implementations: `{', '.join(manifest.get('implementations', []))}`",
+        f"- OMQ revision: `{(manifest.get('omq') or {}).get('revision')}`",
+        "",
+    ]
+    if not rows:
+        lines.extend(["No benchmark rows were captured.", ""])
+        return "\n".join(lines)
+    lines.extend(
+        [
+            "| workload | transport | peers | size | implementation | runtime | throughput | latency | ratio vs zmq.rs tokio |",
+            "| --- | --- | ---: | ---: | --- | --- | ---: | ---: | ---: |",
+        ]
+    )
+    for row in rows:
+        lines.append(
+            "| {workload} | {transport} | {peers} | {size} | {implementation} | {runtime} | {throughput} | {latency} | {ratio} |".format(
+                workload=row.get("workload", ""),
+                transport=row.get("transport", ""),
+                peers=row.get("peers", ""),
+                size=row.get("message_size", ""),
+                implementation=row.get("implementation", ""),
+                runtime=row.get("runtime", ""),
+                throughput=format_bps(row.get("throughput_bytes_per_second")),
+                latency=format_ns(row.get("latency_ns_per_iter")),
+                ratio=format_ratio(row.get("ratio_vs_zmqrs_tokio")),
+            )
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_html(manifest: dict[str, Any], rows: list[dict[str, Any]]) -> str:
+    body = markdown_to_html(render_markdown(manifest, rows))
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Performance Run {html.escape(str(manifest.get('run_id')))}</title>
+<style>
+body {{ font: 14px/1.45 -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif; margin: 32px; color: #17202a; }}
+code {{ background: #f3f4f6; padding: 1px 4px; border-radius: 4px; }}
+table {{ border-collapse: collapse; width: 100%; margin-top: 18px; }}
+th, td {{ border-bottom: 1px solid #e5e7eb; padding: 6px 8px; text-align: left; }}
+th {{ background: #f8fafc; position: sticky; top: 0; }}
+td:nth-child(3), td:nth-child(4), td:nth-child(7), td:nth-child(8), td:nth-child(9) {{ text-align: right; font-variant-numeric: tabular-nums; }}
+</style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+
+
+def markdown_to_html(md: str) -> str:
+    lines = md.splitlines()
+    out: list[str] = []
+    in_list = False
+    in_table = False
+    for line in lines:
+        if line.startswith("# "):
+            close_blocks(out, in_list, in_table)
+            in_list = in_table = False
+            out.append(f"<h1>{html.escape(line[2:])}</h1>")
+        elif line.startswith("- "):
+            if not in_list:
+                out.append("<ul>")
+                in_list = True
+            out.append(f"<li>{inline_code(line[2:])}</li>")
+        elif line.startswith("| ") and not line.startswith("| ---"):
+            if in_list:
+                out.append("</ul>")
+                in_list = False
+            if not in_table:
+                out.append("<table>")
+                in_table = True
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            tag = "th" if cells and cells[0] == "workload" else "td"
+            out.append("<tr>" + "".join(f"<{tag}>{html.escape(cell)}</{tag}>" for cell in cells) + "</tr>")
+        elif line.startswith("| ---"):
+            continue
+        elif line.strip():
+            close_blocks(out, in_list, in_table)
+            in_list = in_table = False
+            out.append(f"<p>{inline_code(line)}</p>")
+    close_blocks(out, in_list, in_table)
+    return "\n".join(out)
+
+
+def close_blocks(out: list[str], in_list: bool, in_table: bool) -> None:
+    if in_list:
+        out.append("</ul>")
+    if in_table:
+        out.append("</table>")
+
+
+def inline_code(text: str) -> str:
+    parts = text.split("`")
+    rendered = []
+    for idx, part in enumerate(parts):
+        escaped = html.escape(part)
+        rendered.append(f"<code>{escaped}</code>" if idx % 2 else escaped)
+    return "".join(rendered)
+
+
+def format_bps(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return ""
+    mb = value / 1_000_000.0
+    if mb >= 1000:
+        return f"{mb / 1000:.2f} GB/s"
+    return f"{mb:.1f} MB/s"
+
+
+def format_ns(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return ""
+    if value >= 1_000_000:
+        return f"{value / 1_000_000:.3f} ms"
+    if value >= 1_000:
+        return f"{value / 1_000:.3f} us"
+    return f"{value:.1f} ns"
+
+
+def format_ratio(value: Any) -> str:
+    if not isinstance(value, (int, float)):
+        return ""
+    return f"{value:.2f}x"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_perf_suite.py
+++ b/scripts/run_perf_suite.py
@@ -1,0 +1,564 @@
+#!/usr/bin/env python3
+"""Run reproducible zmq.rs performance comparisons."""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import json
+import os
+import platform
+import re
+import shutil
+import string
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_CONFIG = "perf-suite.json"
+DEFAULT_OMQ_REV = "a46c1f7"
+ZMQRS_IMPLS = {"zmqrs", "libzmq"}
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(args.repo_root).resolve()
+    candidate_root = Path(args.candidate_path or repo_root).resolve()
+    config = load_config(repo_root / args.config)
+    profile = config["profiles"][args.profile]
+    impls = parse_csv(args.impl)
+    transports = parse_csv(args.transport)
+    runtimes = parse_csv(args.runtime) if args.runtime else profile["zmqrs_runtimes"]
+    run_id = args.run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = repo_root / "target" / "perf-runs" / run_id
+    if run_dir.exists() and not args.force:
+        raise SystemExit(f"run directory already exists: {run_dir} (pass --force to replace)")
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True)
+
+    manifest = build_manifest(
+        args=args,
+        config=config,
+        repo_root=repo_root,
+        candidate_root=candidate_root,
+        profile=profile,
+        impls=impls,
+        transports=transports,
+        runtimes=runtimes,
+        run_id=run_id,
+    )
+    write_json(run_dir / "manifest.json", manifest)
+    results_path = run_dir / "results.jsonl"
+
+    try:
+        if ZMQRS_IMPLS.intersection(impls):
+            run_zmqrs_and_libzmq(
+                args=args,
+                candidate_root=candidate_root,
+                run_dir=run_dir,
+                results_path=results_path,
+                profile=profile,
+                impls=impls,
+                transports=transports,
+                runtimes=runtimes,
+                manifest=manifest,
+            )
+        if "omq" in impls:
+            run_omq(
+                args=args,
+                repo_root=repo_root,
+                run_dir=run_dir,
+                results_path=results_path,
+                config=config,
+                profile=profile,
+                transports=transports,
+                manifest=manifest,
+            )
+        manifest["status"] = "complete"
+        manifest["completed_at"] = now()
+        write_json(run_dir / "manifest.json", manifest)
+        if not args.no_report and not args.dry_run:
+            subprocess.run(
+                [sys.executable, str(repo_root / "scripts" / "report_perf_suite.py"), str(run_dir)],
+                check=True,
+            )
+        print(f"perf run: {run_dir}")
+        return 0
+    except Exception as exc:
+        manifest["status"] = "failed"
+        manifest["failed_at"] = now()
+        manifest["error"] = str(exc)
+        write_json(run_dir / "manifest.json", manifest)
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", default=".")
+    parser.add_argument("--candidate-path", help="zmq.rs checkout to benchmark")
+    parser.add_argument("--config", default=DEFAULT_CONFIG)
+    parser.add_argument("--profile", choices=["smoke", "standard", "full"], default="standard")
+    parser.add_argument("--impl", default="zmqrs,libzmq")
+    parser.add_argument("--transport", default="tcp,ipc")
+    parser.add_argument("--runtime", help="Comma-separated zmq.rs runtime features")
+    parser.add_argument("--run-id")
+    parser.add_argument("--omq-rev", default=DEFAULT_OMQ_REV)
+    parser.add_argument("--cargo", default="cargo")
+    parser.add_argument("--toolchain", help="Optional cargo toolchain, for example stable or 1.94.1")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--force", action="store_true")
+    parser.add_argument("--no-report", action="store_true")
+    return parser.parse_args()
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if data.get("schema") != 1:
+        raise SystemExit(f"unsupported perf-suite config schema in {path}")
+    return data
+
+
+def parse_csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def build_manifest(
+    *,
+    args: argparse.Namespace,
+    config: dict[str, Any],
+    repo_root: Path,
+    candidate_root: Path,
+    profile: dict[str, Any],
+    impls: list[str],
+    transports: list[str],
+    runtimes: list[str],
+    run_id: str,
+) -> dict[str, Any]:
+    omq_cfg = config["omq"]
+    return {
+        "schema": 1,
+        "status": "running",
+        "run_id": run_id,
+        "created_at": now(),
+        "profile": args.profile,
+        "profile_description": profile.get("description"),
+        "repo_root": str(repo_root),
+        "candidate_path": str(candidate_root),
+        "implementations": impls,
+        "transports": transports,
+        "runtimes": runtimes,
+        "omq": {
+            "repository": omq_cfg["repository"],
+            "revision": args.omq_rev,
+            "default_revision": omq_cfg.get("revision"),
+        },
+        "host": host_metadata(),
+        "tools": tool_metadata(cargo_cmd(args)),
+        "git": {
+            "repo": git_metadata(repo_root),
+            "candidate": git_metadata(candidate_root),
+        },
+        "commands": [],
+    }
+
+
+def host_metadata() -> dict[str, Any]:
+    cpu = platform.processor() or platform.machine()
+    if sys.platform == "darwin":
+        try:
+            cpu = subprocess.check_output(["sysctl", "-n", "machdep.cpu.brand_string"], text=True).strip()
+        except (OSError, subprocess.SubprocessError):
+            pass
+    elif Path("/proc/cpuinfo").exists():
+        for line in Path("/proc/cpuinfo").read_text(encoding="utf-8", errors="replace").splitlines():
+            if line.lower().startswith("model name"):
+                cpu = line.split(":", 1)[1].strip()
+                break
+    return {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "processor": cpu,
+        "python": sys.version.split()[0],
+    }
+
+
+def tool_metadata(cargo: list[str]) -> dict[str, str | None]:
+    return {
+        "rustc": command_text(["rustc", "--version"]),
+        "cargo": command_text([*cargo, "--version"]),
+    }
+
+
+def git_metadata(root: Path) -> dict[str, str | None]:
+    return {
+        "sha": command_text(["git", "rev-parse", "HEAD"], cwd=root),
+        "branch": command_text(["git", "branch", "--show-current"], cwd=root),
+        "dirty": command_text(["git", "status", "--short"], cwd=root),
+    }
+
+
+def command_text(cmd: list[str], cwd: Path | None = None) -> str | None:
+    try:
+        return subprocess.check_output(cmd, cwd=cwd, text=True, stderr=subprocess.DEVNULL).strip()
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def run_zmqrs_and_libzmq(
+    *,
+    args: argparse.Namespace,
+    candidate_root: Path,
+    run_dir: Path,
+    results_path: Path,
+    profile: dict[str, Any],
+    impls: list[str],
+    transports: list[str],
+    runtimes: list[str],
+    manifest: dict[str, Any],
+) -> None:
+    selected_impls = [impl for impl in impls if impl in ZMQRS_IMPLS]
+    for bench in profile["benches"]:
+        bench_impls = [impl for impl in selected_impls if impl in bench.get("implementations", selected_impls)]
+        if not bench_impls:
+            continue
+        if "libzmq" in bench_impls:
+            run_criterion_entry(
+                args=args,
+                candidate_root=candidate_root,
+                run_dir=run_dir,
+                results_path=results_path,
+                manifest=manifest,
+                bench=bench,
+                implementation="libzmq",
+                runtime="tokio-runtime",
+                transports=transports,
+                criterion_args=profile["criterion_args"],
+            )
+        if "zmqrs" in bench_impls:
+            for runtime in runtimes:
+                run_criterion_entry(
+                    args=args,
+                    candidate_root=candidate_root,
+                    run_dir=run_dir,
+                    results_path=results_path,
+                    manifest=manifest,
+                    bench=bench,
+                    implementation="zmqrs",
+                    runtime=runtime,
+                    transports=transports,
+                    criterion_args=profile["criterion_args"],
+                )
+
+
+def run_criterion_entry(
+    *,
+    args: argparse.Namespace,
+    candidate_root: Path,
+    run_dir: Path,
+    results_path: Path,
+    manifest: dict[str, Any],
+    bench: dict[str, Any],
+    implementation: str,
+    runtime: str,
+    transports: list[str],
+    criterion_args: list[str],
+) -> None:
+    filters = expand_filters(bench, implementation, transports)
+    if not filters:
+        return
+    filter_regex = "|".join(re.escape(item) for item in filters)
+    target_criterion = candidate_root / "target" / "criterion"
+    if target_criterion.exists():
+        shutil.rmtree(target_criterion)
+
+    cmd = [
+        *cargo_cmd(args),
+        "bench",
+        "--no-default-features",
+        "--features",
+        ",".join(features_for_runtime(runtime)),
+        "--bench",
+        bench["name"],
+        "--",
+        *criterion_args,
+        filter_regex,
+    ]
+    env = os.environ.copy()
+    env.update(criterion_env(criterion_args))
+    run_command(cmd, cwd=candidate_root, env=env, manifest=manifest, dry_run=args.dry_run)
+    artifact_dir = run_dir / "artifacts" / safe_name(f"{implementation}-{runtime}") / bench["name"]
+    if not args.dry_run and target_criterion.exists():
+        shutil.copytree(target_criterion, artifact_dir / "criterion")
+        rows = criterion_rows(
+            artifact_dir / "criterion",
+            implementation=implementation,
+            runtime=runtime.removesuffix("-runtime"),
+            suite=bench["name"],
+        )
+        append_jsonl(results_path, rows)
+
+
+def features_for_runtime(runtime: str) -> list[str]:
+    features = [runtime, "all-transport"]
+    if runtime == "async-dispatcher-runtime":
+        features.append("async-dispatcher-macros")
+    return features
+
+
+def criterion_env(criterion_args: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    pairs = list(zip(criterion_args, criterion_args[1:]))
+    for flag, value in pairs:
+        if flag == "--sample-size":
+            env["ZMQRS_BENCH_SAMPLE_SIZE"] = value
+        elif flag == "--measurement-time":
+            env["ZMQRS_BENCH_MEASUREMENT_MS"] = str(int(float(value) * 1000))
+        elif flag == "--warm-up-time":
+            env["ZMQRS_BENCH_WARMUP_MS"] = str(int(float(value) * 1000))
+    return env
+
+
+def expand_filters(bench: dict[str, Any], implementation: str, transports: list[str]) -> list[str]:
+    values: dict[str, list[Any]] = {
+        "impl": [implementation],
+        "transport": transports,
+        "size": bench.get("sizes", [None]),
+        "subs": bench.get("subs", [None]),
+        "frames": bench.get("frames", [None]),
+    }
+    filters: list[str] = []
+    for template in bench["templates"]:
+        fields = [field for _, field, _, _ in string.Formatter().parse(template) if field]
+        products = [[value for value in values[field] if value is not None] for field in fields]
+        for combo in itertools.product(*products):
+            filters.append(template.format(**dict(zip(fields, combo))))
+    return sorted(set(filters))
+
+
+def criterion_rows(
+    criterion_dir: Path,
+    *,
+    implementation: str,
+    runtime: str,
+    suite: str,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for benchmark_path in criterion_dir.rglob("benchmark.json"):
+        if benchmark_path.parent.name != "new":
+            continue
+        estimates_path = benchmark_path.with_name("estimates.json")
+        if not estimates_path.exists():
+            continue
+        try:
+            benchmark = json.loads(benchmark_path.read_text(encoding="utf-8"))
+            estimates = json.loads(estimates_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        row = parse_criterion_row(benchmark, estimates, implementation, runtime, suite)
+        if row:
+            rows.append(row)
+    return rows
+
+
+def parse_criterion_row(
+    benchmark: dict[str, Any],
+    estimates: dict[str, Any],
+    implementation: str,
+    runtime: str,
+    suite: str,
+) -> dict[str, Any] | None:
+    group_id = benchmark.get("group_id")
+    full_id = benchmark.get("full_id")
+    value_str = benchmark.get("value_str")
+    if not isinstance(group_id, str) or not isinstance(full_id, str):
+        return None
+    try:
+        size = int(value_str if value_str is not None else full_id.rsplit("/", 1)[-1])
+    except (TypeError, ValueError):
+        return None
+    estimate = estimates.get("slope") or estimates.get("mean")
+    if not isinstance(estimate, dict):
+        return None
+    ns = estimate.get("point_estimate")
+    if not isinstance(ns, (int, float)) or ns <= 0:
+        return None
+    parsed = parse_group(group_id, implementation)
+    if parsed is None:
+        return None
+    throughput = benchmark.get("throughput")
+    bytes_per_iter = None
+    if isinstance(throughput, dict) and isinstance(throughput.get("Bytes"), int):
+        bytes_per_iter = throughput["Bytes"]
+    throughput_bps = (bytes_per_iter * 1_000_000_000.0 / ns) if bytes_per_iter else None
+    return {
+        "source": "criterion",
+        "suite": suite,
+        "implementation": implementation,
+        "runtime": runtime,
+        "transport": parsed["transport"],
+        "workload": parsed["workload"],
+        "variant": parsed.get("variant"),
+        "peers": parsed.get("peers", 1),
+        "message_size": size,
+        "latency_ns_per_iter": ns,
+        "throughput_bytes_per_second": throughput_bps,
+        "full_id": full_id,
+    }
+
+
+def parse_group(group_id: str, implementation: str) -> dict[str, Any] | None:
+    parts = group_id.split("/")
+    if parts[:1] == ["codec"]:
+        return {"workload": f"codec_{parts[1]}", "transport": "memory", "peers": 1}
+    if not parts or parts[0] != implementation:
+        return None
+    if len(parts) >= 5 and parts[1] == "throughput":
+        workload, transport, variant = parts[2], parts[3], parts[4]
+    elif len(parts) >= 4:
+        workload, transport, variant = parts[1], parts[2], parts[3]
+    elif len(parts) >= 3:
+        workload, transport, variant = parts[1], parts[2], None
+    else:
+        return None
+    peers = 1
+    if variant:
+        match = re.search(r"(subs|peers?)=(\d+)", variant)
+        if match:
+            peers = int(match.group(2))
+    return {"workload": workload, "transport": transport, "variant": variant, "peers": peers}
+
+
+def run_omq(
+    *,
+    args: argparse.Namespace,
+    repo_root: Path,
+    run_dir: Path,
+    results_path: Path,
+    config: dict[str, Any],
+    profile: dict[str, Any],
+    transports: list[str],
+    manifest: dict[str, Any],
+) -> None:
+    omq_dir = repo_root / "target" / "perf-deps" / "omq.rs"
+    ensure_omq_clone(omq_dir=omq_dir, repo=config["omq"]["repository"], rev=args.omq_rev, manifest=manifest, dry_run=args.dry_run)
+    omq_profile = profile["omq"]
+    omq_transports = list(transports)
+    if omq_profile.get("include_inproc") and "inproc" not in omq_transports:
+        omq_transports.append("inproc")
+    for package in omq_profile["packages"]:
+        for bench_name in omq_profile["benches"]:
+            suffix = safe_name(f"{manifest['run_id']}-{package}-{bench_name}")
+            cmd = [
+                *cargo_cmd(args),
+                "bench",
+                "--manifest-path",
+                str(omq_dir / "Cargo.toml"),
+                "-p",
+                package,
+                "--bench",
+                bench_name,
+            ]
+            env = os.environ.copy()
+            env.update(
+                {
+                    "OMQ_BENCH_RUN_ID": manifest["run_id"],
+                    "OMQ_BENCH_RESULTS_SUFFIX": suffix,
+                    "OMQ_BENCH_TRANSPORTS": ",".join(omq_transports),
+                    "OMQ_BENCH_SIZES": ",".join(str(s) for s in omq_profile["sizes"]),
+                    "OMQ_BENCH_PEERS": ",".join(str(p) for p in omq_profile["peers"]),
+                    "OMQ_BENCH_ROUND_MS": str(omq_profile["round_ms"]),
+                    "OMQ_BENCH_ROUNDS": str(omq_profile["rounds"]),
+                }
+            )
+            run_command(cmd, cwd=Path(tempfile.gettempdir()), env=env, manifest=manifest, dry_run=args.dry_run)
+            if args.dry_run:
+                continue
+            source_path = omq_dir / package / "benches" / f"results_{suffix}.jsonl"
+            artifact_dir = run_dir / "artifacts" / package / bench_name
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            if source_path.exists():
+                shutil.copy2(source_path, artifact_dir / source_path.name)
+                append_jsonl(results_path, omq_rows(source_path, package))
+
+
+def ensure_omq_clone(*, omq_dir: Path, repo: str, rev: str, manifest: dict[str, Any], dry_run: bool) -> None:
+    if not omq_dir.exists():
+        omq_dir.parent.mkdir(parents=True, exist_ok=True)
+        run_command(["git", "clone", repo, str(omq_dir)], cwd=omq_dir.parent, manifest=manifest, dry_run=dry_run)
+    run_command(["git", "fetch", "--tags", "origin"], cwd=omq_dir, manifest=manifest, dry_run=dry_run)
+    run_command(["git", "checkout", rev], cwd=omq_dir, manifest=manifest, dry_run=dry_run)
+
+
+def omq_rows(path: Path, package: str) -> list[dict[str, Any]]:
+    rows = []
+    runtime = package.removeprefix("omq-")
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        data = json.loads(line)
+        rows.append(
+            {
+                "source": "omq",
+                "suite": data["pattern"],
+                "implementation": "omq",
+                "runtime": runtime,
+                "transport": data["transport"],
+                "workload": data["pattern"],
+                "variant": f"{data['peers']}peer",
+                "peers": data["peers"],
+                "message_size": data["msg_size"],
+                "latency_ns_per_iter": None,
+                "throughput_bytes_per_second": data["mbps"] * 1_000_000.0,
+                "full_id": f"omq/{runtime}/{data['pattern']}/{data['transport']}/{data['peers']}peer/{data['msg_size']}",
+            }
+        )
+    return rows
+
+
+def run_command(
+    cmd: list[str],
+    *,
+    cwd: Path,
+    manifest: dict[str, Any],
+    dry_run: bool,
+    env: dict[str, str] | None = None,
+) -> None:
+    manifest["commands"].append({"cwd": str(cwd), "cmd": cmd, "dry_run": dry_run})
+    print("+", " ".join(cmd))
+    if not dry_run:
+        subprocess.run(cmd, cwd=cwd, env=env, check=True)
+
+
+def cargo_cmd(args: argparse.Namespace) -> list[str]:
+    cmd = [args.cargo]
+    if args.toolchain:
+        cmd.append(f"+{args.toolchain}")
+    return cmd
+
+
+def append_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        return
+    with path.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
+def write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def safe_name(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This supersedes PR #251 as the official performance path. It does not change runtime internals, socket hot paths, or public crate APIs. The branch adds a reproducible benchmark suite, reporting format, CI smoke coverage, and an agent-ready performance roadmap for moving `zmq.rs` toward OMQ-class numbers while keeping Tokio first-class.

## What changed

- Add `perf-suite.json` with smoke, standard, and full benchmark profiles.
- Add `scripts/run_perf_suite.py` and `scripts/report_perf_suite.py`.
- Normalize Criterion and OMQ outputs into `target/perf-runs/<run-id>/manifest.json`, `results.jsonl`, `summary.md`, and `summary.html`.
- Clone OMQ into `target/perf-deps/omq.rs` at pinned revision `a46c1f7`; no vendoring or submodule.
- Add `docs/PERFORMANCE_ROADMAP.md` with `/goal`-sized work packages.
- Add CI perf smoke for `zmq.rs` + libzmq only.
- Let benchmark groups honor smoke/standard/full timing through environment variables.
- Keep async-dispatcher measurable by fixing the benchmark runtime compile path.

## Validation

- `cargo check --all-targets`
- `cargo bench --no-run`
- `cargo bench --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros --bench compare_libzmq --no-run`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --all --all-targets -- --deny warnings`
- `python3 -m py_compile scripts/run_perf_suite.py scripts/report_perf_suite.py`
- `python3 scripts/run_perf_suite.py --profile smoke --impl zmqrs,libzmq --transport tcp --run-id local-smoke-final --force`
- `python3 scripts/run_perf_suite.py --profile smoke --impl omq --transport tcp --run-id omq-smoke-final --force --toolchain 1.94.1`

Note: the OMQ smoke needed `--toolchain 1.94.1` locally because the default `1.93.0-nightly` was too old for the pinned OMQ dependency set.
