### PR TITLE
Fix REQ recv cancel safety and add stress coverage

### DIFF
--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -236,6 +236,7 @@ mod test {
     use crate::async_rt;
     use crate::fair_queue::FairQueue;
     use futures::task::noop_waker;
+    use futures::Future;
     use futures::{stream, Stream, StreamExt};
     use std::collections::VecDeque;
     use std::pin::Pin;
@@ -253,6 +254,11 @@ mod test {
 
     struct WakePendingStream {
         poll_count: usize,
+    }
+
+    struct WakeThenReadyStream {
+        poll_count: usize,
+        message: Option<&'static str>,
     }
 
     impl TestStream {
@@ -288,6 +294,21 @@ mod test {
             self.get_mut().poll_count += 1;
             cx.waker().wake_by_ref();
             Poll::Pending
+        }
+    }
+
+    impl Stream for WakeThenReadyStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            this.poll_count += 1;
+            if this.poll_count == 1 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(this.message.take())
+            }
         }
     }
 
@@ -356,6 +377,35 @@ mod test {
                 (3, "c3")
             ]
         );
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_next_future_can_be_dropped_after_pending() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<WakeThenReadyStream, &str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "peer",
+                WakeThenReadyStream {
+                    poll_count: 0,
+                    message: Some("message"),
+                },
+            );
+        }
+
+        {
+            let mut next = fair_queue.next();
+            assert!(
+                matches!(Pin::new(&mut next).poll(&mut cx), Poll::Pending),
+                "first poll should park the recv future"
+            );
+        }
+
+        assert_eq!(fair_queue.next().await, Some(("peer", "message")));
     }
 
     #[async_rt::test]

--- a/src/req.rs
+++ b/src/req.rs
@@ -71,36 +71,36 @@ impl SocketSend for ReqSocket {
 #[async_trait]
 impl SocketRecv for ReqSocket {
     async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
-        match self.current_request.take() {
-            Some(peer_id) => {
-                if let Some(mut peer) = self.backend.peers.get_async(&peer_id).await {
-                    match peer.recv_queue.next().await {
-                        Some(Ok(Message::Message(mut m))) => {
-                            if m.len() < 2 {
-                                return Err(ZmqError::Other(
-                                    "Invalid message format: too few frames",
-                                ));
-                            }
-                            if !m.pop_front().unwrap().is_empty() {
-                                return Err(ZmqError::Other(
-                                    "Invalid message format: missing delimiter",
-                                ));
-                            }
-                            Ok(m)
-                        }
-                        Some(Ok(_)) => {
-                            // Non-message frames should be ignored by the caller
-                            Err(ZmqError::Other("Received non-message frame"))
-                        }
-                        Some(Err(error)) => Err(error.into()),
-                        None => Err(ZmqError::NoMessage),
-                    }
+        let peer_id = match self.current_request.clone() {
+            Some(peer_id) => peer_id,
+            None => return Err(ZmqError::Other("Unable to recv. No request in progress")),
+        };
+
+        let Some(mut peer) = self.backend.peers.get_async(&peer_id).await else {
+            self.current_request = None;
+            return Err(ZmqError::Other("Server disconnected"));
+        };
+
+        let result = match peer.recv_queue.next().await {
+            Some(Ok(Message::Message(mut m))) => {
+                if m.len() < 2 {
+                    Err(ZmqError::Other("Invalid message format: too few frames"))
+                } else if !m.pop_front().unwrap().is_empty() {
+                    Err(ZmqError::Other("Invalid message format: missing delimiter"))
                 } else {
-                    Err(ZmqError::Other("Server disconnected"))
+                    Ok(m)
                 }
             }
-            None => Err(ZmqError::Other("Unable to recv. No request in progress")),
-        }
+            Some(Ok(_)) => {
+                // Non-message frames should be ignored by the caller
+                Err(ZmqError::Other("Received non-message frame"))
+            }
+            Some(Err(error)) => Err(error.into()),
+            None => Err(ZmqError::NoMessage),
+        };
+
+        self.current_request = None;
+        result
     }
 }
 

--- a/tests/push_pull_timeout.rs
+++ b/tests/push_pull_timeout.rs
@@ -46,7 +46,12 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
             match tokio::time::timeout(remaining, pull.recv()).await {
                 Ok(Ok(_)) => count += 1,
                 Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-                Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+                Err(err) => {
+                    if Instant::now() >= deadline {
+                        break count;
+                    }
+                    panic!("per-call timeout fired after {count} messages: {err:?}");
+                }
             }
         }
     })
@@ -155,7 +160,12 @@ async fn run_issue_248_pull_child(endpoint: &str) {
         match tokio::time::timeout(remaining, socket.recv()).await {
             Ok(Ok(_)) => count += 1,
             Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-            Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                panic!("per-call timeout fired after {count} messages: {err:?}");
+            }
         }
     }
     assert!(

--- a/tests/recv_cancel_safety.rs
+++ b/tests/recv_cancel_safety.rs
@@ -1,0 +1,254 @@
+#![cfg(feature = "tokio-runtime")]
+
+use bytes::Bytes;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::time::{Duration, Instant};
+use zeromq::prelude::*;
+use zeromq::{ZmqError, ZmqMessage};
+
+const CONNECT_DELAY: Duration = Duration::from_millis(250);
+const WATCHDOG: Duration = Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn req_recv_timeout_keeps_pending_reply_available() {
+    let mut rep = zeromq::RepSocket::new();
+    let endpoint = rep.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let server = tokio::spawn(async move {
+        let request = rep.recv().await.unwrap();
+        assert_eq!(frame_text(&request, 0), "request");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        rep.send(ZmqMessage::from("reply")).await.unwrap();
+    });
+
+    let mut req = zeromq::ReqSocket::new();
+    req.connect(&endpoint).await.unwrap();
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    req.send(ZmqMessage::from("request")).await.unwrap();
+
+    let timed_out = tokio::time::timeout(Duration::from_millis(5), req.recv()).await;
+    assert!(
+        timed_out.is_err(),
+        "first recv should time out before the delayed reply"
+    );
+
+    let reply = tokio::time::timeout(Duration::from_secs(2), req.recv())
+        .await
+        .expect("timed out waiting for reply after canceling recv")
+        .expect("recv failed after canceling a pending REQ receive");
+    assert_eq!(frame_text(&reply, 0), "reply");
+
+    server.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pull_recv_timeout_storm_preserves_single_peer_order() {
+    const MESSAGES: usize = 256;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    let sender = tokio::spawn(async move {
+        for seq in 0..MESSAGES {
+            send_with_retry(&mut push, single_frame(seq)).await;
+            if seq % 8 == 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            } else {
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + WATCHDOG;
+    let mut expected = 0;
+    let mut cancellations = 0;
+
+    while expected < MESSAGES {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "timed out after receiving {expected}/{MESSAGES} messages"
+        );
+
+        match tokio::time::timeout(Duration::from_micros(75).min(remaining), pull.recv()).await {
+            Ok(Ok(message)) => {
+                assert_eq!(message.len(), 1, "single-frame message was corrupted");
+                let seq = parse_seq(frame_text(&message, 0));
+                assert_eq!(seq, expected, "single-peer recv order changed");
+                expected += 1;
+            }
+            Ok(Err(err)) => panic!("recv failed after {expected} messages: {err:?}"),
+            Err(_) => cancellations += 1,
+        }
+    }
+
+    sender.await.unwrap();
+    assert!(
+        cancellations > 0,
+        "test did not exercise a canceled recv path"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pull_recv_cancel_storm_preserves_multipart_multi_peer_queues() {
+    const PEERS: usize = 3;
+    const MESSAGES_PER_PEER: usize = 96;
+    const LARGE_FRAME_LEN: usize = 16 * 1024;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut pushes = Vec::new();
+    for peer in 0..PEERS {
+        let mut push = zeromq::PushSocket::new();
+        push.connect(&endpoint).await.unwrap();
+        pushes.push((peer, push));
+    }
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    let mut senders = Vec::new();
+    for (peer, mut push) in pushes {
+        senders.push(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis((peer as u64 + 1) * 10)).await;
+            for seq in 0..MESSAGES_PER_PEER {
+                send_with_retry(&mut push, multipart_message(peer, seq, LARGE_FRAME_LEN)).await;
+                if seq % 5 == 0 {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                } else {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }));
+    }
+
+    let expected_total = PEERS * MESSAGES_PER_PEER;
+    let mut next_by_peer = BTreeMap::new();
+    for peer in 0..PEERS {
+        next_by_peer.insert(peer, 0usize);
+    }
+
+    let deadline = Instant::now() + WATCHDOG;
+    let mut received = 0;
+    let mut cancellations = 0;
+
+    while received < expected_total {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "timed out after receiving {received}/{expected_total} multipart messages"
+        );
+
+        tokio::select! {
+            biased;
+            _ = tokio::time::sleep(Duration::from_micros(75).min(remaining)) => {
+                cancellations += 1;
+            }
+            result = pull.recv() => {
+                let message = result.unwrap_or_else(|err| {
+                    panic!("recv failed after {received} multipart messages: {err:?}")
+                });
+                assert_multipart_message(message, &mut next_by_peer, LARGE_FRAME_LEN);
+                received += 1;
+            }
+        }
+    }
+
+    for sender in senders {
+        sender.await.unwrap();
+    }
+
+    assert!(
+        cancellations > 0,
+        "test did not exercise canceled recv attempts"
+    );
+    for peer in 0..PEERS {
+        assert_eq!(
+            next_by_peer[&peer], MESSAGES_PER_PEER,
+            "peer {peer} did not deliver all messages"
+        );
+    }
+}
+
+async fn send_with_retry(socket: &mut zeromq::PushSocket, message: ZmqMessage) {
+    let mut message = Some(message);
+    loop {
+        match socket.send(message.take().unwrap()).await {
+            Ok(()) => return,
+            Err(ZmqError::ReturnToSender {
+                message: returned, ..
+            }) => {
+                message = Some(returned);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            Err(err) => panic!("send failed: {err:?}"),
+        }
+    }
+}
+
+fn single_frame(seq: usize) -> ZmqMessage {
+    ZmqMessage::from(format!("seq:{seq:04}"))
+}
+
+fn multipart_message(peer: usize, seq: usize, large_frame_len: usize) -> ZmqMessage {
+    let marker = (b'a' + peer as u8) as char;
+    let large = std::iter::repeat(marker)
+        .take(large_frame_len)
+        .collect::<String>();
+
+    ZmqMessage::try_from(vec![
+        Bytes::from(format!("peer:{peer}")),
+        Bytes::from(format!("seq:{seq:04}")),
+        Bytes::from(large),
+        Bytes::from(format!("end:{peer}:{seq:04}")),
+    ])
+    .unwrap()
+}
+
+fn assert_multipart_message(
+    message: ZmqMessage,
+    next_by_peer: &mut BTreeMap<usize, usize>,
+    large_frame_len: usize,
+) {
+    assert_eq!(message.len(), 4, "multipart message frame count changed");
+
+    let peer_text = frame_text(&message, 0);
+    let peer = peer_text
+        .strip_prefix("peer:")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+    let seq = parse_seq(frame_text(&message, 1));
+    let expected_seq = next_by_peer
+        .get_mut(&peer)
+        .unwrap_or_else(|| panic!("unexpected peer {peer}"));
+
+    assert_eq!(
+        seq, *expected_seq,
+        "peer {peer} message order changed or a message was dropped"
+    );
+
+    let payload = message.get(2).unwrap();
+    assert_eq!(payload.len(), large_frame_len, "large frame length changed");
+    assert!(
+        payload.iter().all(|byte| *byte == b'a' + peer as u8),
+        "large frame payload was corrupted for peer {peer}, seq {seq}"
+    );
+    assert_eq!(frame_text(&message, 3), format!("end:{peer}:{seq:04}"));
+
+    *expected_seq += 1;
+}
+
+fn parse_seq(frame: String) -> usize {
+    frame.strip_prefix("seq:").unwrap().parse().unwrap()
+}
+
+fn frame_text(message: &ZmqMessage, index: usize) -> String {
+    String::from_utf8(message.get(index).unwrap().to_vec()).unwrap()
+}

--- a/tests/recv_cancel_safety.rs
+++ b/tests/recv_cancel_safety.rs
@@ -198,9 +198,7 @@ fn single_frame(seq: usize) -> ZmqMessage {
 
 fn multipart_message(peer: usize, seq: usize, large_frame_len: usize) -> ZmqMessage {
     let marker = (b'a' + peer as u8) as char;
-    let large = std::iter::repeat(marker)
-        .take(large_frame_len)
-        .collect::<String>();
+    let large = std::iter::repeat_n(marker, large_frame_len).collect::<String>();
 
     ZmqMessage::try_from(vec![
         Bytes::from(format!("peer:{peer}")),


### PR DESCRIPTION
Fix a real REQ cancel-safety bug and add stress coverage for canceled receives.

## What changed

- Preserved `ReqSocket::current_request` across a canceled or timed-out
  `recv()` so a pending reply remains available to the next receive call.
- Added `tests/recv_cancel_safety.rs` covering:
  - REQ receive timeout followed by successful receive of the same reply;
  - single-peer PULL timeout storms preserving message order;
  - multi-peer multipart PULL cancellation preserving per-peer ordering and
    large-frame integrity.
- Added FairQueue regression coverage for dropping a pending `next()` future
  without losing the queued stream item.
- Tolerated timeout expiry exactly at the test deadline in
  `tests/push_pull_timeout.rs` while preserving progress assertions.

## Validation

- `cargo test`
- `cargo test --features tokio-runtime --test recv_cancel_safety`
- `cargo test --features tokio-runtime --test req_rep`
- `cargo test --features tokio-runtime --test req_rep_compliant`
- `cargo test --features tokio-runtime --test push_pull_timeout`
- `cargo test --features tokio-runtime fair_queue`
- Single-runtime compile checks for Tokio and async-std
- `git diff --check origin/master...HEAD`

## Status

CI is green. Audit found no correctness blocker. Remaining risk is limited to
the usual timing sensitivity of async stress tests.
