### PR TITLE
Borrow outbound messages during ZMTP encoding

### DIFF
--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -25,6 +25,7 @@ fn bench_encode(c: &mut Criterion) {
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);
+            let message = Message::Message(m);
             let total_bytes = (frames * size) as u64;
             group.throughput(Throughput::Bytes(total_bytes));
             group.bench_with_input(
@@ -34,9 +35,7 @@ fn bench_encode(c: &mut Criterion) {
                     b.iter(|| {
                         let mut codec = ZmqCodec::new();
                         let mut dst = BytesMut::with_capacity(total_bytes as usize + 64);
-                        codec
-                            .encode(Message::Message(m.clone()), &mut dst)
-                            .expect("encode");
+                        codec.encode(&message, &mut dst).expect("encode");
                         black_box(dst);
                     });
                 },
@@ -54,8 +53,9 @@ fn bench_decode(c: &mut Criterion) {
             let total_bytes = (frames * size) as u64;
 
             let mut encoded = BytesMut::new();
+            let message = Message::Message(m);
             ZmqCodec::new()
-                .encode(Message::Message(m), &mut encoded)
+                .encode(&message, &mut encoded)
                 .expect("encode for decode bench");
             let encoded = encoded.freeze();
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -92,7 +92,7 @@ impl GenericSocketBackend {
                 },
             };
             let send_result = match self.peers.get_async(&next_peer_id).await {
-                Some(mut peer) => peer.send_queue.send(message).await,
+                Some(mut peer) => peer.send_queue.send(&message).await,
                 None => continue,
             };
             return match send_result {

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -143,12 +143,12 @@ fn encode_frame(frame: &Bytes, dst: &mut BytesMut, more: bool) {
 
 impl Encoder for ZmqCodec {
     type Error = CodecError;
-    type Item<'a> = Message;
+    type Item<'a> = &'a Message;
 
     fn encode(&mut self, message: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         match message {
-            Message::Greeting(payload) => dst.unsplit(payload.into()),
-            Message::Command(command) => dst.unsplit(command.into()),
+            Message::Greeting(payload) => dst.unsplit((*payload).into()),
+            Message::Command(command) => dst.unsplit(command.clone().into()),
             Message::Message(message) => {
                 let last_element = message.len() - 1;
                 for (idx, part) in message.iter().enumerate() {

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -174,13 +174,9 @@ impl SocketSend for PubSocket {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -135,7 +135,8 @@ impl SocketSend for RepSocket {
                     if let Some(envelope) = self.envelope.take() {
                         message.prepend(&envelope);
                     }
-                    peer.send_queue.send(Message::Message(message)).await?;
+                    let outbound = Message::Message(message);
+                    peer.send_queue.send(&outbound).await?;
                     Ok(())
                 } else {
                     Err(ZmqError::ReturnToSender {

--- a/src/req.rs
+++ b/src/req.rs
@@ -60,7 +60,8 @@ impl SocketSend for ReqSocket {
             if let Some(mut peer) = self.backend.peers.get_async(&next_peer_id).await {
                 self.backend.round_robin.push(next_peer_id.clone());
                 message.push_front(Bytes::new());
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 self.current_request = Some(next_peer_id);
                 return Ok(());
             }

--- a/src/router.rs
+++ b/src/router.rs
@@ -107,7 +107,8 @@ impl SocketSend for RouterSocket {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),
@@ -182,7 +183,8 @@ impl SocketSend for RouterSendHalf {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.inner.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -164,13 +164,9 @@ impl SubSocketBackend {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {
@@ -217,13 +213,9 @@ impl SubSocketBackend {
 
         let mut dead_peers = Vec::new();
         let mut first_error = None;
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let result = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let result = send_queue.lock().await.as_mut().send(&outbound).await;
             match result {
                 Ok(()) => {}
                 Err(e)
@@ -283,7 +275,8 @@ impl MultiPeerBackend for SubSocketBackend {
         let (recv_queue, mut send_queue) = io.into_parts();
 
         for message in self.subscription_messages() {
-            if let Err(e) = send_queue.send(Message::Message(message)).await {
+            let outbound = Message::Message(message);
+            if let Err(e) = send_queue.send(&outbound).await {
                 log::error!("Failed to send subscription to peer {:?}: {:?}", peer_id, e);
                 return;
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -134,10 +134,8 @@ fn negotiate_version(greeting: Message) -> ZmqResult<ZmtpVersion> {
 }
 
 pub(crate) async fn greet_exchange(raw_socket: &mut FramedIo) -> ZmqResult<ZmtpVersion> {
-    raw_socket
-        .write_half
-        .send(Message::Greeting(ZmqGreeting::default()))
-        .await?;
+    let greeting = Message::Greeting(ZmqGreeting::default());
+    raw_socket.write_half.send(&greeting).await?;
 
     let greeting = match raw_socket.read_half.next().await {
         Some(message) => message?,
@@ -155,7 +153,8 @@ pub(crate) async fn ready_exchange(
     if let Some(props) = props {
         ready.add_properties(props);
     }
-    raw_socket.write_half.send(Message::Command(ready)).await?;
+    let ready = Message::Command(ready);
+    raw_socket.write_half.send(&ready).await?;
 
     let ready_repl: Option<CodecResult<Message>> = raw_socket.read_half.next().await;
     match ready_repl {

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -148,13 +148,9 @@ impl SocketSend for XPubSocket {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {

--- a/tests/send_multipart_large.rs
+++ b/tests/send_multipart_large.rs
@@ -1,0 +1,77 @@
+use bytes::Bytes;
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{Endpoint, ZmqMessage};
+
+use std::time::Duration;
+
+fn tcp_endpoint(endpoint: Endpoint) -> String {
+    match endpoint {
+        Endpoint::Tcp(_, port) => format!("tcp://127.0.0.1:{port}"),
+        _ => unreachable!("expected tcp endpoint"),
+    }
+}
+
+#[async_rt::test]
+async fn push_pull_delivers_large_multipart_message() {
+    let topic = Bytes::from_static(b"topic");
+    let large = Bytes::from(vec![0xAB; 300_000]);
+    let tail = Bytes::from(vec![0xCD; 4_096]);
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = tcp_endpoint(pull.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let message = ZmqMessage::try_from(vec![topic.clone(), large.clone(), tail.clone()]).unwrap();
+    push.send(message).await.unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("timeout waiting for PUSH/PULL multipart message")
+        .unwrap();
+    assert_eq!(received.len(), 3);
+    assert_eq!(received.get(0), Some(&topic));
+    assert_eq!(received.get(1), Some(&large));
+    assert_eq!(received.get(2), Some(&tail));
+}
+
+#[async_rt::test]
+async fn dealer_router_roundtrips_large_multipart_message() {
+    let header = Bytes::from_static(b"header");
+    let large = Bytes::from(vec![0xEF; 300_000]);
+    let tail = Bytes::from(vec![0x42; 4_096]);
+
+    let mut router = zeromq::RouterSocket::new();
+    let endpoint = tcp_endpoint(router.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut dealer = zeromq::DealerSocket::new();
+    dealer.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let message = ZmqMessage::try_from(vec![header.clone(), large.clone(), tail.clone()]).unwrap();
+    dealer.send(message).await.unwrap();
+
+    let routed = async_rt::task::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .expect("timeout waiting for DEALER/ROUTER multipart message")
+        .unwrap();
+    assert_eq!(routed.len(), 4);
+    assert!(!routed.get(0).unwrap().is_empty());
+    assert_eq!(routed.get(1), Some(&header));
+    assert_eq!(routed.get(2), Some(&large));
+    assert_eq!(routed.get(3), Some(&tail));
+
+    router.send(routed).await.unwrap();
+
+    let echoed = async_rt::task::timeout(Duration::from_secs(2), dealer.recv())
+        .await
+        .expect("timeout waiting for ROUTER/DEALER multipart echo")
+        .unwrap();
+    assert_eq!(echoed.len(), 3);
+    assert_eq!(echoed.get(0), Some(&header));
+    assert_eq!(echoed.get(1), Some(&large));
+    assert_eq!(echoed.get(2), Some(&tail));
+}


### PR DESCRIPTION
Reduce internal outbound message cloning by encoding borrowed messages.

## What changed

- Changed internal ZMTP codec encoding to borrow `Message` values.
- Updated send, handshake, ROUTER, PUB/XPUB, and SUB/XSUB fanout call sites to
  pass borrowed outbound messages where possible.
- Kept public socket APIs unchanged.
- Added large multipart PUSH/PULL and DEALER/ROUTER send coverage.

This is clone/refcount reduction only. Payload bytes are still copied into the
contiguous encode buffer; gather-write/writev is separate follow-up work.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all --all-targets -- --deny warnings`
- `cargo clippy --all --all-targets --no-default-features --features async-std-runtime,all-transport,async-dispatcher-macros -- --deny warnings`
- `cargo test --test send_multipart_large`
- `cargo test --lib`
- CI-style runtime `cargo test --all` variants during audit
- `cargo bench --no-run`

## Benchmark snapshot

Locked targeted Tokio/TCP runs:

- Baseline: `send-clone-before-targeted-20260514T215829Z`
- Candidate: `send-clone-after-targeted-20260514T215829Z`

The targeted slice showed mixed but promising wins, including a large
DEALER/ROUTER 4096B throughput improvement in that run. Full TCP+IPC standard
comparison against libzmq and pinned OMQ still needs to be repeated before
making broad performance claims.

## Status

Draft parked behind PR #252's codec-by-reference work. If #252 lands first,
this branch needs a manual rebase and may become partially redundant.
