### PR TITLE
Reduce PUB/XPUB fanout lock pressure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod fair_queue;
 mod message;
 mod r#pub;
+mod pub_fanout;
 mod pull;
 mod push;
 mod reconnect;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -2,6 +2,9 @@ use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::message::*;
+use crate::pub_fanout::{
+    subscription_change, FanoutEvent, FanoutEventReceiver, FanoutEventSender, FanoutState,
+};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{async_rt, CaptureSocket, SocketOptions};
@@ -9,64 +12,53 @@ use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, So
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
-use futures::lock::Mutex as AsyncMutex;
-use futures::{select, FutureExt, SinkExt, StreamExt};
+use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) struct Subscriber {
-    pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+pub(crate) struct PubConnection {
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
 pub(crate) struct PubSocketBackend {
-    subscribers: scc::HashMap<PeerIdentity, Subscriber>,
+    connections: scc::HashMap<PeerIdentity, PubConnection>,
+    fanout_events: FanoutEventSender,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
 }
 
 impl PubSocketBackend {
     fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let data = match message {
-            Message::Message(m) => {
-                if m.len() != 1 {
-                    log::warn!("Received message with unexpected length: {}", m.len());
-                    return;
-                }
-                m.into_vec().pop().unwrap_or_default()
-            }
+        let message = match message {
+            Message::Message(m) => m,
             _ => return,
         };
 
-        if data.is_empty() {
+        if let Some(change) = subscription_change(&message) {
+            let _ = self
+                .fanout_events
+                .unbounded_send(FanoutEvent::Subscription {
+                    peer_id: peer_id.clone(),
+                    change,
+                });
             return;
         }
 
-        match data.first() {
-            Some(1) => {
-                // Subscribe
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    entry.subscriptions.push(Vec::from(&data[1..]));
-                }
-            }
-            Some(0) => {
-                // Unsubscribe
-                let sub = Vec::from(&data[1..]);
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    if let Some(index) = entry.subscriptions.iter().position(|s| s == &sub) {
-                        entry.subscriptions.remove(index);
-                    }
-                }
-            }
-            _ => log::warn!(
+        if message.len() != 1 {
+            log::warn!("Received message with unexpected length: {}", message.len());
+            return;
+        }
+
+        let Some(frame) = message.get(0) else {
+            return;
+        };
+        if !frame.is_empty() {
+            log::warn!(
                 "Received message with unexpected first byte: {:?}",
-                data.first()
-            ),
+                frame.first()
+            );
         }
     }
 }
@@ -81,7 +73,7 @@ impl SocketBackend for PubSocketBackend {
     }
 
     fn shutdown(&self) {
-        self.subscribers.clear_sync();
+        self.connections.clear_sync();
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -93,18 +85,28 @@ impl SocketBackend for PubSocketBackend {
 impl MultiPeerBackend for PubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (mut recv_queue, send_queue) = io.into_parts();
-        // TODO provide handling for recv_queue
         let (sender, stop_receiver) = oneshot::channel();
-        self.subscribers
+        self.connections
             .upsert_async(
                 peer_id.clone(),
-                Subscriber {
-                    subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                PubConnection {
                     _subscription_coro_stop: sender,
                 },
             )
             .await;
+
+        if self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerConnected {
+                peer_id: peer_id.clone(),
+                send_queue,
+            })
+            .is_err()
+        {
+            self.connections.remove_sync(peer_id);
+            return;
+        }
+
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -139,12 +141,17 @@ impl MultiPeerBackend for PubSocketBackend {
         if let Some(monitor) = self.monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
         }
-        self.subscribers.remove_sync(peer_id);
+        self.connections.remove_sync(peer_id);
+        let _ = self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerDisconnected(peer_id.clone()));
     }
 }
 
 pub struct PubSocket {
     pub(crate) backend: Arc<PubSocketBackend>,
+    fanout_state: FanoutState,
+    fanout_events: FanoutEventReceiver,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -157,45 +164,17 @@ impl Drop for PubSocket {
 #[async_trait]
 impl SocketSend for PubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         let first_frame = match message.get(0) {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
-        }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
+        let dead_peers = self
+            .fanout_state
+            .send_matching(first_frame, &message)
+            .await?;
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);
         }
@@ -208,12 +187,16 @@ impl CaptureSocket for PubSocket {}
 #[async_trait]
 impl Socket for PubSocket {
     fn with_options(options: SocketOptions) -> Self {
+        let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         Self {
             backend: Arc::new(PubSocketBackend {
-                subscribers: scc::HashMap::new(),
+                connections: scc::HashMap::new(),
+                fanout_events: fanout_event_sender,
                 socket_monitor: Mutex::new(None),
                 socket_options: options,
             }),
+            fanout_state: FanoutState::default(),
+            fanout_events,
             binds: HashMap::new(),
         }
     }

--- a/src/pub_fanout.rs
+++ b/src/pub_fanout.rs
@@ -1,0 +1,201 @@
+use crate::codec::{CodecError, Message, ZmqFramedWrite};
+use crate::error::ZmqResult;
+use crate::message::ZmqMessage;
+use crate::util::PeerIdentity;
+
+use futures::channel::mpsc;
+use futures::SinkExt;
+
+use std::collections::HashMap;
+use std::io::ErrorKind;
+
+pub(crate) type FanoutEventSender = mpsc::UnboundedSender<FanoutEvent>;
+pub(crate) type FanoutEventReceiver = mpsc::UnboundedReceiver<FanoutEvent>;
+
+pub(crate) enum SubscriptionChange {
+    Subscribe(Vec<u8>),
+    Unsubscribe(Vec<u8>),
+}
+
+pub(crate) enum FanoutEvent {
+    PeerConnected {
+        peer_id: PeerIdentity,
+        send_queue: ZmqFramedWrite,
+    },
+    Subscription {
+        peer_id: PeerIdentity,
+        change: SubscriptionChange,
+    },
+    PeerDisconnected(PeerIdentity),
+}
+
+struct FanoutPeer {
+    subscriptions: Vec<Vec<u8>>,
+    send_queue: ZmqFramedWrite,
+}
+
+impl FanoutPeer {
+    fn is_subscribed_to(&self, first_frame: &[u8]) -> bool {
+        self.subscriptions.iter().any(|sub_filter| {
+            sub_filter.len() <= first_frame.len()
+                && sub_filter.as_slice() == &first_frame[..sub_filter.len()]
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct FanoutState {
+    peers: HashMap<PeerIdentity, FanoutPeer>,
+}
+
+impl FanoutState {
+    pub(crate) fn drain_events(&mut self, events: &mut FanoutEventReceiver) {
+        while let Ok(event) = events.try_recv() {
+            self.apply_event(event);
+        }
+    }
+
+    pub(crate) fn apply_event(&mut self, event: FanoutEvent) {
+        match event {
+            FanoutEvent::PeerConnected {
+                peer_id,
+                send_queue,
+            } => self.peer_connected(peer_id, send_queue),
+            FanoutEvent::Subscription { peer_id, change } => {
+                self.apply_subscription(&peer_id, change);
+            }
+            FanoutEvent::PeerDisconnected(peer_id) => self.peer_disconnected(&peer_id),
+        }
+    }
+
+    pub(crate) fn peer_connected(&mut self, peer_id: PeerIdentity, send_queue: ZmqFramedWrite) {
+        self.peers.insert(
+            peer_id,
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue,
+            },
+        );
+    }
+
+    pub(crate) fn peer_disconnected(&mut self, peer_id: &PeerIdentity) {
+        self.peers.remove(peer_id);
+    }
+
+    pub(crate) fn apply_subscription(
+        &mut self,
+        peer_id: &PeerIdentity,
+        change: SubscriptionChange,
+    ) {
+        let Some(peer) = self.peers.get_mut(peer_id) else {
+            return;
+        };
+
+        match change {
+            SubscriptionChange::Subscribe(subscription) => {
+                peer.subscriptions.push(subscription);
+            }
+            SubscriptionChange::Unsubscribe(subscription) => {
+                if let Some(index) = peer
+                    .subscriptions
+                    .iter()
+                    .position(|existing| existing == &subscription)
+                {
+                    peer.subscriptions.remove(index);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn send_matching(
+        &mut self,
+        first_frame: &[u8],
+        message: &ZmqMessage,
+    ) -> ZmqResult<Vec<PeerIdentity>> {
+        let mut dead_peers = Vec::new();
+
+        for (peer_id, peer) in self.peers.iter_mut() {
+            if !peer.is_subscribed_to(first_frame) {
+                continue;
+            }
+
+            let res = peer
+                .send_queue
+                .send(Message::Message(message.clone()))
+                .await;
+            match res {
+                Ok(()) => {}
+                Err(CodecError::Io(e)) => {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        dead_peers.push(peer_id.clone());
+                    } else {
+                        log::error!("Error sending message: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                    return Err(e.into());
+                }
+            }
+        }
+
+        for peer_id in &dead_peers {
+            self.peers.remove(peer_id);
+        }
+
+        Ok(dead_peers)
+    }
+}
+
+pub(crate) fn subscription_change(message: &ZmqMessage) -> Option<SubscriptionChange> {
+    let frame = message.get(0)?;
+    if message.len() != 1 || frame.is_empty() {
+        return None;
+    }
+
+    match frame[0] {
+        1 => Some(SubscriptionChange::Subscribe(frame[1..].to_vec())),
+        0 => Some(SubscriptionChange::Unsubscribe(frame[1..].to_vec())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{FrameableWrite, ZmqCodec};
+
+    use asynchronous_codec::FramedWrite;
+
+    #[test]
+    fn duplicate_subscription_requires_matching_unsubscribe_events() {
+        let mut state = FanoutState::default();
+        let peer_id = PeerIdentity::new();
+        state.peers.insert(
+            peer_id.clone(),
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue: sink_write(),
+            },
+        );
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-subscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-one-unsubscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(!peer.is_subscribed_to(b"dup-after-two-unsubscribes"));
+    }
+
+    fn sink_write() -> ZmqFramedWrite {
+        let writer: Box<dyn FrameableWrite> = Box::new(futures::io::sink());
+        FramedWrite::new(writer, ZmqCodec::new())
+    }
+}

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -3,6 +3,9 @@ use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::{FairQueue, QueueInner};
 use crate::message::*;
+use crate::pub_fanout::{
+    subscription_change, FanoutEvent, FanoutEventReceiver, FanoutEventSender, FanoutState,
+};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{CaptureSocket, SocketOptions};
@@ -13,62 +16,17 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::lock::Mutex as AsyncMutex;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) struct XPubSubscriber {
-    pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
-}
-
 pub(crate) struct XPubSocketBackend {
-    subscribers: scc::HashMap<PeerIdentity, XPubSubscriber>,
+    fanout_events: FanoutEventSender,
     fair_queue_inner: Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
-}
-
-impl XPubSocketBackend {
-    fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let data = match message {
-            Message::Message(m) => {
-                if m.len() != 1 {
-                    return;
-                }
-                m.into_vec().pop().unwrap_or_default()
-            }
-            _ => return,
-        };
-
-        if data.is_empty() {
-            return;
-        }
-
-        match data.first() {
-            Some(1) => {
-                // Subscribe
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    entry.subscriptions.push(Vec::from(&data[1..]));
-                }
-            }
-            Some(0) => {
-                // Unsubscribe
-                let sub = Vec::from(&data[1..]);
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    if let Some(index) = entry.subscriptions.iter().position(|s| s == &sub) {
-                        entry.subscriptions.remove(index);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
 }
 
 impl SocketBackend for XPubSocketBackend {
@@ -81,7 +39,7 @@ impl SocketBackend for XPubSocketBackend {
     }
 
     fn shutdown(&self) {
-        self.subscribers.clear_sync();
+        self.fair_queue_inner.lock().clear();
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -94,15 +52,16 @@ impl MultiPeerBackend for XPubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
 
-        self.subscribers
-            .upsert_async(
-                peer_id.clone(),
-                XPubSubscriber {
-                    subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
-                },
-            )
-            .await;
+        if self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerConnected {
+                peer_id: peer_id.clone(),
+                send_queue,
+            })
+            .is_err()
+        {
+            return;
+        }
 
         self.fair_queue_inner
             .lock()
@@ -111,14 +70,18 @@ impl MultiPeerBackend for XPubSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         log::info!("Client disconnected {:?}", peer_id);
-        self.subscribers.remove_sync(peer_id);
         self.fair_queue_inner.lock().remove(peer_id);
+        let _ = self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerDisconnected(peer_id.clone()));
     }
 }
 
 pub struct XPubSocket {
     pub(crate) backend: Arc<XPubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
+    fanout_state: FanoutState,
+    fanout_events: FanoutEventReceiver,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -131,45 +94,17 @@ impl Drop for XPubSocket {
 #[async_trait]
 impl SocketSend for XPubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         let first_frame = match message.get(0) {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
-        }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
+        let dead_peers = self
+            .fanout_state
+            .send_matching(first_frame, &message)
+            .await?;
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);
         }
@@ -180,19 +115,22 @@ impl SocketSend for XPubSocket {
 #[async_trait]
 impl SocketRecv for XPubSocket {
     async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         loop {
             match self.fair_queue.next().await {
                 Some((peer_id, Ok(Message::Message(message)))) => {
-                    // Process the subscription message internally to update tracking
-                    self.backend
-                        .message_received(&peer_id, Message::Message(message.clone()));
-                    // Also expose it to the application
+                    self.fanout_state.drain_events(&mut self.fanout_events);
+                    if let Some(change) = subscription_change(&message) {
+                        self.fanout_state.apply_subscription(&peer_id, change);
+                    }
                     return Ok(message);
                 }
                 Some((_peer_id, Ok(_msg))) => {
                     // Ignore non-message frames
                 }
                 Some((peer_id, Err(e))) => {
+                    self.fanout_state.peer_disconnected(&peer_id);
                     self.backend.peer_disconnected(&peer_id);
                     return Err(e.into());
                 }
@@ -210,8 +148,9 @@ impl CaptureSocket for XPubSocket {}
 impl Socket for XPubSocket {
     fn with_options(options: SocketOptions) -> Self {
         let mut fair_queue = FairQueue::new(true);
+        let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         let backend = Arc::new(XPubSocketBackend {
-            subscribers: scc::HashMap::new(),
+            fanout_events: fanout_event_sender,
             fair_queue_inner: fair_queue.inner(),
             socket_monitor: Mutex::new(None),
             socket_options: options,
@@ -227,6 +166,8 @@ impl Socket for XPubSocket {
         Self {
             backend,
             fair_queue,
+            fanout_state: FanoutState::default(),
+            fanout_events,
             binds: HashMap::new(),
         }
     }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -9,6 +9,130 @@ mod test {
     use futures::{SinkExt, StreamExt};
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
+    async fn wait_for_delivery(
+        pub_socket: &mut zeromq::PubSocket,
+        sub_socket: &mut zeromq::SubSocket,
+        payload: &str,
+    ) {
+        for _ in 0..200 {
+            pub_socket
+                .send(ZmqMessage::from(payload))
+                .await
+                .expect("failed to send sync payload");
+            match async_rt::task::timeout(Duration::from_millis(10), sub_socket.recv()).await {
+                Ok(Ok(message)) if message.get(0).unwrap().as_ref() == payload.as_bytes() => {
+                    return;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => panic!("failed to receive sync payload: {e:?}"),
+                Err(_) => async_rt::task::sleep(Duration::from_millis(5)).await,
+            }
+        }
+        panic!("timed out waiting for subscription to receive {payload}");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+        wait_for_delivery(&mut pub_socket, &mut early_sub, "early-sync").await;
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+        wait_for_delivery(&mut pub_socket, &mut late_sub, "late-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        pub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_unsubscribe_stops_delivery_after_later_subscription() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "gone-sync").await;
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "stay-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        pub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
+    }
+
     #[async_rt::test]
     async fn test_pub_sub_sockets() {
         pretty_env_logger::try_init().ok();

--- a/tests/xpub_sub.rs
+++ b/tests/xpub_sub.rs
@@ -6,6 +6,14 @@ mod test {
 
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
     #[async_rt::test]
     async fn test_xpub_basic_pubsub() {
         pretty_env_logger::try_init().ok();
@@ -181,5 +189,130 @@ mod test {
         // SUB should only receive "topic1-message"
         let received = sub_handle.await.expect("SUB task failed");
         assert_eq!(received, "topic1-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+
+        let early_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for early subscription")
+            .expect("Failed to receive early subscription");
+        assert_eq!(early_sub_msg.get(0).unwrap().as_ref(), b"\x01early");
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+
+        let late_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for late subscription")
+            .expect("Failed to receive late subscription");
+        assert_eq!(late_sub_msg.get(0).unwrap().as_ref(), b"\x01late");
+
+        xpub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        xpub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_unsubscribe_updates_fanout_state() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+
+        let sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for subscription")
+            .expect("Failed to receive subscription");
+        assert_eq!(sub_msg.get(0).unwrap().as_ref(), b"\x01gone");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-before-unsubscribe"))
+            .await
+            .expect("Failed to send subscribed message");
+        assert_eq!(recv_text(&mut sub_socket).await, "gone-before-unsubscribe");
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        let unsub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for unsubscribe")
+            .expect("Failed to receive unsubscribe");
+        assert_eq!(unsub_msg.get(0).unwrap().as_ref(), b"\x00gone");
+
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        let replacement_sub = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for replacement subscription")
+            .expect("Failed to receive replacement subscription");
+        assert_eq!(replacement_sub.get(0).unwrap().as_ref(), b"\x01stay");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        xpub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
     }
 }


### PR DESCRIPTION
Move PUB/XPUB fanout connection and subscription state into socket-owned
`FanoutState` updated by backend events. This removes steady-state
per-subscriber backend map lookups and async writer mutex acquisition from
fanout sends while preserving subscription, unsubscribe, late-subscriber, and
XPUB visibility semantics.

## What changed

- Added socket-owned fanout state for PUB/XPUB send paths.
- Delivered backend connection, subscription, and disconnect events to the
  socket before fanout sends and XPUB receives.
- Preserved duplicate subscribe/unsubscribe behavior and late-subscriber
  filtering rules.
- Added coverage for PUB/SUB and XPUB/XSUB fanout behavior.

## Validation

Local lane validation:

- `cargo check --all-targets`
- `cargo test --test pub_sub -- --nocapture`
- `cargo test --test xpub_sub -- --nocapture`
- `cargo test --test xsub_xpub -- --nocapture`
- `cargo test --tests`

## Benchmark snapshot

Locked quick Criterion PUB fanout runs with `tokio-runtime`, sample size 10,
1s measurement, 0.5s warmup showed improvements on the targeted
multi-subscriber cases:

| transport | subscribers | 256B | 4096B |
| --- | ---: | ---: | ---: |
| tcp | 1 | +8.5% | +11.5% |
| tcp | 8 | +8.3% | +6.4% |
| tcp | 64 | +5.7% | +5.2% |
| ipc | 1 | +4.3% | +0.1% |
| ipc | 8 | +17.1% | +13.3% |
| ipc | 64 | +18.1% | +10.9% |

CI is green. This remains a draft performance PR until maintainers review the
fanout state ownership changes and the locked benchmark evidence.
