### PR TITLE
Define Sans-I/O ZMTP frame boundary

### DIFF
--- a/docs/PERFORMANCE_ROADMAP.md
+++ b/docs/PERFORMANCE_ROADMAP.md
@@ -53,6 +53,7 @@ configuration does not leak into the external benchmark build.
      runtime policy work.
    - Correctness checks: protocol fixture tests, greeting/mechanism tests,
      interop with libzmq, and no public socket API changes.
+   - Boundary note: [`SANS_IO_ZMTP_BOUNDARY.md`](SANS_IO_ZMTP_BOUNDARY.md).
 
 5. Gather-write and `writev` large-frame path
    - Goal: send multipart and large frames with vectored writes where the

--- a/docs/SANS_IO_ZMTP_BOUNDARY.md
+++ b/docs/SANS_IO_ZMTP_BOUNDARY.md
@@ -1,0 +1,125 @@
+# Sans-I/O ZMTP Boundary
+
+This note scopes work package 4 from the performance roadmap: separate ZMTP
+protocol parsing, framing, and handshake state from runtime I/O while keeping
+Tokio as the first-class transport path.
+
+## Current Ownership Map
+
+- `src/transport/mod.rs`, `src/transport/tcp.rs`, and `src/transport/ipc.rs`
+  own runtime-specific stream creation. Tokio streams are split and adapted
+  through `tokio_util::compat`; async-std streams are split directly.
+- `src/codec/framed.rs` boxes async read/write halves as `FrameableRead` and
+  `FrameableWrite`, then couples both halves to `asynchronous_codec` through
+  `FramedIo`.
+- `src/codec/zmq_codec.rs` owns streaming parse state: greeting bytes, frame
+  flags, frame length, payload body, and multipart accumulation.
+- `src/codec/greeting.rs`, `src/codec/mechanism.rs`, and
+  `src/codec/command.rs` parse or serialize protocol values. Before this lane,
+  command serialization also owned its command-frame prefix.
+- `src/util.rs` owns connection protocol state above framing: greeting exchange,
+  version negotiation, READY exchange, socket compatibility, and peer identity.
+- Socket backends own post-handshake state: peer tables, fair-queue streams,
+  subscription state, reconnection notifiers, and monitor events.
+
+The current shape is correct for the public API, but protocol state and runtime
+I/O are interleaved enough that writev, receive-copy reduction, and runtime
+policy changes have to reason through `FramedIo` and socket backends at the same
+time.
+
+## Minimal Boundary
+
+The minimal Sans-I/O boundary should sit below socket backends and above runtime
+transports:
+
+```text
+runtime transport <-> async adapter <-> Sans-I/O ZMTP core <-> socket backend
+```
+
+The core should own only deterministic protocol work:
+
+- Greeting encode/decode and version choice.
+- Frame flag and length parsing.
+- Command payload parse/encode.
+- Multipart assembly and message emission.
+- Handshake sequencing for Greeting and READY as a pure state machine.
+
+Runtime adapters should own:
+
+- Tokio, async-std, and any future runtime-specific stream types.
+- Read readiness, write readiness, cancellation policy, and timeout policy.
+- Buffer ownership around syscalls, including vectored writes.
+- Conversion between protocol actions and `Sink`/`Stream` behavior.
+
+Socket backends should continue to own:
+
+- Public socket semantics.
+- Peer routing, fair queues, subscription filters, reconnect policy, and
+  monitor events.
+
+## Data Crossing The Boundary
+
+Inbound data should cross as caller-owned byte buffers, with the protocol core
+consuming only the bytes that make a complete ZMTP item:
+
+- Input: `BytesMut` or a small cursor over received bytes.
+- Output: a protocol event such as greeting, command, complete message, or
+  "need N more bytes".
+- Payload ownership: `Bytes` slices split from the input buffer so complete
+  message frames do not copy.
+
+Outbound data should cross as owned protocol values plus an encode plan:
+
+- Input: `ZmqGreeting`, `ZmqCommand`, or `ZmqMessage`.
+- Output today: bytes appended to `BytesMut`.
+- Output target: a stable frame plan containing small header bytes and borrowed
+  or cloned `Bytes` payloads. Tokio adapters can turn that plan into `writev`
+  without changing socket APIs.
+
+Handshake state should cross as actions instead of I/O:
+
+- Input: local `SocketType`, local identity option, and incoming protocol
+  events.
+- Output: send greeting, send READY, accept peer identity, reject incompatible
+  peer, or close.
+
+## Migration Steps
+
+1. Keep `FramedIo` and the public socket API unchanged.
+2. Extract frame header and prefix handling into a private Sans-I/O helper with
+   fixture tests. This lane starts that extraction in `src/codec/zmtp_frame.rs`.
+3. Move command payload encoding behind the same frame helper so command and
+   data frames share one flag/length implementation.
+4. Make `ZmqCodec` delegate greeting, frame, command, and multipart decisions to
+   a core state object while remaining the async-codec adapter.
+5. Extract greeting and READY sequencing from `util.rs` into a pure
+   `ZmtpSession` state machine, then let `util.rs` drive it over `FramedIo`.
+6. Add a write-plan API inside the crate. Tokio remains the first optimized
+   adapter, with async-std preserving the same protocol behavior.
+7. Add receive-copy tests around partial frames, multipart cancellation, and
+   buffer reuse before changing receive ownership.
+
+## Correctness Fixtures
+
+The first fixtures are byte-level tests for ZMTP frame flags and short/long
+length prefixes. Follow-on fixtures should cover:
+
+- 64-byte greeting acceptance and rejection.
+- NULL, PLAIN, and CURVE mechanism parsing.
+- READY command payloads with `Socket-Type` and `Identity`.
+- Multipart frames split across arbitrary input chunks.
+- Bad length, bad command name, and incompatible socket type failures.
+- libzmq interop for greeting/READY and large multipart frames.
+
+## Blockers For Writev And Recv-Copy Work
+
+- `ZmqCodec::encode` still writes each outbound message into one `BytesMut`.
+  Writev needs an internal encode plan that separates frame headers from
+  existing `Bytes` payloads.
+- `ZmqCodec::decode` still owns multipart accumulation. Receive-copy work needs
+  cancellation tests before changing how partial message state is exposed.
+- Handshake sequencing is still async I/O in `util.rs`. Runtime policy work
+  will be safer once a pure state machine emits protocol actions.
+- `FramedIo` currently erases concrete transport halves behind trait objects.
+  Tokio-specific vectored-write support may need an internal fast path while
+  preserving the existing boxed adapter for other runtimes.

--- a/src/codec/command.rs
+++ b/src/codec/command.rs
@@ -1,4 +1,5 @@
 use super::error::CodecError;
+use super::zmtp_frame::ZmtpFrameHeader;
 use crate::SocketType;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -97,18 +98,9 @@ impl From<ZmqCommand> for BytesMut {
             message_len += val.len() + 4;
         }
 
-        let long_message = message_len > 255;
-
-        let mut bytes = BytesMut::new();
-        if long_message {
-            bytes.reserve(message_len + 9);
-            bytes.put_u8(0x06);
-            bytes.put_u64(message_len as u64);
-        } else {
-            bytes.reserve(message_len + 2);
-            bytes.put_u8(0x04);
-            bytes.put_u8(message_len as u8);
-        };
+        let header = ZmtpFrameHeader::for_payload(message_len, true, false);
+        let mut bytes = BytesMut::with_capacity(header.encoded_len(message_len));
+        header.write_prefix(message_len, &mut bytes);
         bytes.put_u8(command_name.len() as u8);
         bytes.extend_from_slice(command_name.as_ref());
         for (prop, val) in command.properties.iter() {

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -7,6 +7,7 @@ mod framed;
 mod greeting;
 pub(crate) mod mechanism;
 mod zmq_codec;
+mod zmtp_frame;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -1,27 +1,21 @@
 use super::command::ZmqCommand;
 use super::error::CodecError;
 use super::greeting::ZmqGreeting;
+use super::zmtp_frame::{encode_payload_frame, ZmtpFrameHeader, GREETING_SIZE};
 use super::Message;
 use crate::ZmqMessage;
 
 use asynchronous_codec::{Decoder, Encoder};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 
 use std::convert::TryFrom;
-
-#[derive(Debug, Clone, Copy)]
-struct Frame {
-    command: bool,
-    long: bool,
-    more: bool,
-}
 
 #[derive(Debug)]
 enum DecoderState {
     Greeting,
     FrameHeader,
-    FrameLen(Frame),
-    Frame(Frame),
+    FrameLen(ZmtpFrameHeader),
+    Frame(ZmtpFrameHeader),
 }
 
 #[derive(Debug)]
@@ -38,7 +32,7 @@ impl ZmqCodec {
     pub fn new() -> Self {
         Self {
             state: DecoderState::Greeting,
-            waiting_for: 64, // len of the greeting frame
+            waiting_for: GREETING_SIZE,
             buffered_message: None,
         }
     }
@@ -67,19 +61,15 @@ impl Decoder for ZmqCodec {
                 self.state = DecoderState::FrameHeader;
                 self.waiting_for = 1;
                 Ok(Some(Message::Greeting(ZmqGreeting::try_from(
-                    src.split_to(64).freeze(),
+                    src.split_to(GREETING_SIZE).freeze(),
                 )?)))
             }
             DecoderState::FrameHeader => {
                 let flags = src.get_u8();
 
-                let frame = Frame {
-                    command: (flags & 0b0000_0100) != 0,
-                    long: (flags & 0b0000_0010) != 0,
-                    more: (flags & 0b0000_0001) != 0,
-                };
+                let frame = ZmtpFrameHeader::from_flags(flags);
                 self.state = DecoderState::FrameLen(frame);
-                self.waiting_for = if frame.long { 8 } else { 1 };
+                self.waiting_for = frame.length_size();
                 self.decode(src)
             }
             DecoderState::FrameLen(frame) => {
@@ -121,24 +111,7 @@ impl Decoder for ZmqCodec {
 }
 
 fn encode_frame(frame: &Bytes, dst: &mut BytesMut, more: bool) {
-    let mut flags: u8 = 0;
-    if more {
-        flags |= 0b0000_0001;
-    }
-    let len = frame.len();
-    if len > 255 {
-        flags |= 0b0000_0010;
-        dst.reserve(len + 9);
-    } else {
-        dst.reserve(len + 2);
-    }
-    dst.put_u8(flags);
-    if len > 255 {
-        dst.put_u64(len as u64);
-    } else {
-        dst.put_u8(len as u8);
-    }
-    dst.extend_from_slice(frame.as_ref());
+    encode_payload_frame(frame, dst, false, more);
 }
 
 impl Encoder for ZmqCodec {

--- a/src/codec/zmtp_frame.rs
+++ b/src/codec/zmtp_frame.rs
@@ -1,0 +1,126 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
+pub(crate) const GREETING_SIZE: usize = 64;
+
+const MORE_FLAG: u8 = 0b0000_0001;
+const LONG_FLAG: u8 = 0b0000_0010;
+const COMMAND_FLAG: u8 = 0b0000_0100;
+const SHORT_FRAME_LIMIT: usize = u8::MAX as usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ZmtpFrameHeader {
+    pub(crate) command: bool,
+    pub(crate) long: bool,
+    pub(crate) more: bool,
+}
+
+impl ZmtpFrameHeader {
+    pub(crate) fn from_flags(flags: u8) -> Self {
+        Self {
+            command: (flags & COMMAND_FLAG) != 0,
+            long: (flags & LONG_FLAG) != 0,
+            more: (flags & MORE_FLAG) != 0,
+        }
+    }
+
+    pub(crate) fn for_payload(payload_len: usize, command: bool, more: bool) -> Self {
+        Self {
+            command,
+            long: payload_len > SHORT_FRAME_LIMIT,
+            more,
+        }
+    }
+
+    pub(crate) const fn length_size(self) -> usize {
+        if self.long {
+            8
+        } else {
+            1
+        }
+    }
+
+    pub(crate) fn encoded_len(self, payload_len: usize) -> usize {
+        1 + self.length_size() + payload_len
+    }
+
+    pub(crate) fn write_prefix(self, payload_len: usize, dst: &mut BytesMut) {
+        debug_assert_eq!(self.long, payload_len > SHORT_FRAME_LIMIT);
+
+        dst.reserve(self.encoded_len(payload_len));
+        dst.put_u8(self.flag_byte());
+        if self.long {
+            dst.put_u64(payload_len as u64);
+        } else {
+            dst.put_u8(payload_len as u8);
+        }
+    }
+
+    const fn flag_byte(self) -> u8 {
+        let mut flags = 0;
+        if self.more {
+            flags |= MORE_FLAG;
+        }
+        if self.long {
+            flags |= LONG_FLAG;
+        }
+        if self.command {
+            flags |= COMMAND_FLAG;
+        }
+        flags
+    }
+}
+
+pub(crate) fn encode_payload_frame(payload: &Bytes, dst: &mut BytesMut, command: bool, more: bool) {
+    let header = ZmtpFrameHeader::for_payload(payload.len(), command, more);
+    header.write_prefix(payload.len(), dst);
+    dst.extend_from_slice(payload.as_ref());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_frame_flag_fixture() {
+        let header = ZmtpFrameHeader::from_flags(COMMAND_FLAG | LONG_FLAG | MORE_FLAG);
+
+        assert!(header.command);
+        assert!(header.long);
+        assert!(header.more);
+        assert_eq!(header.length_size(), 8);
+    }
+
+    #[test]
+    fn encodes_short_data_frame_fixture() {
+        let payload = Bytes::from_static(b"abc");
+        let mut out = BytesMut::new();
+
+        encode_payload_frame(&payload, &mut out, false, true);
+
+        assert_eq!(&out[..], &[MORE_FLAG, 3, b'a', b'b', b'c']);
+    }
+
+    #[test]
+    fn encodes_short_command_frame_fixture() {
+        let mut out = BytesMut::new();
+        let header = ZmtpFrameHeader::for_payload(5, true, false);
+
+        header.write_prefix(5, &mut out);
+        out.extend_from_slice(b"READY");
+
+        assert_eq!(&out[..], &[COMMAND_FLAG, 5, b'R', b'E', b'A', b'D', b'Y']);
+    }
+
+    #[test]
+    fn encodes_long_data_frame_fixture() {
+        let payload = Bytes::from(vec![0xab; 256]);
+        let mut out = BytesMut::new();
+
+        encode_payload_frame(&payload, &mut out, false, false);
+
+        assert_eq!(out[0], LONG_FLAG);
+        assert_eq!(&out[1..9], 256u64.to_be_bytes());
+        assert_eq!(out.len(), 1 + 8 + payload.len());
+        assert!(out[9..].iter().all(|byte| *byte == 0xab));
+    }
+}

--- a/tests/push_pull_timeout.rs
+++ b/tests/push_pull_timeout.rs
@@ -46,7 +46,12 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
             match tokio::time::timeout(remaining, pull.recv()).await {
                 Ok(Ok(_)) => count += 1,
                 Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-                Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+                Err(err) => {
+                    if Instant::now() >= deadline {
+                        break count;
+                    }
+                    panic!("per-call timeout fired after {count} messages: {err:?}");
+                }
             }
         }
     })
@@ -155,7 +160,12 @@ async fn run_issue_248_pull_child(endpoint: &str) {
         match tokio::time::timeout(remaining, socket.recv()).await {
             Ok(Ok(_)) => count += 1,
             Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-            Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                panic!("per-call timeout fired after {count} messages: {err:?}");
+            }
         }
     }
     assert!(


### PR DESCRIPTION
Add a first private ZMTP frame-prefix extraction and document the Sans-I/O
boundary.

## What changed

- Added `docs/SANS_IO_ZMTP_BOUNDARY.md` to map current protocol/framing,
  transport, and socket-state ownership.
- Added private ZMTP frame header/prefix helpers with fixture tests.
- Routed command and data-frame prefix generation through the shared helper.
- Kept the public socket API and transport path unchanged.

This is not a completed Sans-I/O refactor. `ZmqCodec` still owns decode state,
multipart accumulation, and encode buffering.

## Validation

- `cargo test zmtp_frame`
- `cargo test --lib`
- `cargo test --test large_message -- --test-threads=1`
- `cargo test --test req_rep_compliant -- --test-threads=1`
- `cargo test --test router_dealer_compliant -- --test-threads=1`
- `cargo test --test pub_sub_compliant -- --test-threads=1`
- `cargo test --test pub_sub_compliant_reverse -- --test-threads=1`
- `cargo clippy --all --all-targets -- --deny warnings`
- `git diff --check`

## Status

CI is green. This remains draft groundwork for the Sans-I/O boundary rather
than a completed transport or codec refactor.
