### PR TITLE
Batch ZMTP framed reads

### DIFF
--- a/benches/bench_runtime.rs
+++ b/benches/bench_runtime.rs
@@ -24,9 +24,15 @@ impl BenchRuntime {
             }
         }
 
+        #[cfg(all(not(feature = "tokio-runtime"), feature = "async-dispatcher-runtime"))]
+        {
+            async_dispatcher::set_dispatcher(async_dispatcher::thread_dispatcher());
+            Self {}
+        }
+
         #[cfg(all(
-            not(feature = "tokio-runtime"),
-            any(feature = "async-std-runtime", feature = "async-dispatcher-runtime")
+            not(any(feature = "tokio-runtime", feature = "async-dispatcher-runtime")),
+            feature = "async-std-runtime"
         ))]
         {
             Self {}
@@ -43,9 +49,14 @@ impl BenchRuntime {
             self.inner.block_on(future)
         }
 
+        #[cfg(all(not(feature = "tokio-runtime"), feature = "async-dispatcher-runtime"))]
+        {
+            async_dispatcher::block_on(future)
+        }
+
         #[cfg(all(
-            not(feature = "tokio-runtime"),
-            any(feature = "async-std-runtime", feature = "async-dispatcher-runtime")
+            not(any(feature = "tokio-runtime", feature = "async-dispatcher-runtime")),
+            feature = "async-std-runtime"
         ))]
         {
             async_std::task::block_on(future)

--- a/benches/bench_runtime.rs
+++ b/benches/bench_runtime.rs
@@ -15,9 +15,17 @@ impl BenchRuntime {
     pub fn new() -> Self {
         #[cfg(feature = "tokio-runtime")]
         {
+            let worker_threads = std::env::var("ZMQRS_BENCH_TOKIO_WORKERS")
+                .ok()
+                .and_then(|value| value.parse::<usize>().ok())
+                .filter(|&value| value > 0)
+                .unwrap_or_else(|| {
+                    std::thread::available_parallelism().map_or(2, std::num::NonZero::get)
+                });
+
             Self {
                 inner: Builder::new_multi_thread()
-                    .worker_threads(2)
+                    .worker_threads(worker_threads)
                     .enable_all()
                     .build()
                     .expect("tokio runtime"),

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -25,6 +25,7 @@ fn bench_encode(c: &mut Criterion) {
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);
+            let message = Message::Message(m);
             let total_bytes = (frames * size) as u64;
             group.throughput(Throughput::Bytes(total_bytes));
             group.bench_with_input(
@@ -34,9 +35,7 @@ fn bench_encode(c: &mut Criterion) {
                     b.iter(|| {
                         let mut codec = ZmqCodec::new();
                         let mut dst = BytesMut::with_capacity(total_bytes as usize + 64);
-                        codec
-                            .encode(Message::Message(m.clone()), &mut dst)
-                            .expect("encode");
+                        codec.encode(&message, &mut dst).expect("encode");
                         black_box(dst);
                     });
                 },
@@ -54,8 +53,9 @@ fn bench_decode(c: &mut Criterion) {
             let total_bytes = (frames * size) as u64;
 
             let mut encoded = BytesMut::new();
+            let message = Message::Message(m);
             ZmqCodec::new()
-                .encode(Message::Message(m), &mut encoded)
+                .encode(&message, &mut encoded)
                 .expect("encode for decode bench");
             let encoded = encoded.freeze();
 

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -3,6 +3,7 @@
 mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
@@ -10,11 +11,15 @@ use std::thread;
 use std::time::Duration;
 
 use zeromq::{
-    __async_rt::task, prelude::*, DealerSocket, PubSocket, RouterSocket, SubSocket, ZmqMessage,
+    __async_rt::task, prelude::*, DealerSocket, PubSocket, PullSocket, PushSocket, RouterSocket,
+    SubSocket, ZmqMessage,
 };
 
 const BATCH_SIZE: usize = 1024;
+const PUSH_PULL_BATCH_SIZE: usize = 8192;
 const PIPELINE_SIZES: &[usize] = &[256, 4096];
+const PUSH_PULL_SIZES: &[usize] = &[128, 2048, 8192];
+const PEER_COUNTS: &[usize] = &[1, 8];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
 const TRANSPORTS: &[&str] = &["tcp", "ipc"];
 
@@ -231,6 +236,183 @@ fn bench_libzmq_pub_pipelined_one(
     });
 }
 
+fn bench_zmqrs_push_pull_pipelined(c: &mut Criterion) {
+    let rt = build_rt();
+    for &transport in TRANSPORTS {
+        for &peers in PEER_COUNTS {
+            let mut group = c.benchmark_group(format!(
+                "zmqrs/throughput/push_pull/{transport}/peers={peers}"
+            ));
+            bench_runtime::configure_group(&mut group);
+            for &msg_size in PUSH_PULL_SIZES {
+                group.throughput(Throughput::Bytes((PUSH_PULL_BATCH_SIZE * msg_size) as u64));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(msg_size),
+                    &msg_size,
+                    |b, &s| {
+                        bench_zmqrs_push_pull_pipelined_one(b, &rt, peers, s, transport);
+                    },
+                );
+            }
+            group.finish();
+        }
+    }
+}
+
+fn bench_zmqrs_push_pull_pipelined_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    peers: usize,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-pushpull-{peers}-{msg_size}"), transport);
+    let (mut pull, pushes) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull.bind(&endpoint).await.expect("pull bind").to_string();
+        let mut pushes = Vec::with_capacity(peers);
+        for _ in 0..peers {
+            let mut push = PushSocket::new();
+            push.connect(bound.as_str()).await.expect("push connect");
+            pushes.push(push);
+        }
+
+        let sync = ZmqMessage::from(Bytes::from_static(b"sync"));
+        for push in &mut pushes {
+            push.send(sync.clone()).await.expect("push sync");
+        }
+        for _ in 0..peers {
+            black_box(pull.recv().await.expect("pull sync"));
+        }
+        (pull, pushes)
+    });
+
+    let mut pushes = Some(pushes);
+    let payload = Bytes::from(vec![0xCD; msg_size]);
+    b.iter(|| {
+        let mut active_pushes = pushes.take().expect("push sockets");
+        rt.block_on(async {
+            let per_peer = PUSH_PULL_BATCH_SIZE / active_pushes.len();
+            let recv_count = per_peer * active_pushes.len();
+            let send_handles: Vec<_> = active_pushes
+                .drain(..)
+                .map(|mut push| {
+                    let payload = payload.clone();
+                    task::spawn(async move {
+                        for _ in 0..per_peer {
+                            push.send(ZmqMessage::from(payload.clone()))
+                                .await
+                                .expect("push send");
+                        }
+                        push
+                    })
+                })
+                .collect();
+
+            for _ in 0..recv_count {
+                black_box(pull.recv().await.expect("pull recv"));
+            }
+
+            let mut returned_pushes = Vec::with_capacity(send_handles.len());
+            for h in send_handles {
+                returned_pushes.push(h.await.expect("push task"));
+            }
+            pushes.replace(returned_pushes);
+        });
+    });
+}
+
+fn bench_libzmq_push_pull_pipelined(c: &mut Criterion) {
+    for &transport in TRANSPORTS {
+        for &peers in PEER_COUNTS {
+            let mut group = c.benchmark_group(format!(
+                "libzmq/throughput/push_pull/{transport}/peers={peers}"
+            ));
+            bench_runtime::configure_group(&mut group);
+            for &msg_size in PUSH_PULL_SIZES {
+                group.throughput(Throughput::Bytes((PUSH_PULL_BATCH_SIZE * msg_size) as u64));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(msg_size),
+                    &msg_size,
+                    |b, &s| {
+                        bench_libzmq_push_pull_pipelined_one(b, peers, s, transport);
+                    },
+                );
+            }
+            group.finish();
+        }
+    }
+}
+
+fn bench_libzmq_push_pull_pipelined_one(
+    b: &mut criterion::Bencher<'_>,
+    peers: usize,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-pushpull-{peers}-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    let hwm = (PUSH_PULL_BATCH_SIZE * 4) as i32;
+    pull.set_rcvhwm(hwm).expect("pull rcvhwm");
+    pull.bind(&endpoint).expect("pull bind");
+    let bound = pull.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    struct PushHandle {
+        tx_drive: mpsc::Sender<usize>,
+        rx_done: mpsc::Receiver<()>,
+        _thread: thread::JoinHandle<()>,
+    }
+
+    let mut pushes = Vec::with_capacity(peers);
+    for _ in 0..peers {
+        let ctx = ctx.clone();
+        let bound = bound.clone();
+        let payload = vec![0xCD; msg_size];
+        let (tx_drive, rx_drive) = mpsc::channel();
+        let (tx_done, rx_done) = mpsc::channel();
+        let thread = thread::spawn(move || {
+            let push = ctx.socket(zmq2::PUSH).expect("push socket");
+            push.set_sndhwm(hwm).expect("push sndhwm");
+            push.connect(&bound).expect("push connect");
+            while let Ok(n) = rx_drive.recv() {
+                for _ in 0..n {
+                    push.send(&payload, 0).expect("push send");
+                }
+                if tx_done.send(()).is_err() {
+                    break;
+                }
+            }
+        });
+        pushes.push(PushHandle {
+            tx_drive,
+            rx_done,
+            _thread: thread,
+        });
+    }
+
+    thread::sleep(Duration::from_millis(200));
+    let per_peer = PUSH_PULL_BATCH_SIZE / peers;
+    b.iter(|| {
+        for push in &pushes {
+            push.tx_drive.send(per_peer).expect("drive push");
+        }
+        for _ in 0..(per_peer * peers) {
+            black_box(pull.recv_bytes(0).expect("pull recv"));
+        }
+        for push in &pushes {
+            push.rx_done.recv().expect("push done");
+        }
+    });
+
+    drop(
+        pushes
+            .into_iter()
+            .map(|push| push.tx_drive)
+            .collect::<Vec<_>>(),
+    );
+}
+
 fn bench_zmqrs_dealer_router_pipelined(c: &mut Criterion) {
     let rt = build_rt();
     for &transport in TRANSPORTS {
@@ -365,8 +547,10 @@ fn bench_libzmq_dealer_router_one(
 criterion_group!(
     benches,
     bench_zmqrs_pub_pipelined,
+    bench_zmqrs_push_pull_pipelined,
     bench_zmqrs_dealer_router_pipelined,
     bench_libzmq_pub_pipelined,
+    bench_libzmq_push_pull_pipelined,
     bench_libzmq_dealer_router_pipelined,
 );
 criterion_main!(benches);

--- a/docs/INPROC_TRANSPORT_PLAN.md
+++ b/docs/INPROC_TRANSPORT_PLAN.md
@@ -1,0 +1,153 @@
+# Inproc Transport Plan
+
+This note maps the current transport boundary and records the constraints for
+an eventual `inproc://` path. It is intentionally a planning artifact: work
+package 7 in `PERFORMANCE_ROADMAP.md` says inproc should follow the core
+boundary cleanup, so this should not introduce a public endpoint or slow
+prototype before the lower layers are ready.
+
+## Current Transport Boundary
+
+The public socket API reaches transports through two functions:
+
+- `transport::begin_accept(endpoint, callback)` binds an endpoint, starts an
+  accept task, returns the resolved endpoint, and returns an `AcceptStopHandle`.
+- `transport::connect(endpoint)` opens one outgoing connection and returns a
+  `FramedIo` plus the resolved peer endpoint.
+
+The layer above the transport assumes every connection is a byte stream wrapped
+in `FramedIo`. Both bind-side accepted peers and connect-side peers then run the
+normal ZMTP greeting and READY exchange before the socket backend installs the
+peer. After that, send/recv is backend-owned:
+
+- round-robin sockets send through `GenericSocketBackend::send_round_robin`;
+- receiving sockets insert each peer read half into `FairQueue`;
+- PUB/XPUB maintain subscriber state from subscription commands;
+- SUB/XSUB replay subscriptions when a peer is connected or reconnected.
+
+Teardown is bind-map driven. `Socket::unbind` removes the resolved endpoint from
+the socket's `HashMap<Endpoint, AcceptStopHandle>` and awaits shutdown of the
+accept task. `Socket::close` awaits all bound endpoints. `Drop` shuts down the
+backend but is not a deterministic resource-release API, so lifecycle tests that
+need endpoint reuse should use `close` or `unbind`.
+
+`connect` is also policy-bearing. It calls `connect_forever` under the socket's
+connect timeout; currently connection-refused TCP and missing IPC paths are
+retryable. A future inproc "no binding yet" result should participate in that
+same timeout policy rather than inventing a different public behavior.
+
+## Inproc Registry Requirements
+
+An inproc endpoint needs a name registry, not an OS listener:
+
+- parse `inproc://name` only when a transport implementation exists;
+- reject empty names and decide whether to enforce libzmq's 256 character name
+  limit at parse time or bind/connect time;
+- keep active names unique while bound;
+- release the name when the bind handle is shut down, and make `close`/`unbind`
+  deterministic;
+- support multiple connectors per bound name for all current multi-peer socket
+  types;
+- return the same endpoint as the resolved endpoint, because there is no
+  wildcard address to resolve;
+- make connect-before-bind follow zmq.rs timeout/retry semantics if the public
+  API accepts `inproc://` endpoints;
+- preserve socket compatibility and peer identity behavior that is currently
+  enforced by the ZMTP READY exchange.
+
+Because zmq.rs has no public `Context`, the initial registry scope would have to
+be process-wide or hidden behind an internal default context. That matches the
+available API but differs from libzmq's context-scoped names. Introducing public
+contexts would be an API design decision and should not be hidden inside this
+transport work.
+
+## External Behavior Constraints
+
+libzmq documents inproc as in-process, same-context message passing with no I/O
+threads involved. It treats the address after `inproc://` as an arbitrary name,
+requires active bind names to be unique, and documents a maximum name length of
+256 characters. Current libzmq documentation says bind/connect order has not
+mattered for inproc since libzmq 4.0.
+
+The pinned OMQ source used by the perf suite (`paddor/omq.rs` at `a46c1f7`)
+uses a process-global registry keyed by name, rejects duplicate active binds,
+releases the registry entry when the listener drops, exchanges peer socket type
+and identity snapshots during connect/accept, and skips the ZMTP codec for
+inproc messages. Its current transport-level tests reject connect without a
+prior bind. That is useful implementation evidence, but zmq.rs should prefer
+current libzmq behavior and its own `connect_forever` policy for a public
+inproc endpoint.
+
+Useful source references:
+
+- libzmq inproc docs: <https://zeromq.github.io/libzmq/zmq_inproc.html>
+- libzmq bind/connect docs: <https://libzmq.readthedocs.io/en/latest/zmq_bind.html>,
+  <https://libzmq.readthedocs.io/en/latest/zmq_connect.html>
+- OMQ inproc transport: <https://github.com/paddor/omq.rs/blob/a46c1f7/omq-tokio/src/transport/inproc.rs>,
+  <https://github.com/paddor/omq.rs/blob/a46c1f7/omq-compio/src/transport/inproc.rs>
+
+## Correctness Traps
+
+- A byte-stream-only inproc transport would be easy to wire through `FramedIo`,
+  but it would preserve codec/greeting overhead and would not make zmq.rs
+  comparable with OMQ or libzmq inproc.
+- A codec-less fast path cannot bypass socket compatibility, identity, monitor
+  events, subscription replay, disconnect notification, or fair routing.
+- Registry leaks are user-visible: an inproc name left registered after drop or
+  failed accept will make later tests and applications fail with duplicate bind.
+- Connect-before-bind must be specified before parser support lands. Accepting
+  `inproc://` and returning immediate "not found" would be observable and could
+  conflict with current libzmq behavior.
+- Endpoint equality is the lifecycle key. Any normalization of names must be
+  applied consistently at parse, bind, connect, unbind, and monitor-event time.
+- Inproc teardown has no kernel EOF to lean on. Channel closure must notify
+  receiving queues and reconnection logic just as TCP/IPC EOF does today.
+- PUB/XPUB subscription state is currently learned through command frames. A
+  codec-less inproc path still needs command delivery or an equivalent direct
+  subscription update path.
+
+## Staged Implementation Plan
+
+1. Keep inproc out of the public endpoint parser until the transport can connect
+   and bind successfully.
+2. Finish the Sans-I/O ZMTP/core boundary work so peer setup, socket
+   compatibility, READY properties, and message routing can be invoked without
+   forcing bytes through `FramedIo`.
+3. Add an internal inproc registry module with tests for duplicate bind,
+   listener drop/rebind, connect-before-bind retry classification, multiple
+   pending connectors, and accept shutdown.
+4. Add `Transport::Inproc` and `Endpoint::Inproc` together with parser/display
+   tests and transport dispatch. The first public slice should be functional for
+   PUSH/PULL and REQ/REP, not just parseable.
+5. Install inproc peers through the same backend contracts as TCP/IPC, initially
+   by synthesizing the same peer metadata that READY provides.
+6. Extend coverage to PUB/SUB, XPUB/XSUB, DEALER/ROUTER, multi-peer fairness,
+   disconnect notification, and rebind/reconnect behavior.
+7. Add inproc benchmark cases to the standard suite only after correctness
+   parity tests pass and generated data remains under `target/perf-runs/`.
+
+## Test Inventory
+
+Existing useful coverage:
+
+- `tests/connect.rs` covers IPC connect-before-bind retry, connect timeout,
+  no-timeout delayed bind, and IPC close/rebind.
+- socket unit tests cover TCP wildcard/port resolution for each socket family.
+- reconnection tests cover TCP restart behavior and subscription resync.
+
+Added in this lane:
+
+- active TCP duplicate bind is rejected;
+- active IPC duplicate bind is rejected;
+- unbinding an endpoint that was never bound returns `NoSuchBind`.
+
+Those additions exercise the bind-map and active-endpoint lifecycle invariants
+that the future inproc registry must preserve.
+
+## Prototype Decision
+
+No inproc transport prototype was attempted in this lane. The minimal
+byte-stream prototype is not a no-regret path because it would add public
+surface area while preserving the exact codec overhead that work package 7 is
+meant to avoid. The useful no-regret work here is the lifecycle test coverage
+and the staged plan for landing inproc after the core boundary is available.

--- a/docs/PERFORMANCE_ROADMAP.md
+++ b/docs/PERFORMANCE_ROADMAP.md
@@ -53,6 +53,7 @@ configuration does not leak into the external benchmark build.
      runtime policy work.
    - Correctness checks: protocol fixture tests, greeting/mechanism tests,
      interop with libzmq, and no public socket API changes.
+   - Boundary note: [`SANS_IO_ZMTP_BOUNDARY.md`](SANS_IO_ZMTP_BOUNDARY.md).
 
 5. Gather-write and `writev` large-frame path
    - Goal: send multipart and large frames with vectored writes where the

--- a/docs/RUNTIME_POLICY_MEASUREMENT.md
+++ b/docs/RUNTIME_POLICY_MEASUREMENT.md
@@ -1,0 +1,134 @@
+# Runtime Policy Measurement
+
+Date: 2026-05-14
+Branch: `quod/perf-runtime-policy-lab1`
+
+## Goal
+
+Keep Tokio mandatory and first-class while collecting enough evidence to decide
+whether the legacy `async-std` and `async-dispatcher` runtime paths should stay,
+be deprecated, or be removed later.
+
+## Runtime Feature Map
+
+| Runtime path | Feature set | Dependencies | Status |
+| --- | --- | --- | --- |
+| Tokio | `tokio-runtime,all-transport` | `tokio`, `tokio-util` | Default runtime through `default = ["tokio-runtime", "all-transport"]`. |
+| async-std | `async-std-runtime,all-transport` | `async-std` | Legacy non-default runtime path. |
+| async-dispatcher | `async-dispatcher-runtime,all-transport,async-dispatcher-macros` | `async-std`, `async-dispatcher`, optional macros | Legacy non-default runtime path. Uses async-std transport I/O plus async-dispatcher task/sleep/timeout helpers. |
+
+Transport features are independent of runtime selection:
+`all-transport = ["ipc-transport", "tcp-transport"]`,
+`ipc-transport = ["dep:win_uds"]`, and `tcp-transport = []`.
+
+Runtime features are de facto exclusive. The default Tokio feature set cannot
+currently be combined with `async-std-runtime` because runtime-specific imports,
+macros, transport adapters, and task helpers are all selected by independent
+`cfg(feature = "...")` gates.
+
+## CI Coverage Map
+
+| Area | Tokio | async-std | async-dispatcher |
+| --- | --- | --- | --- |
+| Clippy/lint | Yes, default `cargo clippy --all --all-targets`. | Yes, `async-std-runtime,all-transport,async-dispatcher-macros`. | No direct async-dispatcher clippy job. |
+| Tests | Yes, default `cargo test --all`. | Yes, `cargo test --all --no-default-features --features async-std-runtime,all-transport`. | Yes, `cargo test --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros`. |
+| Perf smoke | Yes, default smoke profile uses `tokio-runtime`. | Not by default in CI. Runtime override works after the bench harness fix below. | Not by default in CI. Runtime override required a bench harness fix below. |
+| Windows IPC | Yes, stable and MSRV check/test with `tokio-runtime,ipc-transport,tcp-transport`. | No. | No. |
+| MSRV | Yes, default check. | Yes, async-std check. | No. |
+| Nightly | Yes, default check, continue-on-error. | Yes, async-std check, continue-on-error. | No. |
+
+The integration tests mostly use the runtime-neutral `#[async_rt::test]`
+alias. `tests/push_pull_timeout.rs` is explicitly Tokio-only through
+`#![cfg(feature = "tokio-runtime")]` and `#[tokio::test]`.
+
+## Benchmark Coverage Map
+
+| Profile or harness | Tokio | async-std | async-dispatcher | Notes |
+| --- | --- | --- | --- | --- |
+| `perf-suite.json` smoke defaults | Yes | No | No | Smoke declares only `["tokio-runtime"]`, but `--runtime` can override it. |
+| `perf-suite.json` standard/full defaults | Yes | Yes | Yes | Config declares all three runtimes for zmq.rs. |
+| `benches/compare_libzmq.rs` | Yes | Yes | Yes after harness fix | Latency-style socket comparison for PUSH/PULL, REQ/REP, DEALER/ROUTER, PUB/SUB. |
+| `benches/throughput.rs` | Yes | Yes | Yes after harness fix | Pipelined DEALER/ROUTER and PUB fanout. |
+| `benches/codec.rs` | Runtime-independent | Runtime-independent | Runtime-independent | Still compiled/run under selected feature sets by the perf suite. |
+
+The benchmark runtime shim now initializes `async_dispatcher::thread_dispatcher()`
+and uses `async_dispatcher::block_on()` when `async-dispatcher-runtime` is
+selected. Before that fix, the async-dispatcher smoke benchmark panicked with
+`The dispatcher requires a call to set_dispatcher()`.
+
+## Command Matrix
+
+| Command | Status | Evidence |
+| --- | --- | --- |
+| `cargo check --all --all-targets` | Pass | Finished `dev` profile for the default Tokio feature set. |
+| `cargo check --all --all-targets --no-default-features --features tokio-runtime,all-transport` | Pass | Finished `dev` profile. |
+| `cargo check --all --all-targets --no-default-features --features async-std-runtime,all-transport` | Pass | Finished `dev` profile. |
+| `cargo check --all --all-targets --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros` | Pass | Finished `dev` profile. |
+| `cargo test --no-run --all --no-default-features --features tokio-runtime,all-transport` | Pass | Test executables linked successfully. |
+| `cargo test --no-run --all --no-default-features --features async-std-runtime,all-transport` | Pass | Test executables linked successfully. |
+| `cargo test --no-run --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros` | Pass | Test executables linked successfully. |
+| `cargo check --all-targets --features async-std-runtime` | Fail, expected | Confirms mixed default Tokio plus async-std features are unsupported; errors include duplicate runtime macros/imports and conflicting transport helpers. |
+| `/home/ubuntu/labs/zmqrs-perf/with-benchmark-lock.sh -- python3 scripts/run_perf_suite.py --profile smoke --impl zmqrs --transport tcp --runtime tokio-runtime,async-std-runtime,async-dispatcher-runtime --run-id runtime-policy-smoke-runtimes --force` | Pass | `target/perf-runs/runtime-policy-smoke-runtimes/summary.md` status `complete`. |
+| `cargo fmt --all -- --check` | Pass | Repository formatting is clean after applying rustfmt import ordering in `benches/codec.rs`. |
+
+## Runtime Benchmark Smoke
+
+Completed run:
+`target/perf-runs/runtime-policy-smoke-runtimes/summary.md`
+
+| Runtime | Workload | Transport | Size | Latency | Throughput | Ratio vs Tokio |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| Tokio | PUSH/PULL | TCP | 16 | 18.704 us | 0.9 MB/s | 1.00x |
+| async-std | PUSH/PULL | TCP | 16 | 6.297 us | 2.5 MB/s | 2.97x |
+| async-dispatcher | PUSH/PULL | TCP | 16 | 4.551 us | 3.5 MB/s | 4.11x |
+
+This is a smoke result only. It proves the three runtime feature sets can run
+the benchmark harness for one TCP PUSH/PULL point. It is not enough to claim a
+runtime-wide performance ranking.
+
+## Recommendation
+
+Keep Tokio mandatory, default, and first-class.
+
+Keep `async-std-runtime` for now. It has direct CI lint, test, MSRV, and nightly
+coverage, passes the explicit compile matrix, and now has smoke benchmark
+evidence. There is not enough standard/full runtime data to justify removal.
+
+Keep `async-dispatcher-runtime` provisionally, but mark it as the higher-risk
+legacy path. It passes compile and CI test coverage, and the benchmark harness
+now works for smoke. However, it lacks direct clippy, MSRV, nightly, Windows IPC,
+and default perf-smoke coverage. It also has global dispatcher initialization
+requirements that already caused benchmark coverage to fail until fixed.
+
+Do not remove either legacy runtime path from this branch. A later deprecation
+decision should wait until standard runs complete across at least TCP and IPC
+for PUSH/PULL, REQ/REP, PUB/SUB, and DEALER/ROUTER, plus throughput fanout.
+If maintenance pressure forces a staged deprecation, async-dispatcher should be
+evaluated first because it has more coverage gaps and more runtime-specific
+setup risk than async-std.
+
+## Migration Risks
+
+- Users may rely on `#[zeromq::__async_rt::main]` or
+  `#[zeromq::__async_rt::test]` resolving to async-std or async-dispatcher
+  macros under non-default features.
+- async-dispatcher users must install a dispatcher before spawning, sleeping,
+  or timing out work. Removing or changing that path needs an explicit migration
+  note to Tokio or async-std.
+- Removing `async-std-runtime` would also affect `async-dispatcher-runtime`
+  because the dispatcher feature currently depends on async-std transport I/O.
+- CI currently gives Tokio the broadest platform coverage. Removing legacy
+  runtimes without more measurements risks surprising downstream users who are
+  green under the existing test matrix.
+
+## Missing Measurements
+
+- Completed standard profile per runtime. A prior TCP-only attempt left no
+  completed summary artifact and is not counted as measurement evidence.
+- IPC benchmark results per runtime.
+- Direct CI perf-smoke coverage for async-std and async-dispatcher.
+- async-dispatcher clippy, MSRV, nightly, and Windows IPC checks.
+- Runtime comparisons for throughput fanout and DEALER/ROUTER under standard
+  or full profile settings.
+- A migration note only if a future branch actually deprecates or removes a
+  runtime feature.

--- a/docs/SANS_IO_ZMTP_BOUNDARY.md
+++ b/docs/SANS_IO_ZMTP_BOUNDARY.md
@@ -1,0 +1,125 @@
+# Sans-I/O ZMTP Boundary
+
+This note scopes work package 4 from the performance roadmap: separate ZMTP
+protocol parsing, framing, and handshake state from runtime I/O while keeping
+Tokio as the first-class transport path.
+
+## Current Ownership Map
+
+- `src/transport/mod.rs`, `src/transport/tcp.rs`, and `src/transport/ipc.rs`
+  own runtime-specific stream creation. Tokio streams are split and adapted
+  through `tokio_util::compat`; async-std streams are split directly.
+- `src/codec/framed.rs` boxes async read/write halves as `FrameableRead` and
+  `FrameableWrite`, then couples both halves to `asynchronous_codec` through
+  `FramedIo`.
+- `src/codec/zmq_codec.rs` owns streaming parse state: greeting bytes, frame
+  flags, frame length, payload body, and multipart accumulation.
+- `src/codec/greeting.rs`, `src/codec/mechanism.rs`, and
+  `src/codec/command.rs` parse or serialize protocol values. Before this lane,
+  command serialization also owned its command-frame prefix.
+- `src/util.rs` owns connection protocol state above framing: greeting exchange,
+  version negotiation, READY exchange, socket compatibility, and peer identity.
+- Socket backends own post-handshake state: peer tables, fair-queue streams,
+  subscription state, reconnection notifiers, and monitor events.
+
+The current shape is correct for the public API, but protocol state and runtime
+I/O are interleaved enough that writev, receive-copy reduction, and runtime
+policy changes have to reason through `FramedIo` and socket backends at the same
+time.
+
+## Minimal Boundary
+
+The minimal Sans-I/O boundary should sit below socket backends and above runtime
+transports:
+
+```text
+runtime transport <-> async adapter <-> Sans-I/O ZMTP core <-> socket backend
+```
+
+The core should own only deterministic protocol work:
+
+- Greeting encode/decode and version choice.
+- Frame flag and length parsing.
+- Command payload parse/encode.
+- Multipart assembly and message emission.
+- Handshake sequencing for Greeting and READY as a pure state machine.
+
+Runtime adapters should own:
+
+- Tokio, async-std, and any future runtime-specific stream types.
+- Read readiness, write readiness, cancellation policy, and timeout policy.
+- Buffer ownership around syscalls, including vectored writes.
+- Conversion between protocol actions and `Sink`/`Stream` behavior.
+
+Socket backends should continue to own:
+
+- Public socket semantics.
+- Peer routing, fair queues, subscription filters, reconnect policy, and
+  monitor events.
+
+## Data Crossing The Boundary
+
+Inbound data should cross as caller-owned byte buffers, with the protocol core
+consuming only the bytes that make a complete ZMTP item:
+
+- Input: `BytesMut` or a small cursor over received bytes.
+- Output: a protocol event such as greeting, command, complete message, or
+  "need N more bytes".
+- Payload ownership: `Bytes` slices split from the input buffer so complete
+  message frames do not copy.
+
+Outbound data should cross as owned protocol values plus an encode plan:
+
+- Input: `ZmqGreeting`, `ZmqCommand`, or `ZmqMessage`.
+- Output today: bytes appended to `BytesMut`.
+- Output target: a stable frame plan containing small header bytes and borrowed
+  or cloned `Bytes` payloads. Tokio adapters can turn that plan into `writev`
+  without changing socket APIs.
+
+Handshake state should cross as actions instead of I/O:
+
+- Input: local `SocketType`, local identity option, and incoming protocol
+  events.
+- Output: send greeting, send READY, accept peer identity, reject incompatible
+  peer, or close.
+
+## Migration Steps
+
+1. Keep `FramedIo` and the public socket API unchanged.
+2. Extract frame header and prefix handling into a private Sans-I/O helper with
+   fixture tests. This lane starts that extraction in `src/codec/zmtp_frame.rs`.
+3. Move command payload encoding behind the same frame helper so command and
+   data frames share one flag/length implementation.
+4. Make `ZmqCodec` delegate greeting, frame, command, and multipart decisions to
+   a core state object while remaining the async-codec adapter.
+5. Extract greeting and READY sequencing from `util.rs` into a pure
+   `ZmtpSession` state machine, then let `util.rs` drive it over `FramedIo`.
+6. Add a write-plan API inside the crate. Tokio remains the first optimized
+   adapter, with async-std preserving the same protocol behavior.
+7. Add receive-copy tests around partial frames, multipart cancellation, and
+   buffer reuse before changing receive ownership.
+
+## Correctness Fixtures
+
+The first fixtures are byte-level tests for ZMTP frame flags and short/long
+length prefixes. Follow-on fixtures should cover:
+
+- 64-byte greeting acceptance and rejection.
+- NULL, PLAIN, and CURVE mechanism parsing.
+- READY command payloads with `Socket-Type` and `Identity`.
+- Multipart frames split across arbitrary input chunks.
+- Bad length, bad command name, and incompatible socket type failures.
+- libzmq interop for greeting/READY and large multipart frames.
+
+## Blockers For Writev And Recv-Copy Work
+
+- `ZmqCodec::encode` still writes each outbound message into one `BytesMut`.
+  Writev needs an internal encode plan that separates frame headers from
+  existing `Bytes` payloads.
+- `ZmqCodec::decode` still owns multipart accumulation. Receive-copy work needs
+  cancellation tests before changing how partial message state is exposed.
+- Handshake sequencing is still async I/O in `util.rs`. Runtime policy work
+  will be safer once a pure state machine emits protocol actions.
+- `FramedIo` currently erases concrete transport halves behind trait objects.
+  Tokio-specific vectored-write support may need an internal fast path while
+  preserving the existing boxed adapter for other runtimes.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -92,7 +92,7 @@ impl GenericSocketBackend {
                 },
             };
             let send_result = match self.peers.get_async(&next_peer_id).await {
-                Some(mut peer) => peer.send_queue.send(message).await,
+                Some(mut peer) => peer.send_queue.send(&message).await,
                 None => continue,
             };
             return match send_result {

--- a/src/codec/command.rs
+++ b/src/codec/command.rs
@@ -1,4 +1,5 @@
 use super::error::CodecError;
+use super::zmtp_frame::ZmtpFrameHeader;
 use crate::SocketType;
 
 use bytes::{Buf, BufMut, Bytes, BytesMut};
@@ -97,18 +98,9 @@ impl From<ZmqCommand> for BytesMut {
             message_len += val.len() + 4;
         }
 
-        let long_message = message_len > 255;
-
-        let mut bytes = BytesMut::new();
-        if long_message {
-            bytes.reserve(message_len + 9);
-            bytes.put_u8(0x06);
-            bytes.put_u64(message_len as u64);
-        } else {
-            bytes.reserve(message_len + 2);
-            bytes.put_u8(0x04);
-            bytes.put_u8(message_len as u8);
-        };
+        let header = ZmtpFrameHeader::for_payload(message_len, true, false);
+        let mut bytes = BytesMut::with_capacity(header.encoded_len(message_len));
+        header.write_prefix(message_len, &mut bytes);
         bytes.put_u8(command_name.len() as u8);
         bytes.extend_from_slice(command_name.as_ref());
         for (prop, val) in command.properties.iter() {

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,16 +1,258 @@
-use crate::codec::ZmqCodec;
+use crate::codec::{CodecError, Message, ZmqCodec};
+use crate::ZmqMessage;
 
-use asynchronous_codec::{FramedRead, FramedWrite};
+use asynchronous_codec::{Encoder, FramedRead};
+use bytes::{Buf, Bytes, BytesMut};
+use futures::{ready, Sink};
 use futures::{AsyncRead, AsyncWrite};
+use std::io::{Error, ErrorKind, IoSlice};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
 pub trait FrameableRead: AsyncRead + Unpin + Send + Sync {}
 impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
-pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {}
-impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
+pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {
+    fn supports_write_vectored(&self) -> bool;
+}
 
 pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
-pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
+
+impl<T> FrameableWrite for futures::io::WriteHalf<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + Sync,
+{
+    fn supports_write_vectored(&self) -> bool {
+        // futures::AsyncWrite has no capability flag like Tokio's
+        // is_write_vectored(), so keep generic split writes on the safe path.
+        false
+    }
+}
+
+/// A `Sink` of ZMTP messages encoded to an `AsyncWrite`.
+///
+/// The ordinary codec encoder still exists for pure codec callers. This write
+/// half bypasses its contiguous `BytesMut` payload copy for large or multipart
+/// messages when the erased transport can perform vectored writes.
+pub struct ZmqFramedWrite {
+    inner: Box<dyn FrameableWrite>,
+    codec: ZmqCodec,
+    buffer: BytesMut,
+    pending: Option<PendingWrite>,
+    high_water_mark: usize,
+}
+
+impl ZmqFramedWrite {
+    pub fn new(inner: Box<dyn FrameableWrite>) -> Self {
+        Self {
+            inner,
+            codec: ZmqCodec::new(),
+            buffer: BytesMut::with_capacity(1028 * 8),
+            pending: None,
+            high_water_mark: 131_072,
+        }
+    }
+
+    fn should_write_vectored(&self, message: &ZmqMessage) -> bool {
+        self.inner.supports_write_vectored()
+            && self.buffer.is_empty()
+            && self.pending.is_none()
+            && (message.len() > 1
+                || message
+                    .iter()
+                    .any(|frame| frame.len() >= VECTORED_SINGLE_FRAME_MIN_PAYLOAD))
+    }
+
+    fn poll_drain_pending(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), CodecError>> {
+        while self.pending.is_some() {
+            let num_write = {
+                let pending = self.pending.as_ref().expect("pending write");
+                let mut bufs = Vec::with_capacity(MAX_VECTORED_SLICES);
+                pending.fill_io_slices(&mut bufs);
+                ready!(Pin::new(&mut self.inner).poll_write_vectored(cx, &bufs))?
+            };
+
+            if num_write == 0 {
+                return Poll::Ready(Err(err_eof().into()));
+            }
+
+            let pending = self.pending.as_mut().expect("pending write");
+            pending.advance(num_write);
+            if pending.is_complete() {
+                self.pending = None;
+            }
+        }
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_drain_buffer(
+        &mut self,
+        cx: &mut Context<'_>,
+        drain_all: bool,
+    ) -> Poll<Result<(), CodecError>> {
+        while !self.buffer.is_empty() && (drain_all || self.buffer.len() >= self.high_water_mark) {
+            let num_write = ready!(Pin::new(&mut self.inner).poll_write(cx, &self.buffer))?;
+
+            if num_write == 0 {
+                return Poll::Ready(Err(err_eof().into()));
+            }
+
+            self.buffer.advance(num_write);
+        }
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl Sink<Message> for ZmqFramedWrite {
+    type Error = CodecError;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_drain_pending(cx))?;
+        self.poll_drain_buffer(cx, false)
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+        match item {
+            Message::Message(message) if self.should_write_vectored(&message) => {
+                self.pending = Some(PendingWrite::from_message(message));
+                Ok(())
+            }
+            item => {
+                let this = &mut *self;
+                this.codec.encode(item, &mut this.buffer)
+            }
+        }
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.poll_drain_pending(cx))?;
+        ready!(self.poll_drain_buffer(cx, true))?;
+        Pin::new(&mut self.inner).poll_flush(cx).map_err(Into::into)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        ready!(self.as_mut().poll_flush(cx))?;
+        Pin::new(&mut self.inner).poll_close(cx).map_err(Into::into)
+    }
+}
+
+const MAX_VECTORED_SLICES: usize = 64;
+// Keep modest single-frame sends on the contiguous path; writev mainly pays off
+// once the avoided payload copy is large enough. Multipart stays eligible.
+const VECTORED_SINGLE_FRAME_MIN_PAYLOAD: usize = 16 * 1024;
+
+struct PendingWrite {
+    segments: Vec<PendingSegment>,
+    index: usize,
+    offset: usize,
+}
+
+impl PendingWrite {
+    fn from_message(message: ZmqMessage) -> Self {
+        let mut frames = message.into_vec().into_iter().peekable();
+        let mut segments = Vec::new();
+
+        while let Some(payload) = frames.next() {
+            let more = frames.peek().is_some();
+            segments.push(PendingSegment::Header(FrameHeader::new(&payload, more)));
+            if !payload.is_empty() {
+                segments.push(PendingSegment::Payload(payload));
+            }
+        }
+
+        Self {
+            segments,
+            index: 0,
+            offset: 0,
+        }
+    }
+
+    fn fill_io_slices<'a>(&'a self, bufs: &mut Vec<IoSlice<'a>>) {
+        for segment in self.segments[self.index..].iter() {
+            if bufs.len() == MAX_VECTORED_SLICES {
+                break;
+            }
+
+            let mut bytes = segment.as_slice();
+            if bufs.is_empty() && self.offset > 0 {
+                bytes = &bytes[self.offset..];
+            }
+            if !bytes.is_empty() {
+                bufs.push(IoSlice::new(bytes));
+            }
+        }
+    }
+
+    fn advance(&mut self, mut written: usize) {
+        while written > 0 && !self.is_complete() {
+            let remaining = self.segments[self.index].len() - self.offset;
+            if written < remaining {
+                self.offset += written;
+                return;
+            }
+
+            written -= remaining;
+            self.index += 1;
+            self.offset = 0;
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.index >= self.segments.len()
+    }
+}
+
+enum PendingSegment {
+    Header(FrameHeader),
+    Payload(Bytes),
+}
+
+impl PendingSegment {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Header(header) => header.as_slice(),
+            Self::Payload(payload) => payload.as_ref(),
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+}
+
+struct FrameHeader {
+    bytes: [u8; 9],
+    len: usize,
+}
+
+impl FrameHeader {
+    fn new(payload: &Bytes, more: bool) -> Self {
+        let mut bytes = [0; 9];
+        if more {
+            bytes[0] |= 0b0000_0001;
+        }
+
+        let payload_len = payload.len();
+        let len = if payload_len > 255 {
+            bytes[0] |= 0b0000_0010;
+            bytes[1..].copy_from_slice(&(payload_len as u64).to_be_bytes());
+            9
+        } else {
+            bytes[1] = payload_len as u8;
+            2
+        };
+
+        Self { bytes, len }
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        &self.bytes[..self.len]
+    }
+}
+
+fn err_eof() -> Error {
+    Error::new(ErrorKind::UnexpectedEof, "End of file")
+}
 
 /// Equivalent to [`asynchronous_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
@@ -21,7 +263,7 @@ pub struct FramedIo {
 impl FramedIo {
     pub fn new(read_half: Box<dyn FrameableRead>, write_half: Box<dyn FrameableWrite>) -> Self {
         let read_half = FramedRead::new(read_half, ZmqCodec::new());
-        let write_half = FramedWrite::new(write_half, ZmqCodec::new());
+        let write_half = ZmqFramedWrite::new(write_half);
         Self {
             read_half,
             write_half,
@@ -30,5 +272,141 @@ impl FramedIo {
 
     pub fn into_parts(self) -> (ZmqFramedRead, ZmqFramedWrite) {
         (self.read_half, self.write_half)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::executor::block_on;
+    use futures::SinkExt;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn vectored_write_handles_partial_large_multipart_message() {
+        let (writer, stats) = RecordingWriter::new(true, 3);
+        let message = ZmqMessage::try_from(vec![
+            Bytes::from_static(b"small"),
+            Bytes::from(vec![0xAB; 300]),
+            Bytes::from_static(b"tail"),
+        ])
+        .expect("non-empty multipart");
+        let expected = encode_with_codec(message.clone());
+
+        let mut framed = ZmqFramedWrite::new(Box::new(writer));
+        block_on(framed.send(Message::Message(message))).expect("send succeeds");
+
+        let stats = stats.lock().expect("stats lock");
+        assert_eq!(stats.bytes, expected);
+        assert!(stats.vectored_calls > 1);
+        assert_eq!(stats.write_calls, 0);
+    }
+
+    #[test]
+    fn contiguous_write_is_used_when_transport_does_not_support_vectored_writes() {
+        let (writer, stats) = RecordingWriter::new(false, 64);
+        let message = ZmqMessage::try_from(vec![
+            Bytes::from(vec![0xCD; 300]),
+            Bytes::from_static(b"second"),
+        ])
+        .expect("non-empty multipart");
+        let expected = encode_with_codec(message.clone());
+
+        let mut framed = ZmqFramedWrite::new(Box::new(writer));
+        block_on(framed.send(Message::Message(message))).expect("send succeeds");
+
+        let stats = stats.lock().expect("stats lock");
+        assert_eq!(stats.bytes, expected);
+        assert_eq!(stats.vectored_calls, 0);
+        assert!(stats.write_calls > 1);
+    }
+
+    fn encode_with_codec(message: ZmqMessage) -> Vec<u8> {
+        let mut codec = ZmqCodec::new();
+        let mut dst = BytesMut::new();
+        codec
+            .encode(Message::Message(message), &mut dst)
+            .expect("codec encode");
+        dst.to_vec()
+    }
+
+    #[derive(Default)]
+    struct WriteStats {
+        bytes: Vec<u8>,
+        max_chunk: usize,
+        vectored_calls: usize,
+        write_calls: usize,
+    }
+
+    struct RecordingWriter {
+        stats: Arc<Mutex<WriteStats>>,
+        supports_vectored: bool,
+    }
+
+    impl RecordingWriter {
+        fn new(supports_vectored: bool, max_chunk: usize) -> (Self, Arc<Mutex<WriteStats>>) {
+            let stats = Arc::new(Mutex::new(WriteStats {
+                max_chunk,
+                ..WriteStats::default()
+            }));
+            (
+                Self {
+                    stats: stats.clone(),
+                    supports_vectored,
+                },
+                stats,
+            )
+        }
+    }
+
+    impl AsyncWrite for RecordingWriter {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, Error>> {
+            let mut stats = self.stats.lock().expect("stats lock");
+            stats.write_calls += 1;
+            let len = buf.len().min(stats.max_chunk);
+            stats.bytes.extend_from_slice(&buf[..len]);
+            Poll::Ready(Ok(len))
+        }
+
+        fn poll_write_vectored(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize, Error>> {
+            let mut stats = self.stats.lock().expect("stats lock");
+            stats.vectored_calls += 1;
+
+            let mut remaining = stats.max_chunk;
+            let mut written = 0;
+            for buf in bufs {
+                if remaining == 0 {
+                    break;
+                }
+                let len = buf.len().min(remaining);
+                stats.bytes.extend_from_slice(&buf[..len]);
+                remaining -= len;
+                written += len;
+            }
+
+            Poll::Ready(Ok(written))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Error>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    impl FrameableWrite for RecordingWriter {
+        fn supports_write_vectored(&self) -> bool {
+            self.supports_vectored
+        }
     }
 }

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,11 +1,11 @@
-use crate::codec::{CodecError, Message, ZmqCodec};
+use crate::codec::{CodecError, CodecResult, Message, ZmqCodec};
 use crate::ZmqMessage;
 
-use asynchronous_codec::{Encoder, FramedRead};
+use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Buf, Bytes, BytesMut};
-use futures::{ready, Sink};
+use futures::{ready, Sink, Stream};
 use futures::{AsyncRead, AsyncWrite};
-use std::io::{Error, ErrorKind, IoSlice};
+use std::io::{self, Error, ErrorKind, IoSlice};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
@@ -15,8 +15,6 @@ impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
 pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {
     fn supports_write_vectored(&self) -> bool;
 }
-
-pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 
 impl<T> FrameableWrite for futures::io::WriteHalf<T>
 where
@@ -32,6 +30,76 @@ where
 impl FrameableWrite for futures::io::Sink {
     fn supports_write_vectored(&self) -> bool {
         false
+    }
+}
+
+/// A `Stream` of ZMTP messages decoded from an `AsyncRead`.
+///
+/// This mirrors the read side of `asynchronous_codec::FramedRead` but uses a
+/// larger reusable read buffer. Large PUSH/PULL payloads are 8 KiB in the
+/// focused OMQ-shaped benchmark, so the generic 8 KiB read chunk often splits
+/// every frame header from its final payload bytes. Reading in a larger chunk
+/// lets one socket poll bring in several complete frames while preserving the
+/// same one-message-at-a-time stream contract above the codec.
+pub struct ZmqFramedRead {
+    inner: Box<dyn FrameableRead>,
+    codec: ZmqCodec,
+    buffer: BytesMut,
+    read_buf: Box<[u8]>,
+}
+
+impl ZmqFramedRead {
+    pub fn new(inner: Box<dyn FrameableRead>) -> Self {
+        Self {
+            inner,
+            codec: ZmqCodec::new(),
+            buffer: BytesMut::with_capacity(READ_BUFFER_CAPACITY),
+            read_buf: vec![0; READ_BUFFER_CAPACITY].into_boxed_slice(),
+        }
+    }
+}
+
+impl Stream for ZmqFramedRead {
+    type Item = CodecResult<Message>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        if let Some(item) = this.codec.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
+        loop {
+            let read = {
+                let inner = &mut this.inner;
+                let read_buf = &mut this.read_buf;
+                ready!(Pin::new(inner).poll_read(cx, read_buf))?
+            };
+            let ended = read == 0;
+            this.buffer.extend_from_slice(&this.read_buf[..read]);
+
+            match this.codec.decode(&mut this.buffer)? {
+                Some(item) => return Poll::Ready(Some(Ok(item))),
+                None if ended => {
+                    if this.buffer.is_empty() {
+                        return Poll::Ready(None);
+                    }
+
+                    match this.codec.decode_eof(&mut this.buffer)? {
+                        Some(item) => return Poll::Ready(Some(Ok(item))),
+                        None if this.buffer.is_empty() => return Poll::Ready(None),
+                        None => {
+                            return Poll::Ready(Some(Err(io::Error::new(
+                                ErrorKind::UnexpectedEof,
+                                "bytes remaining in stream",
+                            )
+                            .into())));
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
     }
 }
 
@@ -143,6 +211,7 @@ impl<'a> Sink<&'a Message> for ZmqFramedWrite {
 }
 
 const MAX_VECTORED_SLICES: usize = 64;
+const READ_BUFFER_CAPACITY: usize = 64 * 1024;
 // Keep modest single-frame sends on the contiguous path; writev mainly pays off
 // once the avoided payload copy is large enough. Multipart stays eligible.
 const VECTORED_SINGLE_FRAME_MIN_PAYLOAD: usize = 16 * 1024;
@@ -268,7 +337,7 @@ pub struct FramedIo {
 
 impl FramedIo {
     pub fn new(read_half: Box<dyn FrameableRead>, write_half: Box<dyn FrameableWrite>) -> Self {
-        let read_half = FramedRead::new(read_half, ZmqCodec::new());
+        let read_half = ZmqFramedRead::new(read_half);
         let write_half = ZmqFramedWrite::new(write_half);
         Self {
             read_half,
@@ -284,8 +353,9 @@ impl FramedIo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::ZmqGreeting;
     use futures::executor::block_on;
-    use futures::SinkExt;
+    use futures::{SinkExt, StreamExt};
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -329,12 +399,135 @@ mod tests {
         assert!(stats.write_calls > 1);
     }
 
+    #[test]
+    fn framed_read_serves_buffered_messages_without_extra_reads() {
+        let payload = Bytes::from(vec![0xCD; 8192]);
+        let first = ZmqMessage::from(payload.clone());
+        let second = ZmqMessage::from(payload.clone());
+        let encoded = encode_greeting_and_messages(&[first, second]);
+        let (reader, read_calls) = RecordingReader::new(encoded, READ_BUFFER_CAPACITY);
+
+        let mut framed = ZmqFramedRead::new(Box::new(reader));
+        block_on(async {
+            expect_greeting(framed.next().await);
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+
+            let message = expect_message(framed.next().await);
+            expect_single_frame(message, payload.as_ref());
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+
+            let message = expect_message(framed.next().await);
+            expect_single_frame(message, payload.as_ref());
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+        });
+    }
+
+    #[test]
+    fn framed_read_preserves_fragmented_multipart_messages() {
+        let message = ZmqMessage::try_from(vec![
+            Bytes::from_static(b"first"),
+            Bytes::from(vec![0xAB; 300]),
+            Bytes::from_static(b"tail"),
+        ])
+        .expect("non-empty multipart");
+        let encoded = encode_greeting_and_messages(&[message]);
+        let (reader, _read_calls) = RecordingReader::new(encoded, 5);
+
+        let mut framed = ZmqFramedRead::new(Box::new(reader));
+        block_on(async {
+            expect_greeting(framed.next().await);
+            let message = expect_message(framed.next().await);
+            let frames = message.into_vec();
+
+            assert_eq!(frames.len(), 3);
+            assert_eq!(frames[0].as_ref(), b"first");
+            assert_eq!(frames[1].as_ref(), &[0xAB; 300]);
+            assert_eq!(frames[2].as_ref(), b"tail");
+        });
+    }
+
+    fn encode_greeting_and_messages(messages: &[ZmqMessage]) -> Vec<u8> {
+        let mut codec = ZmqCodec::new();
+        let mut dst = BytesMut::new();
+        let greeting = Message::Greeting(ZmqGreeting::default());
+        codec.encode(&greeting, &mut dst).expect("greeting encode");
+
+        for message in messages {
+            let outbound = Message::Message(message.clone());
+            codec.encode(&outbound, &mut dst).expect("message encode");
+        }
+
+        dst.to_vec()
+    }
+
     fn encode_with_codec(message: ZmqMessage) -> Vec<u8> {
         let mut codec = ZmqCodec::new();
         let mut dst = BytesMut::new();
         let outbound = Message::Message(message);
         codec.encode(&outbound, &mut dst).expect("codec encode");
         dst.to_vec()
+    }
+
+    fn expect_greeting(item: Option<CodecResult<Message>>) {
+        match item.expect("stream item").expect("decode succeeds") {
+            Message::Greeting(_) => {}
+            other => panic!("expected greeting, got {other:?}"),
+        }
+    }
+
+    fn expect_message(item: Option<CodecResult<Message>>) -> ZmqMessage {
+        match item.expect("stream item").expect("decode succeeds") {
+            Message::Message(message) => message,
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    fn expect_single_frame(message: ZmqMessage, expected: &[u8]) {
+        let frames = message.into_vec();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].as_ref(), expected);
+    }
+
+    struct RecordingReader {
+        data: Vec<u8>,
+        offset: usize,
+        max_chunk: usize,
+        read_calls: Arc<Mutex<usize>>,
+    }
+
+    impl RecordingReader {
+        fn new(data: Vec<u8>, max_chunk: usize) -> (Self, Arc<Mutex<usize>>) {
+            let read_calls = Arc::new(Mutex::new(0));
+            (
+                Self {
+                    data,
+                    offset: 0,
+                    max_chunk,
+                    read_calls: read_calls.clone(),
+                },
+                read_calls,
+            )
+        }
+    }
+
+    impl AsyncRead for RecordingReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize, Error>> {
+            *self.read_calls.lock().expect("read calls lock") += 1;
+            if self.offset == self.data.len() {
+                return Poll::Ready(Ok(0));
+            }
+
+            let remaining = self.data.len() - self.offset;
+            let len = remaining.min(buf.len()).min(self.max_chunk);
+            let end = self.offset + len;
+            buf[..len].copy_from_slice(&self.data[self.offset..end]);
+            self.offset = end;
+            Poll::Ready(Ok(len))
+        }
     }
 
     #[derive(Default)]

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -29,6 +29,12 @@ where
     }
 }
 
+impl FrameableWrite for futures::io::Sink {
+    fn supports_write_vectored(&self) -> bool {
+        false
+    }
+}
+
 /// A `Sink` of ZMTP messages encoded to an `AsyncWrite`.
 ///
 /// The ordinary codec encoder still exists for pure codec callers. This write
@@ -103,7 +109,7 @@ impl ZmqFramedWrite {
     }
 }
 
-impl Sink<Message> for ZmqFramedWrite {
+impl<'a> Sink<&'a Message> for ZmqFramedWrite {
     type Error = CodecError;
 
     fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -111,13 +117,13 @@ impl Sink<Message> for ZmqFramedWrite {
         self.poll_drain_buffer(cx, false)
     }
 
-    fn start_send(mut self: Pin<&mut Self>, item: Message) -> Result<(), Self::Error> {
+    fn start_send(mut self: Pin<&mut Self>, item: &'a Message) -> Result<(), Self::Error> {
         match item {
-            Message::Message(message) if self.should_write_vectored(&message) => {
+            Message::Message(message) if self.should_write_vectored(message) => {
                 self.pending = Some(PendingWrite::from_message(message));
                 Ok(())
             }
-            item => {
+            _ => {
                 let this = &mut *self;
                 this.codec.encode(item, &mut this.buffer)
             }
@@ -148,15 +154,15 @@ struct PendingWrite {
 }
 
 impl PendingWrite {
-    fn from_message(message: ZmqMessage) -> Self {
-        let mut frames = message.into_vec().into_iter().peekable();
+    fn from_message(message: &ZmqMessage) -> Self {
+        let mut frames = message.iter().peekable();
         let mut segments = Vec::new();
 
         while let Some(payload) = frames.next() {
             let more = frames.peek().is_some();
-            segments.push(PendingSegment::Header(FrameHeader::new(&payload, more)));
+            segments.push(PendingSegment::Header(FrameHeader::new(payload, more)));
             if !payload.is_empty() {
-                segments.push(PendingSegment::Payload(payload));
+                segments.push(PendingSegment::Payload(payload.clone()));
             }
         }
 
@@ -294,7 +300,8 @@ mod tests {
         let expected = encode_with_codec(message.clone());
 
         let mut framed = ZmqFramedWrite::new(Box::new(writer));
-        block_on(framed.send(Message::Message(message))).expect("send succeeds");
+        let outbound = Message::Message(message);
+        block_on(framed.send(&outbound)).expect("send succeeds");
 
         let stats = stats.lock().expect("stats lock");
         assert_eq!(stats.bytes, expected);
@@ -313,7 +320,8 @@ mod tests {
         let expected = encode_with_codec(message.clone());
 
         let mut framed = ZmqFramedWrite::new(Box::new(writer));
-        block_on(framed.send(Message::Message(message))).expect("send succeeds");
+        let outbound = Message::Message(message);
+        block_on(framed.send(&outbound)).expect("send succeeds");
 
         let stats = stats.lock().expect("stats lock");
         assert_eq!(stats.bytes, expected);
@@ -324,9 +332,8 @@ mod tests {
     fn encode_with_codec(message: ZmqMessage) -> Vec<u8> {
         let mut codec = ZmqCodec::new();
         let mut dst = BytesMut::new();
-        codec
-            .encode(Message::Message(message), &mut dst)
-            .expect("codec encode");
+        let outbound = Message::Message(message);
+        codec.encode(&outbound, &mut dst).expect("codec encode");
         dst.to_vec()
     }
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -7,6 +7,7 @@ mod framed;
 mod greeting;
 pub(crate) mod mechanism;
 mod zmq_codec;
+mod zmtp_frame;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -11,7 +11,7 @@ mod zmtp_frame;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};
-pub(crate) use framed::{FrameableRead, FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
+pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
 pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub use zmq_codec::ZmqCodec;
 

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -143,12 +143,12 @@ fn encode_frame(frame: &Bytes, dst: &mut BytesMut, more: bool) {
 
 impl Encoder for ZmqCodec {
     type Error = CodecError;
-    type Item<'a> = Message;
+    type Item<'a> = &'a Message;
 
     fn encode(&mut self, message: Self::Item<'_>, dst: &mut BytesMut) -> Result<(), Self::Error> {
         match message {
-            Message::Greeting(payload) => dst.unsplit(payload.into()),
-            Message::Command(command) => dst.unsplit(command.into()),
+            Message::Greeting(payload) => dst.unsplit((*payload).into()),
+            Message::Command(command) => dst.unsplit(command.clone().into()),
             Message::Message(message) => {
                 let last_element = message.len() - 1;
                 for (idx, part) in message.iter().enumerate() {

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -1,27 +1,21 @@
 use super::command::ZmqCommand;
 use super::error::CodecError;
 use super::greeting::ZmqGreeting;
+use super::zmtp_frame::{encode_payload_frame, ZmtpFrameHeader, GREETING_SIZE};
 use super::Message;
 use crate::ZmqMessage;
 
 use asynchronous_codec::{Decoder, Encoder};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 
 use std::convert::TryFrom;
-
-#[derive(Debug, Clone, Copy)]
-struct Frame {
-    command: bool,
-    long: bool,
-    more: bool,
-}
 
 #[derive(Debug)]
 enum DecoderState {
     Greeting,
     FrameHeader,
-    FrameLen(Frame),
-    Frame(Frame),
+    FrameLen(ZmtpFrameHeader),
+    Frame(ZmtpFrameHeader),
 }
 
 #[derive(Debug)]
@@ -38,7 +32,7 @@ impl ZmqCodec {
     pub fn new() -> Self {
         Self {
             state: DecoderState::Greeting,
-            waiting_for: 64, // len of the greeting frame
+            waiting_for: GREETING_SIZE,
             buffered_message: None,
         }
     }
@@ -67,19 +61,15 @@ impl Decoder for ZmqCodec {
                 self.state = DecoderState::FrameHeader;
                 self.waiting_for = 1;
                 Ok(Some(Message::Greeting(ZmqGreeting::try_from(
-                    src.split_to(64).freeze(),
+                    src.split_to(GREETING_SIZE).freeze(),
                 )?)))
             }
             DecoderState::FrameHeader => {
                 let flags = src.get_u8();
 
-                let frame = Frame {
-                    command: (flags & 0b0000_0100) != 0,
-                    long: (flags & 0b0000_0010) != 0,
-                    more: (flags & 0b0000_0001) != 0,
-                };
+                let frame = ZmtpFrameHeader::from_flags(flags);
                 self.state = DecoderState::FrameLen(frame);
-                self.waiting_for = if frame.long { 8 } else { 1 };
+                self.waiting_for = frame.length_size();
                 self.decode(src)
             }
             DecoderState::FrameLen(frame) => {
@@ -121,24 +111,7 @@ impl Decoder for ZmqCodec {
 }
 
 fn encode_frame(frame: &Bytes, dst: &mut BytesMut, more: bool) {
-    let mut flags: u8 = 0;
-    if more {
-        flags |= 0b0000_0001;
-    }
-    let len = frame.len();
-    if len > 255 {
-        flags |= 0b0000_0010;
-        dst.reserve(len + 9);
-    } else {
-        dst.reserve(len + 2);
-    }
-    dst.put_u8(flags);
-    if len > 255 {
-        dst.put_u64(len as u64);
-    } else {
-        dst.put_u8(len as u8);
-    }
-    dst.extend_from_slice(frame.as_ref());
+    encode_payload_frame(frame, dst, false, more);
 }
 
 impl Encoder for ZmqCodec {

--- a/src/codec/zmtp_frame.rs
+++ b/src/codec/zmtp_frame.rs
@@ -1,0 +1,126 @@
+use bytes::{BufMut, Bytes, BytesMut};
+
+pub(crate) const GREETING_SIZE: usize = 64;
+
+const MORE_FLAG: u8 = 0b0000_0001;
+const LONG_FLAG: u8 = 0b0000_0010;
+const COMMAND_FLAG: u8 = 0b0000_0100;
+const SHORT_FRAME_LIMIT: usize = u8::MAX as usize;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ZmtpFrameHeader {
+    pub(crate) command: bool,
+    pub(crate) long: bool,
+    pub(crate) more: bool,
+}
+
+impl ZmtpFrameHeader {
+    pub(crate) fn from_flags(flags: u8) -> Self {
+        Self {
+            command: (flags & COMMAND_FLAG) != 0,
+            long: (flags & LONG_FLAG) != 0,
+            more: (flags & MORE_FLAG) != 0,
+        }
+    }
+
+    pub(crate) fn for_payload(payload_len: usize, command: bool, more: bool) -> Self {
+        Self {
+            command,
+            long: payload_len > SHORT_FRAME_LIMIT,
+            more,
+        }
+    }
+
+    pub(crate) const fn length_size(self) -> usize {
+        if self.long {
+            8
+        } else {
+            1
+        }
+    }
+
+    pub(crate) fn encoded_len(self, payload_len: usize) -> usize {
+        1 + self.length_size() + payload_len
+    }
+
+    pub(crate) fn write_prefix(self, payload_len: usize, dst: &mut BytesMut) {
+        debug_assert_eq!(self.long, payload_len > SHORT_FRAME_LIMIT);
+
+        dst.reserve(self.encoded_len(payload_len));
+        dst.put_u8(self.flag_byte());
+        if self.long {
+            dst.put_u64(payload_len as u64);
+        } else {
+            dst.put_u8(payload_len as u8);
+        }
+    }
+
+    const fn flag_byte(self) -> u8 {
+        let mut flags = 0;
+        if self.more {
+            flags |= MORE_FLAG;
+        }
+        if self.long {
+            flags |= LONG_FLAG;
+        }
+        if self.command {
+            flags |= COMMAND_FLAG;
+        }
+        flags
+    }
+}
+
+pub(crate) fn encode_payload_frame(payload: &Bytes, dst: &mut BytesMut, command: bool, more: bool) {
+    let header = ZmtpFrameHeader::for_payload(payload.len(), command, more);
+    header.write_prefix(payload.len(), dst);
+    dst.extend_from_slice(payload.as_ref());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_frame_flag_fixture() {
+        let header = ZmtpFrameHeader::from_flags(COMMAND_FLAG | LONG_FLAG | MORE_FLAG);
+
+        assert!(header.command);
+        assert!(header.long);
+        assert!(header.more);
+        assert_eq!(header.length_size(), 8);
+    }
+
+    #[test]
+    fn encodes_short_data_frame_fixture() {
+        let payload = Bytes::from_static(b"abc");
+        let mut out = BytesMut::new();
+
+        encode_payload_frame(&payload, &mut out, false, true);
+
+        assert_eq!(&out[..], &[MORE_FLAG, 3, b'a', b'b', b'c']);
+    }
+
+    #[test]
+    fn encodes_short_command_frame_fixture() {
+        let mut out = BytesMut::new();
+        let header = ZmtpFrameHeader::for_payload(5, true, false);
+
+        header.write_prefix(5, &mut out);
+        out.extend_from_slice(b"READY");
+
+        assert_eq!(&out[..], &[COMMAND_FLAG, 5, b'R', b'E', b'A', b'D', b'Y']);
+    }
+
+    #[test]
+    fn encodes_long_data_frame_fixture() {
+        let payload = Bytes::from(vec![0xab; 256]);
+        let mut out = BytesMut::new();
+
+        encode_payload_frame(&payload, &mut out, false, false);
+
+        assert_eq!(out[0], LONG_FLAG);
+        assert_eq!(&out[1..9], 256u64.to_be_bytes());
+        assert_eq!(out.len(), 1 + 8 + payload.len());
+        assert!(out[9..].iter().all(|byte| *byte == 0xab));
+    }
+}

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -236,6 +236,7 @@ mod test {
     use crate::async_rt;
     use crate::fair_queue::FairQueue;
     use futures::task::noop_waker;
+    use futures::Future;
     use futures::{stream, Stream, StreamExt};
     use std::collections::VecDeque;
     use std::pin::Pin;
@@ -253,6 +254,11 @@ mod test {
 
     struct WakePendingStream {
         poll_count: usize,
+    }
+
+    struct WakeThenReadyStream {
+        poll_count: usize,
+        message: Option<&'static str>,
     }
 
     impl TestStream {
@@ -288,6 +294,21 @@ mod test {
             self.get_mut().poll_count += 1;
             cx.waker().wake_by_ref();
             Poll::Pending
+        }
+    }
+
+    impl Stream for WakeThenReadyStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            this.poll_count += 1;
+            if this.poll_count == 1 {
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            } else {
+                Poll::Ready(this.message.take())
+            }
         }
     }
 
@@ -356,6 +377,35 @@ mod test {
                 (3, "c3")
             ]
         );
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_next_future_can_be_dropped_after_pending() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<WakeThenReadyStream, &str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "peer",
+                WakeThenReadyStream {
+                    poll_count: 0,
+                    message: Some("message"),
+                },
+            );
+        }
+
+        {
+            let mut next = fair_queue.next();
+            assert!(
+                matches!(Pin::new(&mut next).poll(&mut cx), Poll::Pending),
+                "first poll should park the recv future"
+            );
+        }
+
+        assert_eq!(fair_queue.next().await, Some(("peer", "message")));
     }
 
     #[async_rt::test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,6 @@ use crate::transport::AcceptStopHandle;
 use util::PeerIdentity;
 
 use async_trait::async_trait;
-use asynchronous_codec::FramedWrite;
 use futures::channel::mpsc;
 use futures::{select, FutureExt};
 use parking_lot::Mutex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod fair_queue;
 mod message;
 mod r#pub;
+mod pub_fanout;
 mod pull;
 mod push;
 mod reconnect;

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -2,6 +2,9 @@ use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::message::*;
+use crate::pub_fanout::{
+    subscription_change, FanoutEvent, FanoutEventReceiver, FanoutEventSender, FanoutState,
+};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{async_rt, CaptureSocket, SocketOptions};
@@ -9,64 +12,53 @@ use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, So
 
 use async_trait::async_trait;
 use futures::channel::{mpsc, oneshot};
-use futures::lock::Mutex as AsyncMutex;
-use futures::{select, FutureExt, SinkExt, StreamExt};
+use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) struct Subscriber {
-    pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+pub(crate) struct PubConnection {
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
 pub(crate) struct PubSocketBackend {
-    subscribers: scc::HashMap<PeerIdentity, Subscriber>,
+    connections: scc::HashMap<PeerIdentity, PubConnection>,
+    fanout_events: FanoutEventSender,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
 }
 
 impl PubSocketBackend {
     fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let data = match message {
-            Message::Message(m) => {
-                if m.len() != 1 {
-                    log::warn!("Received message with unexpected length: {}", m.len());
-                    return;
-                }
-                m.into_vec().pop().unwrap_or_default()
-            }
+        let message = match message {
+            Message::Message(m) => m,
             _ => return,
         };
 
-        if data.is_empty() {
+        if let Some(change) = subscription_change(&message) {
+            let _ = self
+                .fanout_events
+                .unbounded_send(FanoutEvent::Subscription {
+                    peer_id: peer_id.clone(),
+                    change,
+                });
             return;
         }
 
-        match data.first() {
-            Some(1) => {
-                // Subscribe
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    entry.subscriptions.push(Vec::from(&data[1..]));
-                }
-            }
-            Some(0) => {
-                // Unsubscribe
-                let sub = Vec::from(&data[1..]);
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    if let Some(index) = entry.subscriptions.iter().position(|s| s == &sub) {
-                        entry.subscriptions.remove(index);
-                    }
-                }
-            }
-            _ => log::warn!(
+        if message.len() != 1 {
+            log::warn!("Received message with unexpected length: {}", message.len());
+            return;
+        }
+
+        let Some(frame) = message.get(0) else {
+            return;
+        };
+        if !frame.is_empty() {
+            log::warn!(
                 "Received message with unexpected first byte: {:?}",
-                data.first()
-            ),
+                frame.first()
+            );
         }
     }
 }
@@ -81,7 +73,7 @@ impl SocketBackend for PubSocketBackend {
     }
 
     fn shutdown(&self) {
-        self.subscribers.clear_sync();
+        self.connections.clear_sync();
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -93,18 +85,28 @@ impl SocketBackend for PubSocketBackend {
 impl MultiPeerBackend for PubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (mut recv_queue, send_queue) = io.into_parts();
-        // TODO provide handling for recv_queue
         let (sender, stop_receiver) = oneshot::channel();
-        self.subscribers
+        self.connections
             .upsert_async(
                 peer_id.clone(),
-                Subscriber {
-                    subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                PubConnection {
                     _subscription_coro_stop: sender,
                 },
             )
             .await;
+
+        if self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerConnected {
+                peer_id: peer_id.clone(),
+                send_queue,
+            })
+            .is_err()
+        {
+            self.connections.remove_sync(peer_id);
+            return;
+        }
+
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -139,12 +141,17 @@ impl MultiPeerBackend for PubSocketBackend {
         if let Some(monitor) = self.monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
         }
-        self.subscribers.remove_sync(peer_id);
+        self.connections.remove_sync(peer_id);
+        let _ = self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerDisconnected(peer_id.clone()));
     }
 }
 
 pub struct PubSocket {
     pub(crate) backend: Arc<PubSocketBackend>,
+    fanout_state: FanoutState,
+    fanout_events: FanoutEventReceiver,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -157,45 +164,17 @@ impl Drop for PubSocket {
 #[async_trait]
 impl SocketSend for PubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         let first_frame = match message.get(0) {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
-        }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
+        let dead_peers = self
+            .fanout_state
+            .send_matching(first_frame, &message)
+            .await?;
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);
         }
@@ -208,12 +187,16 @@ impl CaptureSocket for PubSocket {}
 #[async_trait]
 impl Socket for PubSocket {
     fn with_options(options: SocketOptions) -> Self {
+        let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         Self {
             backend: Arc::new(PubSocketBackend {
-                subscribers: scc::HashMap::new(),
+                connections: scc::HashMap::new(),
+                fanout_events: fanout_event_sender,
                 socket_monitor: Mutex::new(None),
                 socket_options: options,
             }),
+            fanout_state: FanoutState::default(),
+            fanout_events,
             binds: HashMap::new(),
         }
     }

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -174,13 +174,9 @@ impl SocketSend for PubSocket {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {

--- a/src/pub_fanout.rs
+++ b/src/pub_fanout.rs
@@ -1,0 +1,201 @@
+use crate::codec::{CodecError, Message, ZmqFramedWrite};
+use crate::error::ZmqResult;
+use crate::message::ZmqMessage;
+use crate::util::PeerIdentity;
+
+use futures::channel::mpsc;
+use futures::SinkExt;
+
+use std::collections::HashMap;
+use std::io::ErrorKind;
+
+pub(crate) type FanoutEventSender = mpsc::UnboundedSender<FanoutEvent>;
+pub(crate) type FanoutEventReceiver = mpsc::UnboundedReceiver<FanoutEvent>;
+
+pub(crate) enum SubscriptionChange {
+    Subscribe(Vec<u8>),
+    Unsubscribe(Vec<u8>),
+}
+
+pub(crate) enum FanoutEvent {
+    PeerConnected {
+        peer_id: PeerIdentity,
+        send_queue: ZmqFramedWrite,
+    },
+    Subscription {
+        peer_id: PeerIdentity,
+        change: SubscriptionChange,
+    },
+    PeerDisconnected(PeerIdentity),
+}
+
+struct FanoutPeer {
+    subscriptions: Vec<Vec<u8>>,
+    send_queue: ZmqFramedWrite,
+}
+
+impl FanoutPeer {
+    fn is_subscribed_to(&self, first_frame: &[u8]) -> bool {
+        self.subscriptions.iter().any(|sub_filter| {
+            sub_filter.len() <= first_frame.len()
+                && sub_filter.as_slice() == &first_frame[..sub_filter.len()]
+        })
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct FanoutState {
+    peers: HashMap<PeerIdentity, FanoutPeer>,
+}
+
+impl FanoutState {
+    pub(crate) fn drain_events(&mut self, events: &mut FanoutEventReceiver) {
+        while let Ok(event) = events.try_recv() {
+            self.apply_event(event);
+        }
+    }
+
+    pub(crate) fn apply_event(&mut self, event: FanoutEvent) {
+        match event {
+            FanoutEvent::PeerConnected {
+                peer_id,
+                send_queue,
+            } => self.peer_connected(peer_id, send_queue),
+            FanoutEvent::Subscription { peer_id, change } => {
+                self.apply_subscription(&peer_id, change);
+            }
+            FanoutEvent::PeerDisconnected(peer_id) => self.peer_disconnected(&peer_id),
+        }
+    }
+
+    pub(crate) fn peer_connected(&mut self, peer_id: PeerIdentity, send_queue: ZmqFramedWrite) {
+        self.peers.insert(
+            peer_id,
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue,
+            },
+        );
+    }
+
+    pub(crate) fn peer_disconnected(&mut self, peer_id: &PeerIdentity) {
+        self.peers.remove(peer_id);
+    }
+
+    pub(crate) fn apply_subscription(
+        &mut self,
+        peer_id: &PeerIdentity,
+        change: SubscriptionChange,
+    ) {
+        let Some(peer) = self.peers.get_mut(peer_id) else {
+            return;
+        };
+
+        match change {
+            SubscriptionChange::Subscribe(subscription) => {
+                peer.subscriptions.push(subscription);
+            }
+            SubscriptionChange::Unsubscribe(subscription) => {
+                if let Some(index) = peer
+                    .subscriptions
+                    .iter()
+                    .position(|existing| existing == &subscription)
+                {
+                    peer.subscriptions.remove(index);
+                }
+            }
+        }
+    }
+
+    pub(crate) async fn send_matching(
+        &mut self,
+        first_frame: &[u8],
+        message: &ZmqMessage,
+    ) -> ZmqResult<Vec<PeerIdentity>> {
+        let mut dead_peers = Vec::new();
+
+        for (peer_id, peer) in self.peers.iter_mut() {
+            if !peer.is_subscribed_to(first_frame) {
+                continue;
+            }
+
+            let res = peer
+                .send_queue
+                .send(Message::Message(message.clone()))
+                .await;
+            match res {
+                Ok(()) => {}
+                Err(CodecError::Io(e)) => {
+                    if e.kind() == ErrorKind::BrokenPipe {
+                        dead_peers.push(peer_id.clone());
+                    } else {
+                        log::error!("Error sending message: {:?}", e);
+                    }
+                }
+                Err(e) => {
+                    log::error!("Error sending message: {:?}", e);
+                    return Err(e.into());
+                }
+            }
+        }
+
+        for peer_id in &dead_peers {
+            self.peers.remove(peer_id);
+        }
+
+        Ok(dead_peers)
+    }
+}
+
+pub(crate) fn subscription_change(message: &ZmqMessage) -> Option<SubscriptionChange> {
+    let frame = message.get(0)?;
+    if message.len() != 1 || frame.is_empty() {
+        return None;
+    }
+
+    match frame[0] {
+        1 => Some(SubscriptionChange::Subscribe(frame[1..].to_vec())),
+        0 => Some(SubscriptionChange::Unsubscribe(frame[1..].to_vec())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{FrameableWrite, ZmqCodec};
+
+    use asynchronous_codec::FramedWrite;
+
+    #[test]
+    fn duplicate_subscription_requires_matching_unsubscribe_events() {
+        let mut state = FanoutState::default();
+        let peer_id = PeerIdentity::new();
+        state.peers.insert(
+            peer_id.clone(),
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue: sink_write(),
+            },
+        );
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-subscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-one-unsubscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(!peer.is_subscribed_to(b"dup-after-two-unsubscribes"));
+    }
+
+    fn sink_write() -> ZmqFramedWrite {
+        let writer: Box<dyn FrameableWrite> = Box::new(futures::io::sink());
+        FramedWrite::new(writer, ZmqCodec::new())
+    }
+}

--- a/src/pub_fanout.rs
+++ b/src/pub_fanout.rs
@@ -114,15 +114,13 @@ impl FanoutState {
     ) -> ZmqResult<Vec<PeerIdentity>> {
         let mut dead_peers = Vec::new();
 
+        let outbound = Message::Message(message.clone());
         for (peer_id, peer) in self.peers.iter_mut() {
             if !peer.is_subscribed_to(first_frame) {
                 continue;
             }
 
-            let res = peer
-                .send_queue
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = peer.send_queue.send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {
@@ -163,9 +161,7 @@ pub(crate) fn subscription_change(message: &ZmqMessage) -> Option<SubscriptionCh
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::{FrameableWrite, ZmqCodec};
-
-    use asynchronous_codec::FramedWrite;
+    use crate::codec::FrameableWrite;
 
     #[test]
     fn duplicate_subscription_requires_matching_unsubscribe_events() {
@@ -196,6 +192,6 @@ mod tests {
 
     fn sink_write() -> ZmqFramedWrite {
         let writer: Box<dyn FrameableWrite> = Box::new(futures::io::sink());
-        FramedWrite::new(writer, ZmqCodec::new())
+        ZmqFramedWrite::new(writer)
     }
 }

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -135,7 +135,8 @@ impl SocketSend for RepSocket {
                     if let Some(envelope) = self.envelope.take() {
                         message.prepend(&envelope);
                     }
-                    peer.send_queue.send(Message::Message(message)).await?;
+                    let outbound = Message::Message(message);
+                    peer.send_queue.send(&outbound).await?;
                     Ok(())
                 } else {
                     Err(ZmqError::ReturnToSender {

--- a/src/req.rs
+++ b/src/req.rs
@@ -71,36 +71,36 @@ impl SocketSend for ReqSocket {
 #[async_trait]
 impl SocketRecv for ReqSocket {
     async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
-        match self.current_request.take() {
-            Some(peer_id) => {
-                if let Some(mut peer) = self.backend.peers.get_async(&peer_id).await {
-                    match peer.recv_queue.next().await {
-                        Some(Ok(Message::Message(mut m))) => {
-                            if m.len() < 2 {
-                                return Err(ZmqError::Other(
-                                    "Invalid message format: too few frames",
-                                ));
-                            }
-                            if !m.pop_front().unwrap().is_empty() {
-                                return Err(ZmqError::Other(
-                                    "Invalid message format: missing delimiter",
-                                ));
-                            }
-                            Ok(m)
-                        }
-                        Some(Ok(_)) => {
-                            // Non-message frames should be ignored by the caller
-                            Err(ZmqError::Other("Received non-message frame"))
-                        }
-                        Some(Err(error)) => Err(error.into()),
-                        None => Err(ZmqError::NoMessage),
-                    }
+        let peer_id = match self.current_request.clone() {
+            Some(peer_id) => peer_id,
+            None => return Err(ZmqError::Other("Unable to recv. No request in progress")),
+        };
+
+        let Some(mut peer) = self.backend.peers.get_async(&peer_id).await else {
+            self.current_request = None;
+            return Err(ZmqError::Other("Server disconnected"));
+        };
+
+        let result = match peer.recv_queue.next().await {
+            Some(Ok(Message::Message(mut m))) => {
+                if m.len() < 2 {
+                    Err(ZmqError::Other("Invalid message format: too few frames"))
+                } else if !m.pop_front().unwrap().is_empty() {
+                    Err(ZmqError::Other("Invalid message format: missing delimiter"))
                 } else {
-                    Err(ZmqError::Other("Server disconnected"))
+                    Ok(m)
                 }
             }
-            None => Err(ZmqError::Other("Unable to recv. No request in progress")),
-        }
+            Some(Ok(_)) => {
+                // Non-message frames should be ignored by the caller
+                Err(ZmqError::Other("Received non-message frame"))
+            }
+            Some(Err(error)) => Err(error.into()),
+            None => Err(ZmqError::NoMessage),
+        };
+
+        self.current_request = None;
+        result
     }
 }
 

--- a/src/req.rs
+++ b/src/req.rs
@@ -60,7 +60,8 @@ impl SocketSend for ReqSocket {
             if let Some(mut peer) = self.backend.peers.get_async(&next_peer_id).await {
                 self.backend.round_robin.push(next_peer_id.clone());
                 message.push_front(Bytes::new());
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 self.current_request = Some(next_peer_id);
                 return Ok(());
             }

--- a/src/router.rs
+++ b/src/router.rs
@@ -107,7 +107,8 @@ impl SocketSend for RouterSocket {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),
@@ -182,7 +183,8 @@ impl SocketSend for RouterSendHalf {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.inner.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                let outbound = Message::Message(message);
+                peer.send_queue.send(&outbound).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -164,13 +164,9 @@ impl SubSocketBackend {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {
@@ -217,13 +213,9 @@ impl SubSocketBackend {
 
         let mut dead_peers = Vec::new();
         let mut first_error = None;
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let result = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let result = send_queue.lock().await.as_mut().send(&outbound).await;
             match result {
                 Ok(()) => {}
                 Err(e)
@@ -283,7 +275,8 @@ impl MultiPeerBackend for SubSocketBackend {
         let (recv_queue, mut send_queue) = io.into_parts();
 
         for message in self.subscription_messages() {
-            if let Err(e) = send_queue.send(Message::Message(message)).await {
+            let outbound = Message::Message(message);
+            if let Err(e) = send_queue.send(&outbound).await {
                 log::error!("Failed to send subscription to peer {:?}: {:?}", peer_id, e);
                 return;
             }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -93,20 +93,70 @@ where
 #[cfg(feature = "tokio-runtime")]
 fn make_framed<T>(stream: T) -> FramedIo
 where
-    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Send + Sync + 'static,
+    T: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin + Send + Sync + 'static,
 {
-    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+    use tokio_util::compat::TokioAsyncReadCompatExt;
     let (read, write) = tokio::io::split(stream);
-    FramedIo::new(Box::new(read.compat()), Box::new(write.compat_write()))
+    FramedIo::new(Box::new(read.compat()), Box::new(TokioWriteCompat(write)))
+}
+
+#[cfg(feature = "tokio-runtime")]
+struct TokioWriteCompat<T>(T);
+
+#[cfg(feature = "tokio-runtime")]
+impl<T> futures::AsyncWrite for TokioWriteCompat<T>
+where
+    T: tokio::io::AsyncWrite + Unpin,
+{
+    fn poll_write(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        tokio::io::AsyncWrite::poll_write(std::pin::Pin::new(&mut self.0), cx, buf)
+    }
+
+    fn poll_write_vectored(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        bufs: &[std::io::IoSlice<'_>],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        tokio::io::AsyncWrite::poll_write_vectored(std::pin::Pin::new(&mut self.0), cx, bufs)
+    }
+
+    fn poll_flush(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        tokio::io::AsyncWrite::poll_flush(std::pin::Pin::new(&mut self.0), cx)
+    }
+
+    fn poll_close(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        tokio::io::AsyncWrite::poll_shutdown(std::pin::Pin::new(&mut self.0), cx)
+    }
+}
+
+#[cfg(feature = "tokio-runtime")]
+impl<T> crate::codec::FrameableWrite for TokioWriteCompat<T>
+where
+    T: tokio::io::AsyncWrite + Unpin + Send + Sync,
+{
+    fn supports_write_vectored(&self) -> bool {
+        tokio::io::AsyncWrite::is_write_vectored(&self.0)
+    }
 }
 
 #[allow(unused)]
 #[cfg(any(feature = "async-std-runtime", feature = "async-dispatcher-runtime"))]
 fn make_framed<T>(stream: T) -> FramedIo
 where
-    T: futures::AsyncRead + futures::AsyncWrite + Send + Sync + 'static,
+    T: futures::AsyncRead + futures::AsyncWrite + Unpin + Send + Sync + 'static,
 {
     use futures::AsyncReadExt;
     let (read, write) = stream.split();
-    FramedIo::new(Box::new(read), Box::new(write))
+    let write: Box<dyn crate::codec::FrameableWrite> = Box::new(write);
+    FramedIo::new(Box::new(read), write)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
-use crate::codec::{CodecResult, FramedIo, ZmqFramedWrite};
+use crate::codec::{CodecResult, FramedIo, ZmqFramedRead, ZmqFramedWrite};
 use crate::*;
 
-use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use rand::Rng;
@@ -100,7 +99,7 @@ impl From<PeerIdentity> for Vec<u8> {
 pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: ZmqFramedWrite,
-    pub(crate) recv_queue: FramedRead<Box<dyn FrameableRead>, ZmqCodec>,
+    pub(crate) recv_queue: ZmqFramedRead,
 }
 
 /// Given the result of the greetings exchange, determines the version of the

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use crate::codec::{CodecResult, FramedIo};
+use crate::codec::{CodecResult, FramedIo, ZmqFramedWrite};
 use crate::*;
 
 use asynchronous_codec::FramedRead;
@@ -99,7 +99,7 @@ impl From<PeerIdentity> for Vec<u8> {
 
 pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
-    pub(crate) send_queue: FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>,
+    pub(crate) send_queue: ZmqFramedWrite,
     pub(crate) recv_queue: FramedRead<Box<dyn FrameableRead>, ZmqCodec>,
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -134,10 +134,8 @@ fn negotiate_version(greeting: Message) -> ZmqResult<ZmtpVersion> {
 }
 
 pub(crate) async fn greet_exchange(raw_socket: &mut FramedIo) -> ZmqResult<ZmtpVersion> {
-    raw_socket
-        .write_half
-        .send(Message::Greeting(ZmqGreeting::default()))
-        .await?;
+    let greeting = Message::Greeting(ZmqGreeting::default());
+    raw_socket.write_half.send(&greeting).await?;
 
     let greeting = match raw_socket.read_half.next().await {
         Some(message) => message?,
@@ -155,7 +153,8 @@ pub(crate) async fn ready_exchange(
     if let Some(props) = props {
         ready.add_properties(props);
     }
-    raw_socket.write_half.send(Message::Command(ready)).await?;
+    let ready = Message::Command(ready);
+    raw_socket.write_half.send(&ready).await?;
 
     let ready_repl: Option<CodecResult<Message>> = raw_socket.read_half.next().await;
     match ready_repl {

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -148,13 +148,9 @@ impl SocketSend for XPubSocket {
         }
 
         let mut dead_peers = Vec::new();
+        let outbound = Message::Message(message);
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
+            let res = send_queue.lock().await.as_mut().send(&outbound).await;
             match res {
                 Ok(()) => {}
                 Err(CodecError::Io(e)) => {

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -3,6 +3,9 @@ use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::{FairQueue, QueueInner};
 use crate::message::*;
+use crate::pub_fanout::{
+    subscription_change, FanoutEvent, FanoutEventReceiver, FanoutEventSender, FanoutState,
+};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{CaptureSocket, SocketOptions};
@@ -13,62 +16,17 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::lock::Mutex as AsyncMutex;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) struct XPubSubscriber {
-    pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
-}
-
 pub(crate) struct XPubSocketBackend {
-    subscribers: scc::HashMap<PeerIdentity, XPubSubscriber>,
+    fanout_events: FanoutEventSender,
     fair_queue_inner: Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
-}
-
-impl XPubSocketBackend {
-    fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let data = match message {
-            Message::Message(m) => {
-                if m.len() != 1 {
-                    return;
-                }
-                m.into_vec().pop().unwrap_or_default()
-            }
-            _ => return,
-        };
-
-        if data.is_empty() {
-            return;
-        }
-
-        match data.first() {
-            Some(1) => {
-                // Subscribe
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    entry.subscriptions.push(Vec::from(&data[1..]));
-                }
-            }
-            Some(0) => {
-                // Unsubscribe
-                let sub = Vec::from(&data[1..]);
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    if let Some(index) = entry.subscriptions.iter().position(|s| s == &sub) {
-                        entry.subscriptions.remove(index);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
 }
 
 impl SocketBackend for XPubSocketBackend {
@@ -81,7 +39,7 @@ impl SocketBackend for XPubSocketBackend {
     }
 
     fn shutdown(&self) {
-        self.subscribers.clear_sync();
+        self.fair_queue_inner.lock().clear();
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -94,15 +52,16 @@ impl MultiPeerBackend for XPubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
 
-        self.subscribers
-            .upsert_async(
-                peer_id.clone(),
-                XPubSubscriber {
-                    subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
-                },
-            )
-            .await;
+        if self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerConnected {
+                peer_id: peer_id.clone(),
+                send_queue,
+            })
+            .is_err()
+        {
+            return;
+        }
 
         self.fair_queue_inner
             .lock()
@@ -111,14 +70,18 @@ impl MultiPeerBackend for XPubSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         log::info!("Client disconnected {:?}", peer_id);
-        self.subscribers.remove_sync(peer_id);
         self.fair_queue_inner.lock().remove(peer_id);
+        let _ = self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerDisconnected(peer_id.clone()));
     }
 }
 
 pub struct XPubSocket {
     pub(crate) backend: Arc<XPubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
+    fanout_state: FanoutState,
+    fanout_events: FanoutEventReceiver,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -131,45 +94,17 @@ impl Drop for XPubSocket {
 #[async_trait]
 impl SocketSend for XPubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         let first_frame = match message.get(0) {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
-        }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
+        let dead_peers = self
+            .fanout_state
+            .send_matching(first_frame, &message)
+            .await?;
         for peer in dead_peers {
             self.backend.peer_disconnected(&peer);
         }
@@ -180,19 +115,22 @@ impl SocketSend for XPubSocket {
 #[async_trait]
 impl SocketRecv for XPubSocket {
     async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         loop {
             match self.fair_queue.next().await {
                 Some((peer_id, Ok(Message::Message(message)))) => {
-                    // Process the subscription message internally to update tracking
-                    self.backend
-                        .message_received(&peer_id, Message::Message(message.clone()));
-                    // Also expose it to the application
+                    self.fanout_state.drain_events(&mut self.fanout_events);
+                    if let Some(change) = subscription_change(&message) {
+                        self.fanout_state.apply_subscription(&peer_id, change);
+                    }
                     return Ok(message);
                 }
                 Some((_peer_id, Ok(_msg))) => {
                     // Ignore non-message frames
                 }
                 Some((peer_id, Err(e))) => {
+                    self.fanout_state.peer_disconnected(&peer_id);
                     self.backend.peer_disconnected(&peer_id);
                     return Err(e.into());
                 }
@@ -210,8 +148,9 @@ impl CaptureSocket for XPubSocket {}
 impl Socket for XPubSocket {
     fn with_options(options: SocketOptions) -> Self {
         let mut fair_queue = FairQueue::new(true);
+        let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         let backend = Arc::new(XPubSocketBackend {
-            subscribers: scc::HashMap::new(),
+            fanout_events: fanout_event_sender,
             fair_queue_inner: fair_queue.inner(),
             socket_monitor: Mutex::new(None),
             socket_options: options,
@@ -227,6 +166,8 @@ impl Socket for XPubSocket {
         Self {
             backend,
             fair_queue,
+            fanout_state: FanoutState::default(),
+            fanout_events,
             binds: HashMap::new(),
         }
     }

--- a/tests/connect.rs
+++ b/tests/connect.rs
@@ -1,6 +1,6 @@
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
-use zeromq::{SocketOptions, ZmqError, ZmqMessage};
+use zeromq::{Endpoint, SocketOptions, ZmqError, ZmqMessage};
 
 use std::path::PathBuf;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -78,6 +78,45 @@ async fn connect_timeout_expires_for_missing_ipc_socket() {
 }
 
 #[async_rt::test]
+async fn tcp_active_bind_to_same_endpoint_is_rejected() {
+    let mut first = zeromq::RouterSocket::new();
+    let bound = first.bind("tcp://127.0.0.1:0").await.unwrap();
+    let endpoint = bound.to_string();
+
+    let mut second = zeromq::RouterSocket::new();
+    let err = second
+        .bind(&endpoint)
+        .await
+        .expect_err("second bind should fail while first listener is active");
+
+    assert!(matches!(err, ZmqError::Network(_)), "{err:?}");
+
+    let errs = first.close().await;
+    assert!(errs.is_empty(), "Could not unbind first socket: {:?}", errs);
+}
+
+#[async_rt::test]
+async fn ipc_active_bind_to_same_path_is_rejected() {
+    let (endpoint, path) = unique_ipc_endpoint("active-duplicate-bind");
+
+    let mut first = zeromq::RouterSocket::new();
+    let first_bound = first.bind(&endpoint).await.unwrap();
+    assert_eq!(first_bound.to_string(), endpoint);
+
+    let mut second = zeromq::RouterSocket::new();
+    let err = second
+        .bind(&endpoint)
+        .await
+        .expect_err("second bind should fail while first listener is active");
+
+    assert!(matches!(err, ZmqError::Network(_)), "{err:?}");
+
+    let errs = first.close().await;
+    assert!(errs.is_empty(), "Could not unbind first socket: {:?}", errs);
+    let _ = std::fs::remove_file(path);
+}
+
+#[async_rt::test]
 async fn ipc_close_allows_rebinding_same_path() {
     let (endpoint, path) = unique_ipc_endpoint("rebind");
 
@@ -99,6 +138,19 @@ async fn ipc_close_allows_rebinding_same_path() {
         errs
     );
     let _ = std::fs::remove_file(path);
+}
+
+#[async_rt::test]
+async fn unbind_unbound_endpoint_returns_no_such_bind() {
+    let mut socket = zeromq::RouterSocket::new();
+    let endpoint: Endpoint = "tcp://127.0.0.1:1".parse().unwrap();
+
+    let err = socket
+        .unbind(endpoint.clone())
+        .await
+        .expect_err("unbinding an endpoint that was never bound should fail");
+
+    assert!(matches!(err, ZmqError::NoSuchBind(e) if e == endpoint));
 }
 
 #[async_rt::test]

--- a/tests/large_message.rs
+++ b/tests/large_message.rs
@@ -2,6 +2,8 @@ use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
 use zeromq::{Endpoint, ZmqMessage};
 
+use bytes::Bytes;
+use std::convert::TryFrom;
 use std::time::Duration;
 
 fn tcp_endpoint(endpoint: Endpoint) -> String {
@@ -84,4 +86,32 @@ async fn xsub_xpub_delivers_large_message() {
         .expect("timeout waiting for large XSUB message")
         .unwrap();
     assert_eq!(received.get(0).unwrap().as_ref(), payload.as_slice());
+}
+
+#[async_rt::test]
+async fn dealer_router_delivers_large_multipart_message() {
+    let small = Bytes::from_static(b"metadata");
+    let large_a = Bytes::from(vec![0xA1; 300_000]);
+    let large_b = Bytes::from(vec![0xB2; 128_000]);
+
+    let mut router_socket = zeromq::RouterSocket::new();
+    let endpoint = tcp_endpoint(router_socket.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut dealer_socket = zeromq::DealerSocket::new();
+    dealer_socket.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let sent = ZmqMessage::try_from(vec![small.clone(), large_a.clone(), large_b.clone()])
+        .expect("multipart message");
+    dealer_socket.send(sent).await.unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), router_socket.recv())
+        .await
+        .expect("timeout waiting for large multipart DEALER message")
+        .unwrap();
+
+    assert_eq!(received.len(), 4);
+    assert_eq!(received.get(1).unwrap(), &small);
+    assert_eq!(received.get(2).unwrap(), &large_a);
+    assert_eq!(received.get(3).unwrap(), &large_b);
 }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -9,6 +9,130 @@ mod test {
     use futures::{SinkExt, StreamExt};
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
+    async fn wait_for_delivery(
+        pub_socket: &mut zeromq::PubSocket,
+        sub_socket: &mut zeromq::SubSocket,
+        payload: &str,
+    ) {
+        for _ in 0..200 {
+            pub_socket
+                .send(ZmqMessage::from(payload))
+                .await
+                .expect("failed to send sync payload");
+            match async_rt::task::timeout(Duration::from_millis(10), sub_socket.recv()).await {
+                Ok(Ok(message)) if message.get(0).unwrap().as_ref() == payload.as_bytes() => {
+                    return;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => panic!("failed to receive sync payload: {e:?}"),
+                Err(_) => async_rt::task::sleep(Duration::from_millis(5)).await,
+            }
+        }
+        panic!("timed out waiting for subscription to receive {payload}");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+        wait_for_delivery(&mut pub_socket, &mut early_sub, "early-sync").await;
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+        wait_for_delivery(&mut pub_socket, &mut late_sub, "late-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        pub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_unsubscribe_stops_delivery_after_later_subscription() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "gone-sync").await;
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "stay-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        pub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
+    }
+
     #[async_rt::test]
     async fn test_pub_sub_sockets() {
         pretty_env_logger::try_init().ok();

--- a/tests/push_pull_timeout.rs
+++ b/tests/push_pull_timeout.rs
@@ -46,7 +46,12 @@ async fn pull_recv_with_per_call_timeout_keeps_making_progress() {
             match tokio::time::timeout(remaining, pull.recv()).await {
                 Ok(Ok(_)) => count += 1,
                 Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-                Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+                Err(err) => {
+                    if Instant::now() >= deadline {
+                        break count;
+                    }
+                    panic!("per-call timeout fired after {count} messages: {err:?}");
+                }
             }
         }
     })
@@ -155,7 +160,12 @@ async fn run_issue_248_pull_child(endpoint: &str) {
         match tokio::time::timeout(remaining, socket.recv()).await {
             Ok(Ok(_)) => count += 1,
             Ok(Err(err)) => panic!("recv failed after {count} messages: {err:?}"),
-            Err(err) => panic!("per-call timeout fired after {count} messages: {err:?}"),
+            Err(err) => {
+                if Instant::now() >= deadline {
+                    break;
+                }
+                panic!("per-call timeout fired after {count} messages: {err:?}");
+            }
         }
     }
     assert!(

--- a/tests/recv_cancel_safety.rs
+++ b/tests/recv_cancel_safety.rs
@@ -1,0 +1,254 @@
+#![cfg(feature = "tokio-runtime")]
+
+use bytes::Bytes;
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use std::time::{Duration, Instant};
+use zeromq::prelude::*;
+use zeromq::{ZmqError, ZmqMessage};
+
+const CONNECT_DELAY: Duration = Duration::from_millis(250);
+const WATCHDOG: Duration = Duration::from_secs(10);
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn req_recv_timeout_keeps_pending_reply_available() {
+    let mut rep = zeromq::RepSocket::new();
+    let endpoint = rep.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let server = tokio::spawn(async move {
+        let request = rep.recv().await.unwrap();
+        assert_eq!(frame_text(&request, 0), "request");
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        rep.send(ZmqMessage::from("reply")).await.unwrap();
+    });
+
+    let mut req = zeromq::ReqSocket::new();
+    req.connect(&endpoint).await.unwrap();
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    req.send(ZmqMessage::from("request")).await.unwrap();
+
+    let timed_out = tokio::time::timeout(Duration::from_millis(5), req.recv()).await;
+    assert!(
+        timed_out.is_err(),
+        "first recv should time out before the delayed reply"
+    );
+
+    let reply = tokio::time::timeout(Duration::from_secs(2), req.recv())
+        .await
+        .expect("timed out waiting for reply after canceling recv")
+        .expect("recv failed after canceling a pending REQ receive");
+    assert_eq!(frame_text(&reply, 0), "reply");
+
+    server.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pull_recv_timeout_storm_preserves_single_peer_order() {
+    const MESSAGES: usize = 256;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    let sender = tokio::spawn(async move {
+        for seq in 0..MESSAGES {
+            send_with_retry(&mut push, single_frame(seq)).await;
+            if seq % 8 == 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            } else {
+                tokio::task::yield_now().await;
+            }
+        }
+    });
+
+    let deadline = Instant::now() + WATCHDOG;
+    let mut expected = 0;
+    let mut cancellations = 0;
+
+    while expected < MESSAGES {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "timed out after receiving {expected}/{MESSAGES} messages"
+        );
+
+        match tokio::time::timeout(Duration::from_micros(75).min(remaining), pull.recv()).await {
+            Ok(Ok(message)) => {
+                assert_eq!(message.len(), 1, "single-frame message was corrupted");
+                let seq = parse_seq(frame_text(&message, 0));
+                assert_eq!(seq, expected, "single-peer recv order changed");
+                expected += 1;
+            }
+            Ok(Err(err)) => panic!("recv failed after {expected} messages: {err:?}"),
+            Err(_) => cancellations += 1,
+        }
+    }
+
+    sender.await.unwrap();
+    assert!(
+        cancellations > 0,
+        "test did not exercise a canceled recv path"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pull_recv_cancel_storm_preserves_multipart_multi_peer_queues() {
+    const PEERS: usize = 3;
+    const MESSAGES_PER_PEER: usize = 96;
+    const LARGE_FRAME_LEN: usize = 16 * 1024;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut pushes = Vec::new();
+    for peer in 0..PEERS {
+        let mut push = zeromq::PushSocket::new();
+        push.connect(&endpoint).await.unwrap();
+        pushes.push((peer, push));
+    }
+    tokio::time::sleep(CONNECT_DELAY).await;
+
+    let mut senders = Vec::new();
+    for (peer, mut push) in pushes {
+        senders.push(tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis((peer as u64 + 1) * 10)).await;
+            for seq in 0..MESSAGES_PER_PEER {
+                send_with_retry(&mut push, multipart_message(peer, seq, LARGE_FRAME_LEN)).await;
+                if seq % 5 == 0 {
+                    tokio::time::sleep(Duration::from_millis(1)).await;
+                } else {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }));
+    }
+
+    let expected_total = PEERS * MESSAGES_PER_PEER;
+    let mut next_by_peer = BTreeMap::new();
+    for peer in 0..PEERS {
+        next_by_peer.insert(peer, 0usize);
+    }
+
+    let deadline = Instant::now() + WATCHDOG;
+    let mut received = 0;
+    let mut cancellations = 0;
+
+    while received < expected_total {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        assert!(
+            !remaining.is_zero(),
+            "timed out after receiving {received}/{expected_total} multipart messages"
+        );
+
+        tokio::select! {
+            biased;
+            _ = tokio::time::sleep(Duration::from_micros(75).min(remaining)) => {
+                cancellations += 1;
+            }
+            result = pull.recv() => {
+                let message = result.unwrap_or_else(|err| {
+                    panic!("recv failed after {received} multipart messages: {err:?}")
+                });
+                assert_multipart_message(message, &mut next_by_peer, LARGE_FRAME_LEN);
+                received += 1;
+            }
+        }
+    }
+
+    for sender in senders {
+        sender.await.unwrap();
+    }
+
+    assert!(
+        cancellations > 0,
+        "test did not exercise canceled recv attempts"
+    );
+    for peer in 0..PEERS {
+        assert_eq!(
+            next_by_peer[&peer], MESSAGES_PER_PEER,
+            "peer {peer} did not deliver all messages"
+        );
+    }
+}
+
+async fn send_with_retry(socket: &mut zeromq::PushSocket, message: ZmqMessage) {
+    let mut message = Some(message);
+    loop {
+        match socket.send(message.take().unwrap()).await {
+            Ok(()) => return,
+            Err(ZmqError::ReturnToSender {
+                message: returned, ..
+            }) => {
+                message = Some(returned);
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+            Err(err) => panic!("send failed: {err:?}"),
+        }
+    }
+}
+
+fn single_frame(seq: usize) -> ZmqMessage {
+    ZmqMessage::from(format!("seq:{seq:04}"))
+}
+
+fn multipart_message(peer: usize, seq: usize, large_frame_len: usize) -> ZmqMessage {
+    let marker = (b'a' + peer as u8) as char;
+    let large = std::iter::repeat(marker)
+        .take(large_frame_len)
+        .collect::<String>();
+
+    ZmqMessage::try_from(vec![
+        Bytes::from(format!("peer:{peer}")),
+        Bytes::from(format!("seq:{seq:04}")),
+        Bytes::from(large),
+        Bytes::from(format!("end:{peer}:{seq:04}")),
+    ])
+    .unwrap()
+}
+
+fn assert_multipart_message(
+    message: ZmqMessage,
+    next_by_peer: &mut BTreeMap<usize, usize>,
+    large_frame_len: usize,
+) {
+    assert_eq!(message.len(), 4, "multipart message frame count changed");
+
+    let peer_text = frame_text(&message, 0);
+    let peer = peer_text
+        .strip_prefix("peer:")
+        .unwrap()
+        .parse::<usize>()
+        .unwrap();
+    let seq = parse_seq(frame_text(&message, 1));
+    let expected_seq = next_by_peer
+        .get_mut(&peer)
+        .unwrap_or_else(|| panic!("unexpected peer {peer}"));
+
+    assert_eq!(
+        seq, *expected_seq,
+        "peer {peer} message order changed or a message was dropped"
+    );
+
+    let payload = message.get(2).unwrap();
+    assert_eq!(payload.len(), large_frame_len, "large frame length changed");
+    assert!(
+        payload.iter().all(|byte| *byte == b'a' + peer as u8),
+        "large frame payload was corrupted for peer {peer}, seq {seq}"
+    );
+    assert_eq!(frame_text(&message, 3), format!("end:{peer}:{seq:04}"));
+
+    *expected_seq += 1;
+}
+
+fn parse_seq(frame: String) -> usize {
+    frame.strip_prefix("seq:").unwrap().parse().unwrap()
+}
+
+fn frame_text(message: &ZmqMessage, index: usize) -> String {
+    String::from_utf8(message.get(index).unwrap().to_vec()).unwrap()
+}

--- a/tests/recv_cancel_safety.rs
+++ b/tests/recv_cancel_safety.rs
@@ -198,9 +198,7 @@ fn single_frame(seq: usize) -> ZmqMessage {
 
 fn multipart_message(peer: usize, seq: usize, large_frame_len: usize) -> ZmqMessage {
     let marker = (b'a' + peer as u8) as char;
-    let large = std::iter::repeat(marker)
-        .take(large_frame_len)
-        .collect::<String>();
+    let large = std::iter::repeat_n(marker, large_frame_len).collect::<String>();
 
     ZmqMessage::try_from(vec![
         Bytes::from(format!("peer:{peer}")),

--- a/tests/send_multipart_large.rs
+++ b/tests/send_multipart_large.rs
@@ -1,0 +1,77 @@
+use bytes::Bytes;
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{Endpoint, ZmqMessage};
+
+use std::time::Duration;
+
+fn tcp_endpoint(endpoint: Endpoint) -> String {
+    match endpoint {
+        Endpoint::Tcp(_, port) => format!("tcp://127.0.0.1:{port}"),
+        _ => unreachable!("expected tcp endpoint"),
+    }
+}
+
+#[async_rt::test]
+async fn push_pull_delivers_large_multipart_message() {
+    let topic = Bytes::from_static(b"topic");
+    let large = Bytes::from(vec![0xAB; 300_000]);
+    let tail = Bytes::from(vec![0xCD; 4_096]);
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = tcp_endpoint(pull.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let message = ZmqMessage::try_from(vec![topic.clone(), large.clone(), tail.clone()]).unwrap();
+    push.send(message).await.unwrap();
+
+    let received = async_rt::task::timeout(Duration::from_secs(2), pull.recv())
+        .await
+        .expect("timeout waiting for PUSH/PULL multipart message")
+        .unwrap();
+    assert_eq!(received.len(), 3);
+    assert_eq!(received.get(0), Some(&topic));
+    assert_eq!(received.get(1), Some(&large));
+    assert_eq!(received.get(2), Some(&tail));
+}
+
+#[async_rt::test]
+async fn dealer_router_roundtrips_large_multipart_message() {
+    let header = Bytes::from_static(b"header");
+    let large = Bytes::from(vec![0xEF; 300_000]);
+    let tail = Bytes::from(vec![0x42; 4_096]);
+
+    let mut router = zeromq::RouterSocket::new();
+    let endpoint = tcp_endpoint(router.bind("tcp://127.0.0.1:0").await.unwrap());
+
+    let mut dealer = zeromq::DealerSocket::new();
+    dealer.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let message = ZmqMessage::try_from(vec![header.clone(), large.clone(), tail.clone()]).unwrap();
+    dealer.send(message).await.unwrap();
+
+    let routed = async_rt::task::timeout(Duration::from_secs(2), router.recv())
+        .await
+        .expect("timeout waiting for DEALER/ROUTER multipart message")
+        .unwrap();
+    assert_eq!(routed.len(), 4);
+    assert!(!routed.get(0).unwrap().is_empty());
+    assert_eq!(routed.get(1), Some(&header));
+    assert_eq!(routed.get(2), Some(&large));
+    assert_eq!(routed.get(3), Some(&tail));
+
+    router.send(routed).await.unwrap();
+
+    let echoed = async_rt::task::timeout(Duration::from_secs(2), dealer.recv())
+        .await
+        .expect("timeout waiting for ROUTER/DEALER multipart echo")
+        .unwrap();
+    assert_eq!(echoed.len(), 3);
+    assert_eq!(echoed.get(0), Some(&header));
+    assert_eq!(echoed.get(1), Some(&large));
+    assert_eq!(echoed.get(2), Some(&tail));
+}

--- a/tests/xpub_sub.rs
+++ b/tests/xpub_sub.rs
@@ -6,6 +6,14 @@ mod test {
 
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
     #[async_rt::test]
     async fn test_xpub_basic_pubsub() {
         pretty_env_logger::try_init().ok();
@@ -181,5 +189,130 @@ mod test {
         // SUB should only receive "topic1-message"
         let received = sub_handle.await.expect("SUB task failed");
         assert_eq!(received, "topic1-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+
+        let early_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for early subscription")
+            .expect("Failed to receive early subscription");
+        assert_eq!(early_sub_msg.get(0).unwrap().as_ref(), b"\x01early");
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+
+        let late_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for late subscription")
+            .expect("Failed to receive late subscription");
+        assert_eq!(late_sub_msg.get(0).unwrap().as_ref(), b"\x01late");
+
+        xpub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        xpub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_unsubscribe_updates_fanout_state() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+
+        let sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for subscription")
+            .expect("Failed to receive subscription");
+        assert_eq!(sub_msg.get(0).unwrap().as_ref(), b"\x01gone");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-before-unsubscribe"))
+            .await
+            .expect("Failed to send subscribed message");
+        assert_eq!(recv_text(&mut sub_socket).await, "gone-before-unsubscribe");
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        let unsub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for unsubscribe")
+            .expect("Failed to receive unsubscribe");
+        assert_eq!(unsub_msg.get(0).unwrap().as_ref(), b"\x00gone");
+
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        let replacement_sub = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for replacement subscription")
+            .expect("Failed to receive replacement subscription");
+        assert_eq!(replacement_sub.get(0).unwrap().as_ref(), b"\x01stay");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        xpub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
     }
 }


### PR DESCRIPTION
## Summary

- Replace the receive half's generic `asynchronous_codec::FramedRead` wrapper with a local `ZmqFramedRead` stream that keeps the same `CodecResult<Message>` contract but uses a reusable 64 KiB read buffer.
- Preserve one-message-at-a-time delivery above the codec, multipart boundaries, EOF handling, malformed-frame error behavior, cancellation safety, and public socket APIs.
- Add focused framed-read tests covering buffered multi-message delivery from one underlying read and fragmented multipart decode.

## Benchmark

Focused PUSH/PULL TCP/Tokio smoke profile, `peers=1,8`, `size=8192`, sample size 10, measurement 3s, warmup 1s, OMQ revision `a46c1f7`.

Baseline `5e2946b` run `pushpull-focused-after-5e2946b`:

| row | zmq.rs | libzmq | OMQ compio | OMQ Tokio |
| --- | ---: | ---: | ---: | ---: |
| `push_pull tcp peers=1 size=8192` | 1.09 GB/s | 983.0 MB/s | 4.43 GB/s | 4.66 GB/s |
| `push_pull tcp peers=8 size=8192` | 1.30 GB/s | 965.5 MB/s | 4.18 GB/s | 11.13 GB/s |

Candidate `ab4b928` run `pushpull-codec-read-batch-ab4b928`:

| row | zmq.rs | libzmq | OMQ compio | OMQ Tokio |
| --- | ---: | ---: | ---: | ---: |
| `push_pull tcp peers=1 size=8192` | 1.63 GB/s | 976.4 MB/s | 4.30 GB/s | 4.48 GB/s |
| `push_pull tcp peers=8 size=8192` | 2.38 GB/s | 958.5 MB/s | 4.13 GB/s | 11.41 GB/s |

The target 8-peer row improves about 1.83x versus the focused `5e2946b` baseline, reducing the OMQ Tokio ratio from about 8.56x to 4.79x. Criterion reported high outliers on zmq.rs rows and sample-time warnings on libzmq rows, so treat this as focused smoke evidence rather than a final standard-suite claim.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all --all-targets -- --deny warnings`
- `cargo clippy --all --all-targets --no-default-features --features async-std-runtime,all-transport,async-dispatcher-macros -- --deny warnings`
- `cargo test --all`
- `cargo test --all --no-default-features --features async-std-runtime,all-transport`
- `cargo test --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros`
- `cargo test framed_read_ --lib`
- `cargo test --test recv_cancel_safety`
- locked `cargo bench --no-run`

## Risks

- Memory per connected peer increases by one reusable 64 KiB read buffer.
- This keeps the public API stable, but it replaces a third-party framed-read adapter with local polling code, so future codec changes should keep the EOF and cancel-safety tests in view.
- The focused win does not close the full OMQ Tokio gap; send-side flush behavior and broader socket architecture still need separate investigation.
