### PR TITLE
Tune Tokio TCP socket buffers for PUSH/PULL throughput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85.0"
 
 [features]
 default = ["tokio-runtime", "all-transport"]
-tokio-runtime = ["tokio", "tokio-util"]
+tokio-runtime = ["tokio", "tokio-util", "dep:socket2"]
 async-std-runtime = ["async-std"]
 async-dispatcher-runtime = ["async-std", "async-dispatcher"]
 async-dispatcher-macros = ["async-dispatcher/macros"]
@@ -44,6 +44,7 @@ once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
 async-std = { version = "1", features = ["attributes"], optional = true }
+socket2 = { version = "0.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 win_uds = { version = "=0.2.2", features = ["async"], optional = true }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -14,12 +14,16 @@ use crate::ZmqResult;
 
 use futures::{select, FutureExt};
 
+#[cfg(feature = "tokio-runtime")]
+const TCP_SOCKET_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
 pub(crate) async fn connect(host: &Host, port: Port) -> ZmqResult<(FramedIo, Endpoint)> {
     let raw_socket = TcpStream::connect((host.to_string().as_str(), port)).await?;
     // For some reason set_nodelay doesn't work on windows. See
     // https://github.com/zeromq/zmq.rs/issues/148 for details
     #[cfg(not(windows))]
     raw_socket.set_nodelay(true)?;
+    tune_socket_buffers(&raw_socket);
     let peer_addr = raw_socket.peer_addr()?;
 
     Ok((make_framed(raw_socket), Endpoint::from_tcp_addr(peer_addr)))
@@ -45,7 +49,10 @@ where
                         .and_then(|(raw_socket, remote_addr)| {
                             raw_socket
                                 .set_nodelay(true)
-                                .map(|_| (raw_socket, remote_addr))
+                                .map(|_| {
+                                    tune_socket_buffers(&raw_socket);
+                                    (raw_socket, remote_addr)
+                                })
                         })
                         .map(|(raw_socket, remote_addr)| {
                             (
@@ -78,3 +85,17 @@ where
         AcceptStopHandle(TaskHandle::new(stop_channel, task_handle)),
     ))
 }
+
+#[cfg(feature = "tokio-runtime")]
+fn tune_socket_buffers(raw_socket: &TcpStream) {
+    let socket = socket2::SockRef::from(raw_socket);
+    if let Err(error) = socket.set_recv_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP receive buffer size: {error}");
+    }
+    if let Err(error) = socket.set_send_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP send buffer size: {error}");
+    }
+}
+
+#[cfg(not(feature = "tokio-runtime"))]
+fn tune_socket_buffers(_raw_socket: &TcpStream) {}


### PR DESCRIPTION
## Summary

Tune TCP socket buffers for the Tokio transport path.

The default Tokio TCP transport now requests 4 MiB send and receive socket buffers when a connection is established or accepted. Buffer tuning is best-effort: connection setup continues if the platform refuses the requested size. Non-Tokio runtime builds keep the existing behavior.

## Performance

Focused locked Criterion evidence on the high-throughput PUSH/PULL TCP row, measured with the aggregate measurement stack from #261/#263:

- Baseline `a9c2d09`, `zmqrs/throughput/push_pull/tcp/peers=8/8192`: `1.43 GiB/s` estimate.
- Candidate measurement commit `d0db23e`, run `pushpull-tcp-buffers-d0db23e-20260515T0402Z`, same row: `3.80 GiB/s` estimate, interval `3.67-4.04 GiB/s`.
- Candidate sweep `pushpull-tcp-buffers-sweep-dirty-20260515T0354Z`, filter `zmqrs/throughput/push_pull/tcp`, completed all six rows without hangs. The target row repeated at `3.78 GiB/s`.

This PR isolates the transport change onto current master so the code diff stays limited to TCP buffer tuning.

OMQ remains ahead on the same comparison row at roughly `11-12 GB/s`, but this narrows the focused gap substantially without changing the public socket API or message semantics.

## Validation

- `cargo +nightly fmt --all -- --check`
- `cargo clippy --all --all-targets -- --deny warnings`
- `cargo clippy --all --all-targets --no-default-features --features async-std-runtime,all-transport,async-dispatcher-macros -- --deny warnings`
- `cargo test --all`
- `cargo test --all --no-default-features --features async-std-runtime,all-transport`
- `cargo test --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros`
- `cargo test --test connect --test large_message`
- locked `cargo bench --no-run`

Clippy emits existing renamed/removed configured-lint warnings but exits successfully.

## Risks

This is Tokio-only performance tuning. It increases requested per-connection TCP buffer capacity and relies on OS buffer limits, so exact performance impact may vary by platform and sysctl settings. The requests are best-effort to avoid changing connection success behavior. This should stay draft until CI and maintainer review confirm the new dependency/feature wiring is acceptable.
