### PR TITLE
Improve PUSH/PULL throughput with bounded queues and single-frame messages

### DIFF
--- a/docs/SEND_SEMANTICS.md
+++ b/docs/SEND_SEMANTICS.md
@@ -1,0 +1,136 @@
+# Send Semantics Research
+
+This branch evaluates whether zmq.rs can use a PUSH writer task and a bounded
+socket queue without making send completion, backpressure, close, and error
+behavior ambiguous.
+
+## External contract
+
+The libzmq contract is queue based:
+
+- `zmq_send()` queues a message part on the socket.
+- A successful send does not mean the message reached the network; it means the
+  socket queued the message and 0MQ has taken responsibility for it.
+- For PUSH sockets, send blocks in mute state when all downstream pipes have hit
+  high water mark; messages are not discarded.
+- `ZMQ_SNDHWM` is a per-peer outstanding-message limit. The documented default
+  is 1000 messages, but libzmq does not promise the exact usable count.
+- `zmq_close()` is asynchronous with respect to pending outbound data. Unsent
+  messages are controlled by `ZMQ_LINGER`.
+
+Primary references:
+
+- https://libzmq.readthedocs.io/en/latest/zmq_send.html
+- https://zeromq.github.io/libzmq/zmq_socket.html
+- https://zeromq.github.io/libzmq/zmq_setsockopt.html
+- https://zeromq.github.io/libzmq/zmq_close.html
+
+## zmq.rs baseline
+
+Current `origin/master` has no public `SocketSend::send` documentation. The
+generic backend sends directly through `ZmqFramedWrite::send(message).await`,
+which makes a successful PUSH send much closer to "the framed writer accepted
+and flushed this message" than libzmq's socket-queue contract.
+
+That stronger sync point is simple, but it serializes an application send loop
+with transport writes and prevents the I/O overlap that libzmq and omq.rs rely
+on for small-message throughput.
+
+## Fast-path contract under test
+
+For PUSH, this branch treats `send().await` success as:
+
+> The complete message was accepted into a bounded per-peer socket queue selected
+> by round-robin routing.
+
+It deliberately does not mean:
+
+- bytes were already written to the TCP stream
+- the peer received the message
+- later writer errors cannot affect queued messages
+
+Backpressure is applied by the bounded per-peer queue. When the queue is full,
+`send().await` waits. If that wait is cancelled, the round-robin peer must be
+returned to the routing queue so the socket does not silently lose a peer.
+
+Writer errors remove the peer and emit `SocketEvent::Disconnected`. Messages
+already accepted by the socket queue can still be lost if the transport fails
+before the writer drains them; that is consistent with a queue-based send
+contract, but it must be documented rather than hidden.
+
+Close/drop currently drains any messages already buffered in the channel because
+dropping the socket clears the peer map, closes the sender side, and lets the
+writer task flush the receiver. There is not yet a public linger option, so this
+branch documents the current behavior as "best effort drain after close" rather
+than claiming configurable libzmq parity.
+
+## Merge bar
+
+Before this can become a real PR, the implementation needs:
+
+- public docs for `SocketSend::send`, PUSH backpressure, and close/drop behavior
+- focused tests for queue acceptance, multipart preservation, round-robin,
+  backpressure cancellation, writer failure, and close/drop draining
+- a decision on whether to expose `SNDHWM`/linger options now or keep the first
+  patch narrowly scoped to a documented fixed queue size
+- local `fmt`, `clippy`, full tests, bench dry-run, and repeated benchmarks
+  against `origin/master`, libzmq, and omq.rs
+
+## Initial benchmark read
+
+The semantic hardening does not appear to materially change the stable parts of
+the PUSH batch-writer result. Repeated local TCP runs show the same shape as the
+parent batch-writer experiment:
+
+- 8 peers, 128 B: about 246 MiB/s
+- 8 peers, 2048 B: about 2.0 GiB/s
+
+The 8-peer, 8192 B Criterion row is not trustworthy yet. It produced severe
+outliers and long stalls on both this branch and the parent batch-writer branch,
+so the large-frame multi-peer behavior needs a separate queue-depth/drain-rate
+investigation before making a public performance claim for that row.
+
+## Byte-aware queue follow-up
+
+The next experiment (`f88ce18`) keeps the same queue-acceptance send contract
+but changes PUSH writer backpressure from message-count only to message-count
+plus byte credits:
+
+- at most 8192 accepted-but-unflushed messages per peer
+- at most 2 MiB accepted-but-unflushed payload bytes per peer, except that one
+  oversized message is always allowed through an empty queue
+- credits are released after the writer flushes the batch, not when it merely
+  pops messages from the channel
+
+This preserves the small-message runway while preventing 8 KiB frames from
+building an implicit 64 MiB backlog per peer. It also keeps cancellation safe:
+credit is acquired before the message is put on the channel, and a cancelled
+wait consumes no credit.
+
+Validation passed locally with `RUSTC_WRAPPER=`:
+
+- `cargo +nightly fmt --all -- --check`
+- both clippy profiles from the lab validation skill
+- all three full test profiles from the lab validation skill
+- focused backend and `push_send_batching` tests
+- locked `cargo bench --no-run`
+
+Benchmark read:
+
+- candidate run `push-byte-hwm-f88ce18-tcp`
+- candidate/libzmq/OMQ run `push-byte-hwm-f88ce18-tcp-all`
+- scaffold baseline run `baseline-9533f8c-pushbyte-tcp`
+- focused long row:
+  `cargo bench ... zmqrs/throughput/push_pull/tcp/peers=8/8192`
+
+Stable candidate rows:
+
+- 8 peers, 128 B: about 261 MB/s
+- 8 peers, 2048 B: about 2.23 GB/s
+- 8 peers, 8192 B: about 3.18 GiB/s on the focused longer Criterion row
+
+The same-window all-implementation run still had one severe zmq.rs outlier at
+8 peers / 8192 B, so the public claim should use repeated focused rows and call
+out the noisy all-run result. This is nevertheless a stronger shape than the
+message-count-only queue, because the earlier multi-second stalls did not
+reproduce on the focused byte-HWM run.

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,3 +1,4 @@
+use crate::async_rt;
 use crate::codec::{FramedIo, Message, ZmqFramedRead, ZmqFramedWrite};
 use crate::fair_queue::QueueInner;
 use crate::util::PeerIdentity;
@@ -8,17 +9,191 @@ use crate::{
 use async_trait::async_trait;
 use crossbeam_queue::SegQueue;
 use futures::channel::mpsc;
-use futures::SinkExt;
+use futures::future::poll_fn;
+use futures::{SinkExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::task::Poll;
+use std::task::Waker;
 
 /// Sender for notifying reconnection tasks when a peer disconnects.
 pub(crate) type DisconnectNotifier = mpsc::Sender<PeerIdentity>;
 
+const PUSH_SEND_QUEUE_CAPACITY: usize = 8 * 1024;
+const PUSH_SEND_QUEUE_MAX_BYTES: usize = 2 * 1024 * 1024;
+const PUSH_SEND_BATCH_MESSAGES: usize = 128;
+const PUSH_SEND_BATCH_BYTES: usize = 512 * 1024;
+
 pub(crate) struct Peer {
-    pub(crate) send_queue: ZmqFramedWrite,
+    send_queue: PeerSendQueue,
+}
+
+struct RoundRobinPeerGuard<'a> {
+    queue: &'a SegQueue<PeerIdentity>,
+    peer_id: Option<PeerIdentity>,
+    requeue_on_drop: bool,
+}
+
+impl<'a> RoundRobinPeerGuard<'a> {
+    fn new(queue: &'a SegQueue<PeerIdentity>, peer_id: PeerIdentity) -> Self {
+        Self {
+            queue,
+            peer_id: Some(peer_id),
+            requeue_on_drop: true,
+        }
+    }
+
+    fn peer_id(&self) -> &PeerIdentity {
+        self.peer_id.as_ref().expect("guard owns peer identity")
+    }
+
+    fn requeue(mut self) -> PeerIdentity {
+        let peer_id = self.peer_id.take().expect("guard owns peer identity");
+        self.requeue_on_drop = false;
+        self.queue.push(peer_id.clone());
+        peer_id
+    }
+
+    fn discard(mut self) -> PeerIdentity {
+        self.requeue_on_drop = false;
+        self.peer_id.take().expect("guard owns peer identity")
+    }
+}
+
+impl Drop for RoundRobinPeerGuard<'_> {
+    fn drop(&mut self) {
+        if self.requeue_on_drop {
+            if let Some(peer_id) = self.peer_id.take() {
+                self.queue.push(peer_id);
+            }
+        }
+    }
+}
+
+enum PeerSendQueue {
+    Direct(ZmqFramedWrite),
+    BatchedPush(PushBatchSender),
+}
+
+impl Peer {
+    pub(crate) async fn send(&mut self, message: Message) -> ZmqResult<()> {
+        match &mut self.send_queue {
+            PeerSendQueue::Direct(send_queue) => send_queue.send(message).await.map_err(Into::into),
+            PeerSendQueue::BatchedPush(sender) => sender.send(message).await,
+        }
+    }
+}
+
+struct PushBatchSender {
+    sender: mpsc::Sender<QueuedPushMessage>,
+    credits: Arc<PushQueueCredits>,
+}
+
+impl PushBatchSender {
+    async fn send(&mut self, message: Message) -> ZmqResult<()> {
+        let bytes = message_payload_bytes(&message);
+        self.credits.reserve(bytes).await?;
+        if self
+            .sender
+            .try_send(QueuedPushMessage { message, bytes })
+            .is_ok()
+        {
+            Ok(())
+        } else {
+            self.credits.release(1, bytes);
+            Err(ZmqError::BufferFull(
+                "Failed to send message. Send queue full/broken",
+            ))
+        }
+    }
+}
+
+struct QueuedPushMessage {
+    message: Message,
+    bytes: usize,
+}
+
+struct PushQueueCredits {
+    state: Mutex<PushQueueCreditState>,
+}
+
+#[derive(Default)]
+struct PushQueueCreditState {
+    messages: usize,
+    bytes: usize,
+    closed: bool,
+    waiters: Vec<Waker>,
+}
+
+impl PushQueueCredits {
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(PushQueueCreditState::default()),
+        }
+    }
+
+    async fn reserve(&self, bytes: usize) -> ZmqResult<()> {
+        poll_fn(|cx| {
+            let mut state = self.state.lock();
+            if state.closed {
+                return Poll::Ready(Err(ZmqError::BufferFull(
+                    "Failed to send message. Send queue full/broken",
+                )));
+            }
+
+            if queue_has_capacity(&state, bytes) {
+                state.messages += 1;
+                state.bytes = state.bytes.saturating_add(bytes);
+                return Poll::Ready(Ok(()));
+            }
+
+            if !state
+                .waiters
+                .iter()
+                .any(|waker| waker.will_wake(cx.waker()))
+            {
+                state.waiters.push(cx.waker().clone());
+            }
+            Poll::Pending
+        })
+        .await
+    }
+
+    fn release(&self, messages: usize, bytes: usize) {
+        let waiters = {
+            let mut state = self.state.lock();
+            state.messages = state.messages.saturating_sub(messages);
+            state.bytes = state.bytes.saturating_sub(bytes);
+            std::mem::take(&mut state.waiters)
+        };
+        wake_waiters(waiters);
+    }
+
+    fn close(&self) {
+        let waiters = {
+            let mut state = self.state.lock();
+            state.closed = true;
+            std::mem::take(&mut state.waiters)
+        };
+        wake_waiters(waiters);
+    }
+}
+
+fn queue_has_capacity(state: &PushQueueCreditState, bytes: usize) -> bool {
+    if state.messages >= PUSH_SEND_QUEUE_CAPACITY {
+        return false;
+    }
+
+    let projected = state.bytes.saturating_add(bytes);
+    projected <= PUSH_SEND_QUEUE_MAX_BYTES || state.messages == 0
+}
+
+fn wake_waiters(waiters: Vec<Waker>) {
+    for waiter in waiters {
+        waiter.wake();
+    }
 }
 
 pub(crate) struct GenericSocketBackend {
@@ -91,18 +266,23 @@ impl GenericSocketBackend {
                     }
                 },
             };
-            let send_result = match self.peers.get_async(&next_peer_id).await {
-                Some(mut peer) => peer.send_queue.send(message).await,
-                None => continue,
-            };
+            let peer_guard = RoundRobinPeerGuard::new(&self.round_robin, next_peer_id);
+            let send_result =
+                if let Some(mut peer) = self.peers.get_async(peer_guard.peer_id()).await {
+                    peer.send(message).await
+                } else {
+                    peer_guard.discard();
+                    continue;
+                };
             return match send_result {
                 Ok(()) => {
-                    self.round_robin.push(next_peer_id.clone());
-                    Ok(next_peer_id)
+                    let peer_id = peer_guard.requeue();
+                    Ok(peer_id)
                 }
                 Err(e) => {
-                    self.peer_disconnected(&next_peer_id);
-                    Err(e.into())
+                    let peer_id = peer_guard.discard();
+                    self.peer_disconnected(&peer_id);
+                    Err(e)
                 }
             };
         }
@@ -136,6 +316,7 @@ impl SocketBackend for GenericSocketBackend {
 impl MultiPeerBackend for GenericSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
+        let send_queue = self.peer_send_queue(peer_id.clone(), send_queue);
         self.peers
             .upsert_async(peer_id.clone(), Peer { send_queue })
             .await;
@@ -149,7 +330,7 @@ impl MultiPeerBackend for GenericSocketBackend {
     }
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
-        self.peers.remove_sync(peer_id);
+        let was_connected = self.peers.remove_sync(peer_id).is_some();
         match &self.fair_queue_inner {
             None => {}
             Some(inner) => {
@@ -157,11 +338,264 @@ impl MultiPeerBackend for GenericSocketBackend {
             }
         };
 
+        if was_connected {
+            if let Some(monitor) = self.socket_monitor.lock().as_mut() {
+                let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
+            }
+        }
+
         // Notify reconnection task if registered
         if let Some(mut notifier) = self.disconnect_notifiers.lock().remove(peer_id) {
             // Use try_send to avoid blocking - if channel is full, the reconnect task
             // will eventually notice the peer is gone
             let _ = notifier.try_send(peer_id.clone());
+        }
+    }
+}
+
+impl GenericSocketBackend {
+    fn peer_send_queue(
+        self: &Arc<Self>,
+        peer_id: PeerIdentity,
+        mut send_queue: ZmqFramedWrite,
+    ) -> PeerSendQueue {
+        if self.socket_type != SocketType::PUSH {
+            return PeerSendQueue::Direct(send_queue);
+        }
+
+        send_queue.set_send_high_water_mark(PUSH_SEND_BATCH_BYTES);
+        let credits = Arc::new(PushQueueCredits::new());
+        let (sender, receiver) = mpsc::channel(PUSH_SEND_QUEUE_CAPACITY);
+        async_rt::task::spawn(run_push_send_queue(
+            self.clone(),
+            peer_id,
+            send_queue,
+            receiver,
+            credits.clone(),
+        ));
+        PeerSendQueue::BatchedPush(PushBatchSender { sender, credits })
+    }
+}
+
+async fn run_push_send_queue(
+    backend: Arc<GenericSocketBackend>,
+    peer_id: PeerIdentity,
+    mut send_queue: ZmqFramedWrite,
+    mut receiver: mpsc::Receiver<QueuedPushMessage>,
+    credits: Arc<PushQueueCredits>,
+) {
+    while let Some(first) = receiver.next().await {
+        let mut batch_bytes = first.bytes;
+        let mut batch_messages = 1;
+
+        if send_queue.feed(first.message).await.is_err() {
+            credits.close();
+            backend.peer_disconnected(&peer_id);
+            return;
+        }
+
+        while batch_messages < PUSH_SEND_BATCH_MESSAGES && batch_bytes < PUSH_SEND_BATCH_BYTES {
+            let next = match receiver.try_recv() {
+                Ok(message) => message,
+                Err(_) => break,
+            };
+
+            batch_bytes += next.bytes;
+            batch_messages += 1;
+            if send_queue.feed(next.message).await.is_err() {
+                credits.close();
+                backend.peer_disconnected(&peer_id);
+                return;
+            }
+        }
+
+        if send_queue.flush().await.is_err() {
+            credits.close();
+            backend.peer_disconnected(&peer_id);
+            return;
+        }
+
+        credits.release(batch_messages, batch_bytes);
+    }
+
+    let _ = send_queue.flush().await;
+    credits.close();
+}
+
+fn message_payload_bytes(message: &Message) -> usize {
+    match message {
+        Message::Message(message) => message.iter().map(bytes::Bytes::len).sum(),
+        Message::Greeting(_) | Message::Command(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_rt;
+    use crate::codec::FramedIo;
+    use crate::util::PeerIdentity;
+    use crate::{SocketEvent, SocketOptions, SocketType, ZmqMessage};
+
+    use futures::channel::mpsc;
+    use futures::{AsyncWrite, StreamExt};
+
+    use std::io::{self, ErrorKind};
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+    use std::time::Duration;
+
+    #[async_rt::test]
+    async fn batched_push_writer_failure_removes_peer_and_reports_disconnect() {
+        let backend = push_backend();
+        let peer_id = PeerIdentity::try_from(b"peer-a".as_slice()).unwrap();
+        let (monitor_sender, mut monitor_receiver) = mpsc::channel(8);
+        backend.socket_monitor.lock().replace(monitor_sender);
+
+        backend
+            .clone()
+            .peer_connected(&peer_id, framed_io(FailingWrite))
+            .await;
+
+        backend
+            .send_round_robin(Message::Message(ZmqMessage::from("first")))
+            .await
+            .unwrap();
+
+        let event = async_rt::task::timeout(Duration::from_secs(2), monitor_receiver.next())
+            .await
+            .expect("timed out waiting for disconnect event")
+            .expect("monitor closed");
+        assert!(matches!(event, SocketEvent::Disconnected(id) if id == peer_id));
+
+        let err = backend
+            .send_round_robin(Message::Message(ZmqMessage::from("second")))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ZmqError::ReturnToSender { .. }));
+    }
+
+    #[async_rt::test]
+    async fn cancelled_backpressure_wait_requeues_round_robin_peer() {
+        let backend = push_backend();
+        let peer_id = PeerIdentity::try_from(b"peer-b".as_slice()).unwrap();
+
+        backend
+            .clone()
+            .peer_connected(&peer_id, framed_io(PendingWrite))
+            .await;
+
+        let mut blocked_at = None;
+        for seq in 0..=(PUSH_SEND_QUEUE_CAPACITY + PUSH_SEND_BATCH_MESSAGES) {
+            match async_rt::task::timeout(
+                Duration::from_secs(2),
+                backend.send_round_robin(Message::Message(ZmqMessage::from(format!("fill-{seq}")))),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => panic!("send failed before queue filled: {err}"),
+                Err(_) => {
+                    blocked_at = Some(seq);
+                    break;
+                }
+            }
+        }
+
+        let blocked_at = blocked_at.expect("send never waited on the full PUSH queue");
+        assert!(blocked_at >= PUSH_SEND_QUEUE_CAPACITY);
+        assert_eq!(backend.round_robin.pop(), Some(peer_id));
+    }
+
+    #[async_rt::test]
+    async fn large_push_messages_wait_on_byte_hwm() {
+        let backend = push_backend();
+        let peer_id = PeerIdentity::try_from(b"peer-c".as_slice()).unwrap();
+
+        backend
+            .clone()
+            .peer_connected(&peer_id, framed_io(PendingWrite))
+            .await;
+
+        let payload = vec![0xAB; 8192];
+        let mut blocked_at = None;
+        for seq in 0..PUSH_SEND_QUEUE_CAPACITY {
+            match async_rt::task::timeout(
+                Duration::from_secs(2),
+                backend.send_round_robin(Message::Message(ZmqMessage::from(payload.clone()))),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => panic!("send failed before byte queue filled: {err}"),
+                Err(_) => {
+                    blocked_at = Some(seq);
+                    break;
+                }
+            }
+        }
+
+        let blocked_at = blocked_at.expect("send never waited on the byte-limited PUSH queue");
+        assert!(
+            blocked_at < PUSH_SEND_QUEUE_CAPACITY,
+            "byte HWM should apply before message HWM, blocked at {blocked_at}"
+        );
+        assert_eq!(backend.round_robin.pop(), Some(peer_id));
+    }
+
+    fn push_backend() -> Arc<GenericSocketBackend> {
+        Arc::new(GenericSocketBackend::with_options(
+            None,
+            SocketType::PUSH,
+            SocketOptions::default(),
+        ))
+    }
+
+    fn framed_io<W>(writer: W) -> FramedIo
+    where
+        W: AsyncWrite + Unpin + Send + Sync + 'static,
+    {
+        FramedIo::new(Box::new(futures::io::empty()), Box::new(writer))
+    }
+
+    struct FailingWrite;
+
+    impl AsyncWrite for FailingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Err(io::Error::new(ErrorKind::BrokenPipe, "test failure")))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct PendingWrite;
+
+    impl AsyncWrite for PendingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
         }
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -409,13 +409,13 @@ async fn run_push_send_queue(
             }
         }
 
+        credits.release(batch_messages, batch_bytes);
+
         if send_queue.flush().await.is_err() {
             credits.close();
             backend.peer_disconnected(&peer_id);
             return;
         }
-
-        credits.release(batch_messages, batch_bytes);
     }
 
     let _ = send_queue.flush().await;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -424,7 +424,7 @@ async fn run_push_send_queue(
 
 fn message_payload_bytes(message: &Message) -> usize {
     match message {
-        Message::Message(message) => message.iter().map(bytes::Bytes::len).sum(),
+        Message::Message(message) => message.frame_iter().map(bytes::Bytes::len).sum(),
         Message::Greeting(_) | Message::Command(_) => 0,
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -544,6 +544,42 @@ mod tests {
         assert_eq!(backend.round_robin.pop(), Some(peer_id));
     }
 
+    #[async_rt::test]
+    async fn flush_pending_push_messages_remain_byte_limited() {
+        let backend = push_backend();
+        let peer_id = PeerIdentity::try_from(b"peer-d".as_slice()).unwrap();
+
+        backend
+            .clone()
+            .peer_connected(&peer_id, framed_io(FlushPendingWrite))
+            .await;
+
+        let payload = vec![0xCD; 8192];
+        let mut blocked_at = None;
+        for seq in 0..PUSH_SEND_QUEUE_CAPACITY {
+            match async_rt::task::timeout(
+                Duration::from_secs(2),
+                backend.send_round_robin(Message::Message(ZmqMessage::from(payload.clone()))),
+            )
+            .await
+            {
+                Ok(Ok(_)) => {}
+                Ok(Err(err)) => panic!("send failed before flush-pending queue filled: {err}"),
+                Err(_) => {
+                    blocked_at = Some(seq);
+                    break;
+                }
+            }
+        }
+
+        let blocked_at = blocked_at.expect("send never waited while writer flush was pending");
+        assert!(
+            blocked_at < PUSH_SEND_QUEUE_CAPACITY,
+            "byte HWM should still apply while writer flush is pending, blocked at {blocked_at}"
+        );
+        assert_eq!(backend.round_robin.pop(), Some(peer_id));
+    }
+
     fn push_backend() -> Arc<GenericSocketBackend> {
         Arc::new(GenericSocketBackend::with_options(
             None,
@@ -588,6 +624,26 @@ mod tests {
             _buf: &[u8],
         ) -> Poll<io::Result<usize>> {
             Poll::Pending
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Pending
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    struct FlushPendingWrite;
+
+    impl AsyncWrite for FlushPendingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Ok(buf.len()))
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,7 +1,11 @@
-use crate::codec::ZmqCodec;
+use crate::codec::{CodecResult, Message, ZmqCodec};
 
-use asynchronous_codec::{FramedRead, FramedWrite};
-use futures::{AsyncRead, AsyncWrite};
+use asynchronous_codec::{Decoder, FramedWrite};
+use bytes::BytesMut;
+use futures::{ready, AsyncRead, AsyncWrite, Stream};
+use std::io::{self, ErrorKind};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
 pub trait FrameableRead: AsyncRead + Unpin + Send + Sync {}
@@ -9,8 +13,76 @@ impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
 pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {}
 impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
 
-pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
+
+/// A `Stream` of ZMTP messages decoded from an `AsyncRead`.
+///
+/// This mirrors `asynchronous_codec::FramedRead` but uses a larger reusable read
+/// buffer. The PUSH/PULL OMQ comparison stresses 8 KiB payloads, where small
+/// read chunks tend to split frame headers and payloads across polls.
+pub struct ZmqFramedRead {
+    inner: Box<dyn FrameableRead>,
+    codec: ZmqCodec,
+    buffer: BytesMut,
+    read_buf: Box<[u8]>,
+}
+
+impl ZmqFramedRead {
+    pub(crate) fn new(inner: Box<dyn FrameableRead>) -> Self {
+        Self {
+            inner,
+            codec: ZmqCodec::new(),
+            buffer: BytesMut::with_capacity(READ_BUFFER_CAPACITY),
+            read_buf: vec![0; READ_BUFFER_CAPACITY].into_boxed_slice(),
+        }
+    }
+}
+
+impl Stream for ZmqFramedRead {
+    type Item = CodecResult<Message>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        if let Some(item) = this.codec.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
+        loop {
+            let read = {
+                let inner = &mut this.inner;
+                let read_buf = &mut this.read_buf;
+                ready!(Pin::new(inner).poll_read(cx, read_buf))?
+            };
+            let ended = read == 0;
+            this.buffer.extend_from_slice(&this.read_buf[..read]);
+
+            match this.codec.decode(&mut this.buffer)? {
+                Some(item) => return Poll::Ready(Some(Ok(item))),
+                None if ended => {
+                    if this.buffer.is_empty() {
+                        return Poll::Ready(None);
+                    }
+
+                    match this.codec.decode_eof(&mut this.buffer)? {
+                        Some(item) => return Poll::Ready(Some(Ok(item))),
+                        None if this.buffer.is_empty() => return Poll::Ready(None),
+                        None => {
+                            return Poll::Ready(Some(Err(io::Error::new(
+                                ErrorKind::UnexpectedEof,
+                                "bytes remaining in stream",
+                            )
+                            .into())));
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
+
+const READ_BUFFER_CAPACITY: usize = 64 * 1024;
 
 /// Equivalent to [`asynchronous_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
@@ -20,7 +92,7 @@ pub struct FramedIo {
 
 impl FramedIo {
     pub fn new(read_half: Box<dyn FrameableRead>, write_half: Box<dyn FrameableWrite>) -> Self {
-        let read_half = FramedRead::new(read_half, ZmqCodec::new());
+        let read_half = ZmqFramedRead::new(read_half);
         let write_half = FramedWrite::new(write_half, ZmqCodec::new());
         Self {
             read_half,
@@ -30,5 +102,142 @@ impl FramedIo {
 
     pub fn into_parts(self) -> (ZmqFramedRead, ZmqFramedWrite) {
         (self.read_half, self.write_half)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::{ZmqCodec, ZmqGreeting};
+    use crate::ZmqMessage;
+    use asynchronous_codec::Encoder;
+    use bytes::Bytes;
+    use futures::executor::block_on;
+    use futures::StreamExt;
+    use std::io::Error;
+    use std::sync::{Arc, Mutex};
+
+    #[test]
+    fn framed_read_serves_buffered_messages_without_extra_reads() {
+        let payload = Bytes::from(vec![0xCD; 8192]);
+        let first = ZmqMessage::from(payload.clone());
+        let second = ZmqMessage::from(payload.clone());
+        let encoded = encode_greeting_and_messages(&[first, second]);
+        let (reader, read_calls) = RecordingReader::new(encoded, READ_BUFFER_CAPACITY);
+
+        let mut framed = ZmqFramedRead::new(Box::new(reader));
+        block_on(async {
+            expect_greeting(framed.next().await);
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+
+            let message = expect_message(framed.next().await);
+            expect_single_frame(message, payload.as_ref());
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+
+            let message = expect_message(framed.next().await);
+            expect_single_frame(message, payload.as_ref());
+            assert_eq!(*read_calls.lock().expect("read calls lock"), 1);
+        });
+    }
+
+    #[test]
+    fn framed_read_preserves_fragmented_multipart_messages() {
+        let message = ZmqMessage::try_from(vec![
+            Bytes::from_static(b"first"),
+            Bytes::from(vec![0xAB; 300]),
+            Bytes::from_static(b"tail"),
+        ])
+        .expect("non-empty multipart");
+        let encoded = encode_greeting_and_messages(&[message]);
+        let (reader, _read_calls) = RecordingReader::new(encoded, 5);
+
+        let mut framed = ZmqFramedRead::new(Box::new(reader));
+        block_on(async {
+            expect_greeting(framed.next().await);
+            let message = expect_message(framed.next().await);
+            let frames = message.into_vec();
+
+            assert_eq!(frames.len(), 3);
+            assert_eq!(frames[0].as_ref(), b"first");
+            assert_eq!(frames[1].as_ref(), &[0xAB; 300]);
+            assert_eq!(frames[2].as_ref(), b"tail");
+        });
+    }
+
+    fn encode_greeting_and_messages(messages: &[ZmqMessage]) -> Vec<u8> {
+        let mut codec = ZmqCodec::new();
+        let mut dst = BytesMut::new();
+        let greeting = Message::Greeting(ZmqGreeting::default());
+        codec.encode(greeting, &mut dst).expect("greeting encode");
+
+        for message in messages {
+            let outbound = Message::Message(message.clone());
+            codec.encode(outbound, &mut dst).expect("message encode");
+        }
+
+        dst.to_vec()
+    }
+
+    fn expect_greeting(item: Option<CodecResult<Message>>) {
+        match item.expect("stream item").expect("decode succeeds") {
+            Message::Greeting(_) => {}
+            other => panic!("expected greeting, got {other:?}"),
+        }
+    }
+
+    fn expect_message(item: Option<CodecResult<Message>>) -> ZmqMessage {
+        match item.expect("stream item").expect("decode succeeds") {
+            Message::Message(message) => message,
+            other => panic!("expected message, got {other:?}"),
+        }
+    }
+
+    fn expect_single_frame(message: ZmqMessage, expected: &[u8]) {
+        let frames = message.into_vec();
+        assert_eq!(frames.len(), 1);
+        assert_eq!(frames[0].as_ref(), expected);
+    }
+
+    struct RecordingReader {
+        data: Vec<u8>,
+        offset: usize,
+        max_chunk: usize,
+        read_calls: Arc<Mutex<usize>>,
+    }
+
+    impl RecordingReader {
+        fn new(data: Vec<u8>, max_chunk: usize) -> (Self, Arc<Mutex<usize>>) {
+            let read_calls = Arc::new(Mutex::new(0));
+            (
+                Self {
+                    data,
+                    offset: 0,
+                    max_chunk,
+                    read_calls: read_calls.clone(),
+                },
+                read_calls,
+            )
+        }
+    }
+
+    impl AsyncRead for RecordingReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize, Error>> {
+            *self.read_calls.lock().expect("read calls lock") += 1;
+            if self.offset == self.data.len() {
+                return Poll::Ready(Ok(0));
+            }
+
+            let len = buf
+                .len()
+                .min(self.max_chunk)
+                .min(self.data.len() - self.offset);
+            buf[..len].copy_from_slice(&self.data[self.offset..self.offset + len]);
+            self.offset += len;
+            Poll::Ready(Ok(len))
+        }
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -10,7 +10,7 @@ mod zmq_codec;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};
-pub(crate) use framed::{FrameableRead, FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
+pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
 pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub use zmq_codec::ZmqCodec;
 

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -151,7 +151,7 @@ impl Encoder for ZmqCodec {
             Message::Command(command) => dst.unsplit(command.into()),
             Message::Message(message) => {
                 let last_element = message.len() - 1;
-                for (idx, part) in message.iter().enumerate() {
+                for (idx, part) in message.frame_iter().enumerate() {
                     encode_frame(part, dst, idx != last_element);
                 }
             }

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -3,7 +3,7 @@ use futures::Stream;
 use parking_lot::Mutex;
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet, VecDeque};
 use std::hash::Hash;
 use std::pin::Pin;
 use std::sync::atomic;
@@ -59,10 +59,14 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     }
 }
 
-pub struct FairQueue<S, K: Clone> {
+pub struct FairQueue<S: Stream, K: Clone> {
     block_on_no_clients: bool,
     inner: Arc<Mutex<QueueInner<S, K>>>,
+    recv_cache: VecDeque<(K, S::Item)>,
+    recv_cache_capacity: usize,
 }
+
+impl<S: Stream, K: Clone> Unpin for FairQueue<S, K> {}
 
 #[derive(Clone)]
 struct ReadyEvent<K: Clone> {
@@ -118,6 +122,13 @@ where
     #[allow(clippy::needless_continue)]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let fair_queue = self.get_mut();
+        if let Some(item) = fair_queue.recv_cache.pop_front() {
+            return Poll::Ready(Some(item));
+        }
+        if fair_queue.recv_cache_capacity > 0 {
+            return fair_queue.poll_next_cached(cx);
+        }
+
         let mut remaining_ready = {
             let mut inner = fair_queue.inner.lock();
             inner.waker = Some(cx.waker().clone());
@@ -201,8 +212,19 @@ where
     }
 }
 
-impl<S, K: Clone> FairQueue<S, K> {
+impl<S, K> FairQueue<S, K>
+where
+    S: Stream,
+    K: Clone + Eq + Hash,
+{
     pub fn new(block_on_no_clients: bool) -> Self {
+        Self::with_recv_cache_capacity(block_on_no_clients, 0)
+    }
+
+    pub(crate) fn with_recv_cache_capacity(
+        block_on_no_clients: bool,
+        recv_cache_capacity: usize,
+    ) -> Self {
         Self {
             block_on_no_clients,
             inner: Arc::new(Mutex::new(QueueInner {
@@ -213,6 +235,8 @@ impl<S, K: Clone> FairQueue<S, K> {
                 waker: None,
                 on_disconnect: None,
             })),
+            recv_cache: VecDeque::with_capacity(recv_cache_capacity),
+            recv_cache_capacity,
         }
     }
 
@@ -228,6 +252,102 @@ impl<S, K: Clone> FairQueue<S, K> {
 
     pub(crate) fn inner(&self) -> Arc<Mutex<QueueInner<S, K>>> {
         self.inner.clone()
+    }
+}
+
+impl<S, T, K> FairQueue<S, K>
+where
+    T: Send,
+    S: Stream<Item = T> + Send + 'static,
+    K: Eq + Hash + Unpin + Clone + Send + Sync + 'static,
+{
+    fn poll_next_cached(&mut self, cx: &mut Context<'_>) -> Poll<Option<(K, T)>> {
+        let mut local_ready = BinaryHeap::new();
+        {
+            let mut inner = self.inner.lock();
+            inner.waker = Some(cx.waker().clone());
+            while let Some(event) = inner.ready_queue.pop() {
+                inner.queued.remove(&event.key);
+                local_ready.push(event);
+            }
+        }
+
+        let cache_limit = self.recv_cache_capacity + 1;
+        while let Some(event) = local_ready.pop() {
+            let mut io_stream = {
+                let mut inner = self.inner.lock();
+                inner.waker = Some(cx.waker().clone());
+                match inner.streams.remove(&event.key) {
+                    Some(stream) => stream,
+                    None => continue,
+                }
+            };
+
+            let waker = Arc::new(StreamWaker {
+                inner: self.inner.clone(),
+                event: event.clone(),
+            });
+            let waker_ref = waker_ref(&waker);
+            let mut stream_cx = Context::from_waker(&waker_ref);
+            match io_stream.as_mut().poll_next(&mut stream_cx) {
+                Poll::Ready(Some(res)) => {
+                    let key = event.key.clone();
+                    self.recv_cache.push_back((key.clone(), res));
+                    let mut inner = self.inner.lock();
+                    inner.streams.insert(event.key, io_stream);
+                    if self.recv_cache.len() < cache_limit {
+                        local_ready.push(ReadyEvent {
+                            priority: inner.counter.fetch_add(1, atomic::Ordering::Relaxed),
+                            key,
+                        });
+                    } else {
+                        inner.push_ready(key);
+                        Self::restore_ready_events(&mut inner, local_ready);
+                        break;
+                    }
+                }
+                Poll::Ready(None) => {
+                    let callback = {
+                        let inner = self.inner.lock();
+                        inner.on_disconnect.clone()
+                    };
+                    if let Some(callback) = callback {
+                        callback(event.key.clone());
+                    }
+                }
+                Poll::Pending => {
+                    let mut inner = self.inner.lock();
+                    inner.streams.insert(event.key, io_stream);
+                }
+            }
+        }
+
+        if let Some(item) = self.recv_cache.pop_front() {
+            return Poll::Ready(Some(item));
+        }
+
+        let mut inner = self.inner.lock();
+        inner.waker = Some(cx.waker().clone());
+        let should_wake = !inner.ready_queue.is_empty();
+        let result = if !inner.streams.is_empty() || self.block_on_no_clients {
+            Poll::Pending
+        } else {
+            Poll::Ready(None)
+        };
+        drop(inner);
+
+        if should_wake {
+            cx.waker().wake_by_ref();
+        }
+        result
+    }
+
+    fn restore_ready_events(inner: &mut QueueInner<S, K>, local_ready: BinaryHeap<ReadyEvent<K>>) {
+        for event in local_ready {
+            if inner.streams.contains_key(&event.key) && inner.queued.insert(event.key.clone()) {
+                inner.ready_queue.push(event);
+            }
+        }
     }
 }
 
@@ -249,6 +369,11 @@ mod test {
 
     struct CountPendingStream {
         poll_count: usize,
+    }
+
+    struct CountReadyStream {
+        poll_count: usize,
+        messages: VecDeque<&'static str>,
     }
 
     struct WakePendingStream {
@@ -281,6 +406,25 @@ mod test {
         }
     }
 
+    impl CountReadyStream {
+        fn new(messages: &[&'static str]) -> Self {
+            Self {
+                poll_count: 0,
+                messages: messages.iter().copied().collect(),
+            }
+        }
+    }
+
+    impl Stream for CountReadyStream {
+        type Item = &'static str;
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            this.poll_count += 1;
+            Poll::Ready(this.messages.pop_front())
+        }
+    }
+
     impl Stream for WakePendingStream {
         type Item = &'static str;
 
@@ -307,6 +451,7 @@ mod test {
     enum UnifiedStream {
         Test(TestStream),
         CountPending(CountPendingStream),
+        CountReady(CountReadyStream),
         WakePending(WakePendingStream),
     }
 
@@ -317,6 +462,7 @@ mod test {
             match self.get_mut() {
                 UnifiedStream::Test(stream) => Pin::new(stream).poll_next(cx),
                 UnifiedStream::CountPending(stream) => Pin::new(stream).poll_next(cx),
+                UnifiedStream::CountReady(stream) => Pin::new(stream).poll_next(cx),
                 UnifiedStream::WakePending(stream) => Pin::new(stream).poll_next(cx),
             }
         }
@@ -576,6 +722,83 @@ mod test {
         assert_eq!(
             stream.poll_count, 1,
             "FairQueue should not consume same-poll wake events immediately"
+        );
+    }
+
+    #[test]
+    fn test_fair_queue_recv_cache_drains_bounded_burst() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<UnifiedStream, &str> =
+            FairQueue::with_recv_cache_capacity(false, 3);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "peer",
+                UnifiedStream::CountReady(CountReadyStream::new(&["m1", "m2", "m3", "m4", "m5"])),
+            );
+        }
+
+        let result = Pin::new(&mut fair_queue).poll_next(&mut cx);
+        assert_eq!(result, Poll::Ready(Some(("peer", "m1"))));
+        assert_eq!(
+            fair_queue.recv_cache.len(),
+            3,
+            "cache should keep at most the configured number of prefetched messages"
+        );
+
+        let inner = fair_queue.inner();
+        let mut lock = inner.lock();
+        let stream = lock.streams.get_mut("peer").unwrap();
+        let UnifiedStream::CountReady(stream) = stream.as_mut().get_mut() else {
+            panic!("unexpected stream type");
+        };
+        assert_eq!(
+            stream.poll_count, 4,
+            "cache should poll one returned item plus the bounded cached burst"
+        );
+    }
+
+    #[test]
+    fn test_fair_queue_recv_cache_preserves_round_robin_order() {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<UnifiedStream, &str> =
+            FairQueue::with_recv_cache_capacity(false, 4);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "a",
+                UnifiedStream::CountReady(CountReadyStream::new(&["a1", "a2", "a3"])),
+            );
+            lock.insert(
+                "b",
+                UnifiedStream::CountReady(CountReadyStream::new(&["b1", "b2", "b3"])),
+            );
+        }
+
+        let mut results = Vec::new();
+        for _ in 0..6 {
+            match Pin::new(&mut fair_queue).poll_next(&mut cx) {
+                Poll::Ready(Some(item)) => results.push(item),
+                other => panic!("expected cached message, got {other:?}"),
+            }
+        }
+
+        assert_eq!(
+            results,
+            vec![
+                ("a", "a1"),
+                ("b", "b1"),
+                ("a", "a2"),
+                ("b", "b2"),
+                ("a", "a3"),
+                ("b", "b3")
+            ]
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,13 @@ pub trait SocketRecv {
 
 #[async_trait]
 pub trait SocketSend {
+    /// Queues a complete ZMQ message for delivery by this socket.
+    ///
+    /// A successful return means the socket has accepted responsibility for the
+    /// message. It does not guarantee that the message has already been written
+    /// to the network, received by a peer, or processed by the remote
+    /// application. Socket types that apply backpressure may wait here until the
+    /// message can be queued.
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()>;
 }
 
@@ -367,6 +374,10 @@ pub trait Socket: Sized + Send {
     // TODO: async fn disconnect_all(&mut self) -> ZmqResult<()>;
 
     /// Closes the socket, blocking until all associated binds are closed.
+    ///
+    /// Queued outbound messages remain owned by the socket backend and may
+    /// continue draining after this method returns. This currently matches the
+    /// explicit `drop` path rather than providing a configurable linger period.
     /// This is equivalent to `drop()`, but with the benefit of blocking until
     /// resources are released, and getting any underlying errors.
     ///

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,5 @@
 use bytes::Bytes;
 
-use std::collections::vec_deque::Iter;
 use std::collections::VecDeque;
 use std::convert::{From, TryFrom};
 use std::fmt;
@@ -19,15 +18,23 @@ impl fmt::Display for ZmqEmptyMessageError {
 #[derive(Debug)]
 pub struct ZmqMessage {
     frames: MessageFrames,
-    iter_cache: OnceLock<VecDeque<Bytes>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 enum MessageFrames {
     Empty,
-    Single(Bytes),
+    #[allow(clippy::box_collection)]
+    Single {
+        frame: Bytes,
+        // Public API requires returning VecDeque::Iter. Keep that compatibility
+        // cache off the hot message path and allocate it only when public iter()
+        // is used on a single-frame message.
+        iter_cache: OnceLock<Box<VecDeque<Bytes>>>,
+    },
     Multi(VecDeque<Bytes>),
 }
+
+static EMPTY_FRAMES: OnceLock<VecDeque<Bytes>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 enum IterInner<'a> {
@@ -76,10 +83,17 @@ impl ExactSizeIterator for IterRef<'_> {
 impl FusedIterator for IterRef<'_> {}
 
 impl MessageFrames {
+    fn single(frame: Bytes) -> Self {
+        Self::Single {
+            frame,
+            iter_cache: OnceLock::new(),
+        }
+    }
+
     fn from_vecdeque(mut frames: VecDeque<Bytes>) -> Self {
         match frames.len() {
             0 => Self::Empty,
-            1 => Self::Single(frames.pop_front().expect("length checked")),
+            1 => Self::single(frames.pop_front().expect("length checked")),
             _ => Self::Multi(frames),
         }
     }
@@ -87,7 +101,7 @@ impl MessageFrames {
     fn from_vec(mut frames: Vec<Bytes>) -> Self {
         match frames.len() {
             0 => Self::Empty,
-            1 => Self::Single(frames.pop().expect("length checked")),
+            1 => Self::single(frames.pop().expect("length checked")),
             _ => Self::Multi(frames.into()),
         }
     }
@@ -96,7 +110,7 @@ impl MessageFrames {
         let replacement = match self {
             Self::Multi(frames) if frames.is_empty() => Some(Self::Empty),
             Self::Multi(frames) if frames.len() == 1 => {
-                Some(Self::Single(frames.pop_front().expect("length checked")))
+                Some(Self::single(frames.pop_front().expect("length checked")))
             }
             _ => None,
         };
@@ -106,15 +120,17 @@ impl MessageFrames {
         }
     }
 
-    fn to_vecdeque(&self) -> VecDeque<Bytes> {
+    fn public_iter(&self) -> std::collections::vec_deque::Iter<'_, Bytes> {
         match self {
-            Self::Empty => VecDeque::new(),
-            Self::Single(frame) => {
-                let mut frames = VecDeque::with_capacity(1);
-                frames.push_back(frame.clone());
-                frames
-            }
-            Self::Multi(frames) => frames.clone(),
+            Self::Empty => EMPTY_FRAMES.get_or_init(VecDeque::new).iter(),
+            Self::Single { frame, iter_cache } => iter_cache
+                .get_or_init(|| {
+                    let mut frames = VecDeque::with_capacity(1);
+                    frames.push_back(frame.clone());
+                    Box::new(frames)
+                })
+                .iter(),
+            Self::Multi(frames) => frames.iter(),
         }
     }
 }
@@ -123,21 +139,27 @@ impl Clone for ZmqMessage {
     fn clone(&self) -> Self {
         Self {
             frames: self.frames.clone(),
-            iter_cache: OnceLock::new(),
+        }
+    }
+}
+
+impl Clone for MessageFrames {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Empty => Self::Empty,
+            Self::Single { frame, .. } => Self::single(frame.clone()),
+            Self::Multi(frames) => Self::Multi(frames.clone()),
         }
     }
 }
 
 impl ZmqMessage {
-    fn clear_iter_cache(&mut self) {
-        self.iter_cache = OnceLock::new();
-    }
-
     pub fn push_back(&mut self, frame: Bytes) {
-        self.clear_iter_cache();
         match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
-            MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
-            MessageFrames::Single(existing) => {
+            MessageFrames::Empty => self.frames = MessageFrames::single(frame),
+            MessageFrames::Single {
+                frame: existing, ..
+            } => {
                 let mut frames = VecDeque::with_capacity(2);
                 frames.push_back(existing);
                 frames.push_back(frame);
@@ -151,10 +173,11 @@ impl ZmqMessage {
     }
 
     pub fn push_front(&mut self, frame: Bytes) {
-        self.clear_iter_cache();
         match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
-            MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
-            MessageFrames::Single(existing) => {
+            MessageFrames::Empty => self.frames = MessageFrames::single(frame),
+            MessageFrames::Single {
+                frame: existing, ..
+            } => {
                 let mut frames = VecDeque::with_capacity(2);
                 frames.push_back(frame);
                 frames.push_back(existing);
@@ -167,14 +190,8 @@ impl ZmqMessage {
         }
     }
 
-    pub fn iter(&self) -> Iter<'_, Bytes> {
-        match &self.frames {
-            MessageFrames::Multi(frames) => frames.iter(),
-            MessageFrames::Empty | MessageFrames::Single(_) => self
-                .iter_cache
-                .get_or_init(|| self.frames.to_vecdeque())
-                .iter(),
-        }
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, Bytes> {
+        self.frames.public_iter()
     }
 
     pub(crate) fn frame_iter(
@@ -184,19 +201,18 @@ impl ZmqMessage {
         IterRef {
             inner: match &self.frames {
                 MessageFrames::Empty => IterInner::Empty,
-                MessageFrames::Single(frame) => IterInner::Single(Some(frame)),
+                MessageFrames::Single { frame, .. } => IterInner::Single(Some(frame)),
                 MessageFrames::Multi(frames) => IterInner::Multi(frames.iter()),
             },
         }
     }
 
     pub(crate) fn pop_front(&mut self) -> Option<Bytes> {
-        self.clear_iter_cache();
         match &mut self.frames {
             MessageFrames::Empty => None,
-            MessageFrames::Single(_) => {
+            MessageFrames::Single { .. } => {
                 match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
-                    MessageFrames::Single(frame) => Some(frame),
+                    MessageFrames::Single { frame, .. } => Some(frame),
                     _ => unreachable!("variant checked"),
                 }
             }
@@ -211,7 +227,7 @@ impl ZmqMessage {
     pub fn len(&self) -> usize {
         match &self.frames {
             MessageFrames::Empty => 0,
-            MessageFrames::Single(_) => 1,
+            MessageFrames::Single { .. } => 1,
             MessageFrames::Multi(frames) => frames.len(),
         }
     }
@@ -222,16 +238,16 @@ impl ZmqMessage {
 
     pub fn get(&self, index: usize) -> Option<&Bytes> {
         match &self.frames {
-            MessageFrames::Single(frame) if index == 0 => Some(frame),
+            MessageFrames::Single { frame, .. } if index == 0 => Some(frame),
             MessageFrames::Multi(frames) => frames.get(index),
-            MessageFrames::Empty | MessageFrames::Single(_) => None,
+            MessageFrames::Empty | MessageFrames::Single { .. } => None,
         }
     }
 
     pub fn into_vec(self) -> Vec<Bytes> {
         match self.frames {
             MessageFrames::Empty => Vec::new(),
-            MessageFrames::Single(frame) => vec![frame],
+            MessageFrames::Single { frame, .. } => vec![frame],
             MessageFrames::Multi(frames) => Vec::from(frames),
         }
     }
@@ -239,7 +255,7 @@ impl ZmqMessage {
     pub fn into_vecdeque(self) -> VecDeque<Bytes> {
         match self.frames {
             MessageFrames::Empty => VecDeque::new(),
-            MessageFrames::Single(frame) => {
+            MessageFrames::Single { frame, .. } => {
                 let mut frames = VecDeque::with_capacity(1);
                 frames.push_back(frame);
                 frames
@@ -255,7 +271,6 @@ impl ZmqMessage {
     }
 
     pub fn split_off(&mut self, at: usize) -> ZmqMessage {
-        self.clear_iter_cache();
         let frames = match &mut self.frames {
             MessageFrames::Empty => {
                 if at == 0 {
@@ -264,7 +279,7 @@ impl ZmqMessage {
                     panic!("`at` out of bounds")
                 }
             }
-            MessageFrames::Single(_) => match at {
+            MessageFrames::Single { .. } => match at {
                 0 => std::mem::replace(&mut self.frames, MessageFrames::Empty),
                 1 => MessageFrames::Empty,
                 _ => panic!("`at` out of bounds"),
@@ -272,10 +287,7 @@ impl ZmqMessage {
             MessageFrames::Multi(frames) => MessageFrames::from_vecdeque(frames.split_off(at)),
         };
         self.frames.normalize();
-        ZmqMessage {
-            frames,
-            iter_cache: OnceLock::new(),
-        }
+        ZmqMessage { frames }
     }
 }
 
@@ -287,7 +299,6 @@ impl TryFrom<Vec<Bytes>> for ZmqMessage {
         } else {
             Ok(Self {
                 frames: MessageFrames::from_vec(v),
-                iter_cache: OnceLock::new(),
             })
         }
     }
@@ -301,7 +312,6 @@ impl TryFrom<VecDeque<Bytes>> for ZmqMessage {
         } else {
             Ok(Self {
                 frames: MessageFrames::from_vecdeque(v),
-                iter_cache: OnceLock::new(),
             })
         }
     }
@@ -316,8 +326,7 @@ impl From<Vec<u8>> for ZmqMessage {
 impl From<Bytes> for ZmqMessage {
     fn from(b: Bytes) -> Self {
         Self {
-            frames: MessageFrames::Single(b),
-            iter_cache: OnceLock::new(),
+            frames: MessageFrames::single(b),
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,8 +1,9 @@
 use bytes::Bytes;
 
-use std::collections::vec_deque::{Iter, VecDeque};
+use std::collections::VecDeque;
 use std::convert::{From, TryFrom};
 use std::fmt;
+use std::iter::FusedIterator;
 
 #[derive(Debug)]
 pub struct ZmqEmptyMessageError;
@@ -15,44 +16,195 @@ impl fmt::Display for ZmqEmptyMessageError {
 
 #[derive(Debug, Clone)]
 pub struct ZmqMessage {
-    frames: VecDeque<Bytes>,
+    frames: MessageFrames,
+}
+
+#[derive(Debug, Clone)]
+enum MessageFrames {
+    Empty,
+    Single(Bytes),
+    Multi(VecDeque<Bytes>),
+}
+
+#[derive(Debug, Clone)]
+enum IterInner<'a> {
+    Empty,
+    Single(Option<&'a Bytes>),
+    Multi(std::collections::vec_deque::Iter<'a, Bytes>),
+}
+
+#[derive(Debug, Clone)]
+struct IterRef<'a> {
+    inner: IterInner<'a>,
+}
+
+impl<'a> Iterator for IterRef<'a> {
+    type Item = &'a Bytes;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            IterInner::Empty => None,
+            IterInner::Single(frame) => frame.take(),
+            IterInner::Multi(iter) => iter.next(),
+        }
+    }
+}
+
+impl DoubleEndedIterator for IterRef<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match &mut self.inner {
+            IterInner::Empty => None,
+            IterInner::Single(frame) => frame.take(),
+            IterInner::Multi(iter) => iter.next_back(),
+        }
+    }
+}
+
+impl ExactSizeIterator for IterRef<'_> {
+    fn len(&self) -> usize {
+        match &self.inner {
+            IterInner::Empty => 0,
+            IterInner::Single(frame) => usize::from(frame.is_some()),
+            IterInner::Multi(iter) => iter.len(),
+        }
+    }
+}
+
+impl FusedIterator for IterRef<'_> {}
+
+impl MessageFrames {
+    fn from_vecdeque(mut frames: VecDeque<Bytes>) -> Self {
+        match frames.len() {
+            0 => Self::Empty,
+            1 => Self::Single(frames.pop_front().expect("length checked")),
+            _ => Self::Multi(frames),
+        }
+    }
+
+    fn from_vec(mut frames: Vec<Bytes>) -> Self {
+        match frames.len() {
+            0 => Self::Empty,
+            1 => Self::Single(frames.pop().expect("length checked")),
+            _ => Self::Multi(frames.into()),
+        }
+    }
+
+    fn normalize(&mut self) {
+        let replacement = match self {
+            Self::Multi(frames) if frames.is_empty() => Some(Self::Empty),
+            Self::Multi(frames) if frames.len() == 1 => {
+                Some(Self::Single(frames.pop_front().expect("length checked")))
+            }
+            _ => None,
+        };
+
+        if let Some(replacement) = replacement {
+            *self = replacement;
+        }
+    }
 }
 
 impl ZmqMessage {
     pub fn push_back(&mut self, frame: Bytes) {
-        self.frames.push_back(frame);
+        match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
+            MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
+            MessageFrames::Single(existing) => {
+                let mut frames = VecDeque::with_capacity(2);
+                frames.push_back(existing);
+                frames.push_back(frame);
+                self.frames = MessageFrames::Multi(frames);
+            }
+            MessageFrames::Multi(mut frames) => {
+                frames.push_back(frame);
+                self.frames = MessageFrames::Multi(frames);
+            }
+        }
     }
 
     pub fn push_front(&mut self, frame: Bytes) {
-        self.frames.push_front(frame);
+        match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
+            MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
+            MessageFrames::Single(existing) => {
+                let mut frames = VecDeque::with_capacity(2);
+                frames.push_back(frame);
+                frames.push_back(existing);
+                self.frames = MessageFrames::Multi(frames);
+            }
+            MessageFrames::Multi(mut frames) => {
+                frames.push_front(frame);
+                self.frames = MessageFrames::Multi(frames);
+            }
+        }
     }
 
-    pub fn iter(&self) -> Iter<'_, Bytes> {
-        self.frames.iter()
+    pub fn iter(
+        &self,
+    ) -> impl DoubleEndedIterator<Item = &Bytes> + ExactSizeIterator + FusedIterator + Clone + '_
+    {
+        IterRef {
+            inner: match &self.frames {
+                MessageFrames::Empty => IterInner::Empty,
+                MessageFrames::Single(frame) => IterInner::Single(Some(frame)),
+                MessageFrames::Multi(frames) => IterInner::Multi(frames.iter()),
+            },
+        }
     }
 
     pub(crate) fn pop_front(&mut self) -> Option<Bytes> {
-        self.frames.pop_front()
+        match &mut self.frames {
+            MessageFrames::Empty => None,
+            MessageFrames::Single(_) => {
+                match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
+                    MessageFrames::Single(frame) => Some(frame),
+                    _ => unreachable!("variant checked"),
+                }
+            }
+            MessageFrames::Multi(frames) => {
+                let frame = frames.pop_front();
+                self.frames.normalize();
+                frame
+            }
+        }
     }
 
     pub fn len(&self) -> usize {
-        self.frames.len()
+        match &self.frames {
+            MessageFrames::Empty => 0,
+            MessageFrames::Single(_) => 1,
+            MessageFrames::Multi(frames) => frames.len(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.frames.is_empty()
+        matches!(self.frames, MessageFrames::Empty)
     }
 
     pub fn get(&self, index: usize) -> Option<&Bytes> {
-        self.frames.get(index)
+        match &self.frames {
+            MessageFrames::Single(frame) if index == 0 => Some(frame),
+            MessageFrames::Multi(frames) => frames.get(index),
+            MessageFrames::Empty | MessageFrames::Single(_) => None,
+        }
     }
 
     pub fn into_vec(self) -> Vec<Bytes> {
-        Vec::from(self.frames)
+        match self.frames {
+            MessageFrames::Empty => Vec::new(),
+            MessageFrames::Single(frame) => vec![frame],
+            MessageFrames::Multi(frames) => Vec::from(frames),
+        }
     }
 
     pub fn into_vecdeque(self) -> VecDeque<Bytes> {
-        self.frames
+        match self.frames {
+            MessageFrames::Empty => VecDeque::new(),
+            MessageFrames::Single(frame) => {
+                let mut frames = VecDeque::with_capacity(1);
+                frames.push_back(frame);
+                frames
+            }
+            MessageFrames::Multi(frames) => frames,
+        }
     }
 
     pub fn prepend(&mut self, message: &ZmqMessage) {
@@ -62,7 +214,22 @@ impl ZmqMessage {
     }
 
     pub fn split_off(&mut self, at: usize) -> ZmqMessage {
-        let frames = self.frames.split_off(at);
+        let frames = match &mut self.frames {
+            MessageFrames::Empty => {
+                if at == 0 {
+                    MessageFrames::Empty
+                } else {
+                    panic!("`at` out of bounds")
+                }
+            }
+            MessageFrames::Single(_) => match at {
+                0 => std::mem::replace(&mut self.frames, MessageFrames::Empty),
+                1 => MessageFrames::Empty,
+                _ => panic!("`at` out of bounds"),
+            },
+            MessageFrames::Multi(frames) => MessageFrames::from_vecdeque(frames.split_off(at)),
+        };
+        self.frames.normalize();
         ZmqMessage { frames }
     }
 }
@@ -73,7 +240,9 @@ impl TryFrom<Vec<Bytes>> for ZmqMessage {
         if v.is_empty() {
             Err(ZmqEmptyMessageError)
         } else {
-            Ok(Self { frames: v.into() })
+            Ok(Self {
+                frames: MessageFrames::from_vec(v),
+            })
         }
     }
 }
@@ -84,7 +253,9 @@ impl TryFrom<VecDeque<Bytes>> for ZmqMessage {
         if v.is_empty() {
             Err(ZmqEmptyMessageError)
         } else {
-            Ok(Self { frames: v })
+            Ok(Self {
+                frames: MessageFrames::from_vecdeque(v),
+            })
         }
     }
 }
@@ -98,7 +269,7 @@ impl From<Vec<u8>> for ZmqMessage {
 impl From<Bytes> for ZmqMessage {
     fn from(b: Bytes) -> Self {
         Self {
-            frames: vec![b].into(),
+            frames: MessageFrames::Single(b),
         }
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,9 +1,11 @@
 use bytes::Bytes;
 
+use std::collections::vec_deque::Iter;
 use std::collections::VecDeque;
 use std::convert::{From, TryFrom};
 use std::fmt;
 use std::iter::FusedIterator;
+use std::sync::OnceLock;
 
 #[derive(Debug)]
 pub struct ZmqEmptyMessageError;
@@ -14,9 +16,10 @@ impl fmt::Display for ZmqEmptyMessageError {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ZmqMessage {
     frames: MessageFrames,
+    iter_cache: OnceLock<VecDeque<Bytes>>,
 }
 
 #[derive(Debug, Clone)]
@@ -102,10 +105,36 @@ impl MessageFrames {
             *self = replacement;
         }
     }
+
+    fn to_vecdeque(&self) -> VecDeque<Bytes> {
+        match self {
+            Self::Empty => VecDeque::new(),
+            Self::Single(frame) => {
+                let mut frames = VecDeque::with_capacity(1);
+                frames.push_back(frame.clone());
+                frames
+            }
+            Self::Multi(frames) => frames.clone(),
+        }
+    }
+}
+
+impl Clone for ZmqMessage {
+    fn clone(&self) -> Self {
+        Self {
+            frames: self.frames.clone(),
+            iter_cache: OnceLock::new(),
+        }
+    }
 }
 
 impl ZmqMessage {
+    fn clear_iter_cache(&mut self) {
+        self.iter_cache = OnceLock::new();
+    }
+
     pub fn push_back(&mut self, frame: Bytes) {
+        self.clear_iter_cache();
         match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
             MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
             MessageFrames::Single(existing) => {
@@ -122,6 +151,7 @@ impl ZmqMessage {
     }
 
     pub fn push_front(&mut self, frame: Bytes) {
+        self.clear_iter_cache();
         match std::mem::replace(&mut self.frames, MessageFrames::Empty) {
             MessageFrames::Empty => self.frames = MessageFrames::Single(frame),
             MessageFrames::Single(existing) => {
@@ -137,7 +167,17 @@ impl ZmqMessage {
         }
     }
 
-    pub fn iter(
+    pub fn iter(&self) -> Iter<'_, Bytes> {
+        match &self.frames {
+            MessageFrames::Multi(frames) => frames.iter(),
+            MessageFrames::Empty | MessageFrames::Single(_) => self
+                .iter_cache
+                .get_or_init(|| self.frames.to_vecdeque())
+                .iter(),
+        }
+    }
+
+    pub(crate) fn frame_iter(
         &self,
     ) -> impl DoubleEndedIterator<Item = &Bytes> + ExactSizeIterator + FusedIterator + Clone + '_
     {
@@ -151,6 +191,7 @@ impl ZmqMessage {
     }
 
     pub(crate) fn pop_front(&mut self) -> Option<Bytes> {
+        self.clear_iter_cache();
         match &mut self.frames {
             MessageFrames::Empty => None,
             MessageFrames::Single(_) => {
@@ -208,12 +249,13 @@ impl ZmqMessage {
     }
 
     pub fn prepend(&mut self, message: &ZmqMessage) {
-        for frame in message.iter().rev() {
+        for frame in message.frame_iter().rev() {
             self.push_front(frame.clone());
         }
     }
 
     pub fn split_off(&mut self, at: usize) -> ZmqMessage {
+        self.clear_iter_cache();
         let frames = match &mut self.frames {
             MessageFrames::Empty => {
                 if at == 0 {
@@ -230,7 +272,10 @@ impl ZmqMessage {
             MessageFrames::Multi(frames) => MessageFrames::from_vecdeque(frames.split_off(at)),
         };
         self.frames.normalize();
-        ZmqMessage { frames }
+        ZmqMessage {
+            frames,
+            iter_cache: OnceLock::new(),
+        }
     }
 }
 
@@ -242,6 +287,7 @@ impl TryFrom<Vec<Bytes>> for ZmqMessage {
         } else {
             Ok(Self {
                 frames: MessageFrames::from_vec(v),
+                iter_cache: OnceLock::new(),
             })
         }
     }
@@ -255,6 +301,7 @@ impl TryFrom<VecDeque<Bytes>> for ZmqMessage {
         } else {
             Ok(Self {
                 frames: MessageFrames::from_vecdeque(v),
+                iter_cache: OnceLock::new(),
             })
         }
     }
@@ -270,6 +317,7 @@ impl From<Bytes> for ZmqMessage {
     fn from(b: Bytes) -> Self {
         Self {
             frames: MessageFrames::Single(b),
+            iter_cache: OnceLock::new(),
         }
     }
 }

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -16,6 +16,8 @@ use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+const PULL_RECV_CACHE_CAPACITY: usize = 64;
+
 pub struct PullSocket {
     backend: Arc<GenericSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
@@ -25,7 +27,7 @@ pub struct PullSocket {
 #[async_trait]
 impl Socket for PullSocket {
     fn with_options(options: SocketOptions) -> Self {
-        let mut fair_queue = FairQueue::new(true);
+        let mut fair_queue = FairQueue::with_recv_cache_capacity(true, PULL_RECV_CACHE_CAPACITY);
         let backend = Arc::new(GenericSocketBackend::with_options(
             Some(fair_queue.inner()),
             SocketType::PULL,

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -163,7 +163,7 @@ impl SocketRecv for RepSocket {
                             return Err(ZmqError::Other("Invalid message format"));
                         }
                         let mut at = 1;
-                        for (index, frame) in m.iter().enumerate() {
+                        for (index, frame) in m.frame_iter().enumerate() {
                             if frame.is_empty() {
                                 // Include delimiter in envelope.
                                 at = index + 1;

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,7 +11,7 @@ use crate::{Socket, SocketBackend};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -107,7 +107,7 @@ impl SocketSend for RouterSocket {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                peer.send(Message::Message(message)).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),
@@ -182,7 +182,7 @@ impl SocketSend for RouterSendHalf {
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
         match self.inner.backend.peers.get_async(&peer_id).await {
             Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
+                peer.send(Message::Message(message)).await?;
                 Ok(())
             }
             None => Err(ZmqError::Other("Destination client not found by identity")),

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
-use crate::codec::{CodecResult, FramedIo};
+use crate::codec::{CodecResult, FramedIo, ZmqFramedRead};
 use crate::*;
 
-use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use rand::Rng;
@@ -100,7 +99,7 @@ impl From<PeerIdentity> for Vec<u8> {
 pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>,
-    pub(crate) recv_queue: FramedRead<Box<dyn FrameableRead>, ZmqCodec>,
+    pub(crate) recv_queue: ZmqFramedRead,
 }
 
 /// Given the result of the greetings exchange, determines the version of the

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -8,10 +8,13 @@ mod test {
     #[test]
     fn test_single_frame_public_behavior() {
         let m = ZmqMessage::from(Bytes::from("data"));
+        fn assert_public_iter_type(_: std::collections::vec_deque::Iter<'_, Bytes>) {}
+
         assert_eq!(m.len(), 1);
         assert!(!m.is_empty());
         assert_eq!(m.get(0), Some(&Bytes::from("data")));
         assert_eq!(m.get(1), None);
+        assert_public_iter_type(m.iter());
         assert_eq!(
             m.iter().cloned().collect::<Vec<_>>(),
             vec![Bytes::from("data")]
@@ -50,6 +53,22 @@ mod test {
         let data = m.split_off(1);
         assert_eq!(m.get(0), Some(&Bytes::from("data")));
         assert!(data.is_empty());
+    }
+
+    #[test]
+    fn test_single_frame_public_iter_cache_does_not_survive_mutation() {
+        let mut m = ZmqMessage::from(Bytes::from("body"));
+        assert_eq!(
+            m.iter().cloned().collect::<Vec<_>>(),
+            vec![Bytes::from("body")]
+        );
+
+        m.push_front(Bytes::from("id"));
+
+        assert_eq!(
+            m.iter().cloned().collect::<Vec<_>>(),
+            vec![Bytes::from("id"), Bytes::from("body")]
+        );
     }
 
     #[test]

--- a/tests/message.rs
+++ b/tests/message.rs
@@ -6,6 +6,53 @@ mod test {
     use zeromq::ZmqMessage;
 
     #[test]
+    fn test_single_frame_public_behavior() {
+        let m = ZmqMessage::from(Bytes::from("data"));
+        assert_eq!(m.len(), 1);
+        assert!(!m.is_empty());
+        assert_eq!(m.get(0), Some(&Bytes::from("data")));
+        assert_eq!(m.get(1), None);
+        assert_eq!(
+            m.iter().cloned().collect::<Vec<_>>(),
+            vec![Bytes::from("data")]
+        );
+        assert_eq!(m.clone().into_vec(), vec![Bytes::from("data")]);
+        assert_eq!(
+            m.into_vecdeque().into_iter().collect::<Vec<_>>(),
+            vec![Bytes::from("data")]
+        );
+    }
+
+    #[test]
+    fn test_single_frame_promotes_to_multipart() {
+        let mut m = ZmqMessage::from(Bytes::from("body"));
+        m.push_front(Bytes::from("id"));
+        m.push_back(Bytes::from("tail"));
+
+        assert_eq!(m.len(), 3);
+        assert_eq!(m.get(0), Some(&Bytes::from("id")));
+        assert_eq!(m.get(1), Some(&Bytes::from("body")));
+        assert_eq!(m.get(2), Some(&Bytes::from("tail")));
+        assert_eq!(
+            m.iter().rev().cloned().collect::<Vec<_>>(),
+            vec![Bytes::from("tail"), Bytes::from("body"), Bytes::from("id")]
+        );
+    }
+
+    #[test]
+    fn test_split_off_single_frame_boundaries() {
+        let mut m = ZmqMessage::from(Bytes::from("data"));
+        let data = m.split_off(0);
+        assert!(m.is_empty());
+        assert_eq!(data.get(0), Some(&Bytes::from("data")));
+
+        let mut m = ZmqMessage::from(Bytes::from("data"));
+        let data = m.split_off(1);
+        assert_eq!(m.get(0), Some(&Bytes::from("data")));
+        assert!(data.is_empty());
+    }
+
+    #[test]
     fn test_split_off() {
         let mut frames = VecDeque::with_capacity(5);
         frames.push_back(Bytes::from("id1"));
@@ -44,5 +91,15 @@ mod test {
         assert_eq!(m.get(2), Some(&Bytes::from("")));
         assert_eq!(m.get(3), Some(&Bytes::from("data1")));
         assert_eq!(m.get(4), Some(&Bytes::from("data2")));
+        assert_eq!(
+            m.iter().rev().cloned().collect::<Vec<_>>(),
+            vec![
+                Bytes::from("data2"),
+                Bytes::from("data1"),
+                Bytes::from(""),
+                Bytes::from("id2"),
+                Bytes::from("id1"),
+            ]
+        );
     }
 }

--- a/tests/push_send_batching.rs
+++ b/tests/push_send_batching.rs
@@ -1,0 +1,134 @@
+use bytes::Bytes;
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::ZmqMessage;
+
+use std::convert::TryFrom;
+use std::time::Duration;
+
+const CONNECT_DELAY: Duration = Duration::from_millis(250);
+const RECV_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[async_rt::test]
+async fn push_batched_send_drains_queued_messages_after_drop() {
+    const MESSAGES: usize = 512;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(CONNECT_DELAY).await;
+
+    for seq in 0..MESSAGES {
+        push.send(single_frame(seq)).await.unwrap();
+    }
+
+    drop(push);
+
+    for expected in 0..MESSAGES {
+        let message = recv_with_timeout(&mut pull, "queued PUSH message").await;
+        assert_eq!(parse_seq(&message), expected);
+    }
+}
+
+#[async_rt::test]
+async fn push_batched_send_preserves_multipart_frames() {
+    const MESSAGES: usize = 128;
+
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(CONNECT_DELAY).await;
+
+    for seq in 0..MESSAGES {
+        push.send(multipart(seq)).await.unwrap();
+    }
+
+    for expected in 0..MESSAGES {
+        let message = recv_with_timeout(&mut pull, "multipart PUSH message").await;
+        assert_eq!(message.len(), 3);
+        assert_eq!(message.get(0).unwrap().as_ref(), b"meta");
+        assert_eq!(
+            message.get(1).unwrap().as_ref(),
+            format!("seq:{expected:04}").as_bytes()
+        );
+        assert_eq!(message.get(2).unwrap().as_ref(), vec![0xAB; 300].as_slice());
+    }
+}
+
+#[async_rt::test]
+async fn push_batched_send_preserves_round_robin_distribution() {
+    const MESSAGES: usize = 128;
+
+    let mut pull_a = zeromq::PullSocket::new();
+    let endpoint_a = pull_a.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut pull_b = zeromq::PullSocket::new();
+    let endpoint_b = pull_b.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&endpoint_a).await.unwrap();
+    push.connect(&endpoint_b).await.unwrap();
+    async_rt::task::sleep(CONNECT_DELAY).await;
+
+    let recv_a = async_rt::task::spawn(collect_sequences(pull_a, MESSAGES / 2));
+    let recv_b = async_rt::task::spawn(collect_sequences(pull_b, MESSAGES / 2));
+
+    for seq in 0..MESSAGES {
+        push.send(single_frame(seq)).await.unwrap();
+    }
+
+    let seqs_a = recv_a.await.unwrap();
+    let seqs_b = recv_b.await.unwrap();
+    assert_strict_alternating(&seqs_a);
+    assert_strict_alternating(&seqs_b);
+
+    let mut all = seqs_a;
+    all.extend(seqs_b);
+    all.sort_unstable();
+    assert_eq!(all, (0..MESSAGES).collect::<Vec<_>>());
+}
+
+async fn collect_sequences(mut pull: zeromq::PullSocket, count: usize) -> Vec<usize> {
+    let mut seqs = Vec::with_capacity(count);
+    for _ in 0..count {
+        let message = recv_with_timeout(&mut pull, "round-robin message").await;
+        seqs.push(parse_seq(&message));
+    }
+    seqs
+}
+
+async fn recv_with_timeout(pull: &mut zeromq::PullSocket, label: &'static str) -> ZmqMessage {
+    async_rt::task::timeout(RECV_TIMEOUT, pull.recv())
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {label}"))
+        .expect("PULL recv failed")
+}
+
+fn assert_strict_alternating(seqs: &[usize]) {
+    for window in seqs.windows(2) {
+        assert_eq!(window[1], window[0] + 2);
+    }
+}
+
+fn single_frame(seq: usize) -> ZmqMessage {
+    ZmqMessage::from(format!("seq:{seq:04}"))
+}
+
+fn multipart(seq: usize) -> ZmqMessage {
+    ZmqMessage::try_from(vec![
+        Bytes::from_static(b"meta"),
+        Bytes::from(format!("seq:{seq:04}")),
+        Bytes::from(vec![0xAB; 300]),
+    ])
+    .unwrap()
+}
+
+fn parse_seq(message: &ZmqMessage) -> usize {
+    let frame = message.get(0).expect("single frame");
+    let text = std::str::from_utf8(frame.as_ref()).expect("utf8 frame");
+    text.strip_prefix("seq:").unwrap().parse().unwrap()
+}

--- a/tests/recv_cancel_safety.rs
+++ b/tests/recv_cancel_safety.rs
@@ -1,0 +1,54 @@
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::ZmqMessage;
+
+use std::time::Duration;
+
+#[async_rt::test]
+async fn pull_recv_timeout_then_cached_drain_preserves_per_peer_order() {
+    let mut pull = zeromq::PullSocket::new();
+    let endpoint = pull.bind("tcp://127.0.0.1:0").await.unwrap().to_string();
+
+    let mut push_a = zeromq::PushSocket::new();
+    push_a.connect(&endpoint).await.unwrap();
+    let mut push_b = zeromq::PushSocket::new();
+    push_b.connect(&endpoint).await.unwrap();
+    async_rt::task::sleep(Duration::from_millis(100)).await;
+
+    let cancelled = async_rt::task::timeout(Duration::from_millis(10), pull.recv()).await;
+    assert!(
+        cancelled.is_err(),
+        "empty PULL recv should be cancelled by the timeout before messages are sent"
+    );
+
+    for i in 0..8 {
+        push_a
+            .send(ZmqMessage::from(format!("a:{i}")))
+            .await
+            .unwrap();
+        push_b
+            .send(ZmqMessage::from(format!("b:{i}")))
+            .await
+            .unwrap();
+    }
+
+    let mut seen_a = Vec::new();
+    let mut seen_b = Vec::new();
+    for _ in 0..16 {
+        let message = async_rt::task::timeout(Duration::from_secs(2), pull.recv())
+            .await
+            .expect("timed out waiting for queued PULL message")
+            .unwrap();
+        let payload = String::from_utf8(message.get(0).unwrap().to_vec()).unwrap();
+        let (peer, seq) = payload.split_once(':').unwrap();
+        let seq = seq.parse::<usize>().unwrap();
+        match peer {
+            "a" => seen_a.push(seq),
+            "b" => seen_b.push(seq),
+            other => panic!("unexpected peer marker: {other}"),
+        }
+    }
+
+    assert_eq!(seen_a, (0..8).collect::<Vec<_>>());
+    assert_eq!(seen_b, (0..8).collect::<Vec<_>>());
+}

--- a/tests/req_router_dealer_rep.rs
+++ b/tests/req_router_dealer_rep.rs
@@ -55,11 +55,32 @@ mod test {
         let router_events: Vec<_> = router_monitor.collect().await;
         let dealer_events: Vec<_> = dealer_monitor.collect().await;
         let rep_events: Vec<_> = rep_monitor.collect().await;
-        assert_eq!(2, router_events.len(), "{:?}", &router_events);
-        assert_eq!(2, dealer_events.len(), "{:?}", &dealer_events);
+        assert_bound_peer_lifecycle(&router_events);
+        assert_bound_peer_lifecycle(&dealer_events);
         assert_eq!(1, rep_events.len(), "{:?}", &rep_events);
 
         Ok(())
+    }
+
+    fn assert_bound_peer_lifecycle(events: &[zeromq::SocketEvent]) {
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, zeromq::SocketEvent::Listening(_))),
+            "{events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, zeromq::SocketEvent::Accepted(_, _))),
+            "{events:?}"
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(event, zeromq::SocketEvent::Disconnected(_))),
+            "{events:?}"
+        );
     }
 
     #[async_rt::test]


### PR DESCRIPTION
## Summary

This draft gathers the validated PUSH/PULL throughput stack into one reviewable branch:

- bound PUSH writer queues by message count and payload bytes, with queue-acceptance send semantics documented
- release PUSH queue credits after feeding the framed writer, while keeping the writer high-water mark as the second-stage bound
- replace the read-side ZMTP framed adapter with a reusable 64 KiB read buffer
- add a bounded, cancel-safe PULL receive cache under `FairQueue`
- store common single-frame `ZmqMessage`s without a hot-path `VecDeque`, while preserving `ZmqMessage::iter() -> VecDeque::Iter<'_, Bytes>`

I am opening this as a draft because it is intentionally a larger performance stack. The main review questions are the PUSH send/backpressure contract and the narrow `clippy::box_collection` allow used for the lazy single-frame iterator compatibility cache.

## Semantics

`send().await` on the PUSH path means the message has been accepted into a bounded socket queue, not necessarily flushed to the transport. The queue has both message and byte credits. Credits are released once a writer task feeds a message into `ZmqFramedWrite`; after that point, `ZmqFramedWrite`'s high-water mark bounds bytes accepted by the framed writer but not yet flushed.

The PULL receive cache is bounded, opt-in for PULL, and covered by cancellation/fairness tests. Public message iteration remains source-compatible: external `iter()` still returns `VecDeque::Iter<'_, Bytes>`. Internal hot paths use `frame_iter()` to avoid allocating the compatibility cache.

## Validation

Local validation passed with `RUSTC_WRAPPER=`:

```sh
cargo +nightly fmt --all -- --check
cargo clippy --all --all-targets -- --deny warnings
cargo clippy --all --all-targets --no-default-features --features async-std-runtime,all-transport,async-dispatcher-macros -- --deny warnings
cargo test --all
cargo test --all --no-default-features --features async-std-runtime,all-transport
cargo test --all --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros
timeout 900s env RUSTC_WRAPPER= cargo bench --no-run
```

Clippy still prints the repository's existing renamed/removed command-line lint warnings, but exits successfully.

## Benchmark Evidence

Profile: `pushpull-omq`, transport: TCP, implementations: zmq.rs, libzmq, OMQ Tokio, OMQ compio.

Candidate measurement commit: `7a58db4`, replaying the source-compatible clean implementation through `90f19fa`.

| run | zmq.rs 8/128 | zmq.rs 8/2048 | zmq.rs 8/8192 | OMQ Tokio 8/128 | OMQ Tokio 8/2048 | OMQ Tokio 8/8192 | OMQ compio 8/128 | OMQ compio 8/2048 | OMQ compio 8/8192 | libzmq 8/128 | libzmq 8/2048 | libzmq 8/8192 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| `message-repr-api-boxed-7a58db4-tcp-all` | 335.6 MB/s | 2.80 GB/s | 4.36 GB/s | 326.6 MB/s | 4.42 GB/s | 11.17 GB/s | 497.6 MB/s | 3.08 GB/s | 3.95 GB/s | 402.4 MB/s | 877.7 MB/s | 938.8 MB/s |
| `message-repr-api-boxed-7a58db4-tcp-all-rerun` | 330.1 MB/s | 2.37 GB/s | 4.16 GB/s | 287.1 MB/s | 4.34 GB/s | 10.90 GB/s | 501.4 MB/s | 3.06 GB/s | 4.06 GB/s | 396.6 MB/s | 858.5 MB/s | 938.8 MB/s |

Origin-behavior coverage branch for comparison:

| run | origin zmq.rs 8/128 | origin zmq.rs 8/2048 | origin zmq.rs 8/8192 |
| --- | ---: | ---: | ---: |
| `origin-master-coverage-cc3f8ff-tcp-all` | 86.9 MB/s | 1.91 GB/s | 3.13 GB/s |
| `origin-master-coverage-cc3f8ff-tcp-all-rerun` | 156.1 MB/s | 1.96 GB/s | 1.36 GB/s |

Interpretation: the small row is stable around 330-336 MB/s, the large row is stable around 4.16-4.36 GB/s and in OMQ-compio range, and the mid row improves materially over origin/libzmq but remains below OMQ compio/Tokio. This does not claim OMQ Tokio parity.

## Risks

- The branch is broad and should stay draft until reviewers agree the scope is reasonable.
- PUSH send semantics are explicitly queue-acceptance semantics; please review the wording and tests in `docs/SEND_SEMANTICS.md`.
- The boxed compatibility cache intentionally allows `clippy::box_collection` to keep hot queued `ZmqMessage`s small while preserving the public iterator type.
- The `8/2048` row still trails OMQ, so further driver/batching work remains useful after this stack.
