### PR TITLE
Improve socket send and PUB fanout performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ harness = false
 [[bench]]
 name = "throughput"
 harness = false
+
+[[bench]]
+name = "hotpath"
+harness = false

--- a/benches/bench_runtime.rs
+++ b/benches/bench_runtime.rs
@@ -3,14 +3,19 @@ use std::time::Duration;
 
 use criterion::{measurement::WallTime, BenchmarkGroup};
 
+#[allow(dead_code)]
+pub const DEFAULT_TRANSPORTS: &[&str] = &["tcp", "ipc"];
+
 #[cfg(feature = "tokio-runtime")]
 use tokio::runtime::{Builder, Runtime};
 
+#[allow(dead_code)]
 pub struct BenchRuntime {
     #[cfg(feature = "tokio-runtime")]
     inner: Runtime,
 }
 
+#[allow(dead_code)]
 impl BenchRuntime {
     pub fn new() -> Self {
         #[cfg(feature = "tokio-runtime")]
@@ -69,6 +74,33 @@ pub fn configure_group(group: &mut BenchmarkGroup<'_, WallTime>) {
         "ZMQRS_BENCH_WARMUP_MS",
         2_000,
     )));
+}
+
+#[allow(dead_code)]
+pub fn selected_transports(supported: &'static [&'static str]) -> Vec<&'static str> {
+    let Some(filter) = std::env::var("ZMQRS_BENCH_TRANSPORTS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return supported.to_vec();
+    };
+
+    let selected: Vec<_> = supported
+        .iter()
+        .copied()
+        .filter(|transport| {
+            filter
+                .split(',')
+                .any(|candidate| candidate.trim() == *transport)
+        })
+        .collect();
+
+    assert!(
+        !selected.is_empty(),
+        "ZMQRS_BENCH_TRANSPORTS must include at least one of: {}",
+        supported.join(",")
+    );
+    selected
 }
 
 fn env_usize(name: &str, default: usize) -> usize {

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -1,5 +1,7 @@
 //! Pure codec microbenchmarks: no sockets, no I/O.
 
+mod bench_runtime;
+
 use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -22,6 +24,7 @@ fn build_message(frame_count: usize, frame_size: usize) -> ZmqMessage {
 
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/encode");
+    bench_runtime::configure_group(&mut group);
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);
@@ -48,6 +51,7 @@ fn bench_encode(c: &mut Criterion) {
 
 fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/decode");
+    bench_runtime::configure_group(&mut group);
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);

--- a/benches/compare_libzmq.rs
+++ b/benches/compare_libzmq.rs
@@ -8,12 +8,13 @@
 mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use zeromq::{
     __async_rt::task, prelude::*, DealerSocket, PubSocket, PullSocket, PushSocket, RepSocket,
@@ -22,7 +23,12 @@ use zeromq::{
 
 const MSG_SIZES: &[usize] = &[16, 256, 4096, 65536];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
-const TRANSPORTS: &[&str] = &["tcp", "ipc"];
+const HOTPATH_MSG_SIZES: &[usize] = &[64, 256, 1024];
+const HOTPATH_PUB_SUB_COUNTS: &[usize] = &[0, 1, 4];
+const HOTPATH_DELIVERED_PUB_SUB_COUNTS: &[usize] = &[1, 4];
+const HOTPATH_ZMQ2_HWM: i32 = 100_000;
+
+type NativeJoinHandle = task::JoinHandle<()>;
 
 static IPC_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -43,8 +49,759 @@ fn build_rt() -> BenchRuntime {
     BenchRuntime::new()
 }
 
+async fn drain_zmqrs_pub_sync_messages(subs: &mut [SubSocket]) {
+    for sub in subs {
+        loop {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                }
+                Ok(Err(error)) => panic!("zmqrs pub sync drain recv: {error:?}"),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+async fn sync_zmqrs_pub_subscribers(
+    pub_sock: &mut PubSocket,
+    mut subs: Vec<SubSocket>,
+) -> Vec<SubSocket> {
+    let sync = ZmqMessage::from(vec![0xFF]);
+    let mut ready = Vec::with_capacity(subs.len());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !subs.is_empty() {
+        if Instant::now() > deadline {
+            panic!("zmqrs pub/sub sync timed out");
+        }
+        pub_sock.send(sync.clone()).await.expect("zmqrs pub sync");
+        let mut waiting = Vec::new();
+        for mut sub in subs.drain(..) {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                    ready.push(sub);
+                }
+                Ok(Err(error)) => panic!("zmqrs sub sync recv: {error:?}"),
+                Err(_) => waiting.push(sub),
+            }
+        }
+        subs = waiting;
+    }
+
+    // Subscribers that are already ready may receive later sync frames during subscription propagation; drain before timing.
+    drain_zmqrs_pub_sync_messages(&mut ready).await;
+    ready
+}
+
+fn hotpath_payload(size: usize, byte: u8) -> Bytes {
+    Bytes::from(vec![byte; size])
+}
+
+fn hotpath_native_endpoint() -> &'static str {
+    "tcp://127.0.0.1:0"
+}
+
+fn stop_native_drains(rt: &BenchRuntime, stop: Arc<AtomicBool>, handles: Vec<NativeJoinHandle>) {
+    stop.store(true, Ordering::Relaxed);
+    rt.block_on(async {
+        for handle in handles {
+            let _ = handle.await;
+        }
+    });
+}
+
+fn configure_libzmq_socket(socket: &zmq2::Socket) {
+    socket.set_linger(0).expect("linger");
+    socket.set_sndhwm(HOTPATH_ZMQ2_HWM).expect("sndhwm");
+    socket.set_rcvhwm(HOTPATH_ZMQ2_HWM).expect("rcvhwm");
+}
+
+fn libzmq_send_retry(socket: &zmq2::Socket, payload: &[u8]) {
+    loop {
+        match socket.send(payload, zmq2::DONTWAIT) {
+            Ok(()) => return,
+            Err(zmq2::Error::EAGAIN) => std::hint::spin_loop(),
+            Err(e) => panic!("libzmq send: {e:?}"),
+        }
+    }
+}
+
+fn join_libzmq_drains(stop: Arc<AtomicBool>, threads: Vec<thread::JoinHandle<()>>) {
+    stop.store(true, Ordering::Relaxed);
+    for thread in threads {
+        thread.join().expect("drain thread");
+    }
+}
+
+fn sync_libzmq_pub_subscribers(pub_sock: &zmq2::Socket, subs: &[zmq2::Socket]) {
+    let sync_payload = [0xFFu8];
+    let mut ready = vec![false; subs.len()];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+        pub_sock
+            .send(&sync_payload[..], 0)
+            .expect("libzmq pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                match sub.recv_bytes(zmq2::DONTWAIT) {
+                    Ok(message) => {
+                        black_box(message);
+                        ready[index] = true;
+                    }
+                    Err(zmq2::Error::EAGAIN) => {}
+                    Err(error) => panic!("libzmq sub sync recv: {error:?}"),
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    loop {
+        let mut drained_any = false;
+        for sub in subs {
+            loop {
+                match sub.recv_bytes(zmq2::DONTWAIT) {
+                    Ok(message) => {
+                        black_box(message);
+                        drained_any = true;
+                    }
+                    Err(zmq2::Error::EAGAIN) => break,
+                    Err(error) => panic!("libzmq sub sync drain recv: {error:?}"),
+                }
+            }
+        }
+        if !drained_any {
+            break;
+        }
+    }
+}
+
+fn sync_libzmq_pub_drain_threads(pub_sock: &zmq2::Socket, counters: &[Arc<AtomicUsize>]) {
+    let sync_payload = [0xFFu8];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while counters
+        .iter()
+        .any(|counter| counter.load(Ordering::Relaxed) == 0)
+    {
+        if Instant::now() > deadline {
+            panic!("libzmq pub drain thread sync timed out");
+        }
+        pub_sock
+            .send(&sync_payload[..], 0)
+            .expect("libzmq pub drain sync");
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let mut previous: usize = counters
+        .iter()
+        .map(|counter| counter.load(Ordering::Relaxed))
+        .sum();
+    loop {
+        thread::sleep(Duration::from_millis(2));
+        let current: usize = counters
+            .iter()
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .sum();
+        if current == previous {
+            break;
+        }
+        previous = current;
+    }
+}
+
+fn bench_native_socket_send(c: &mut Criterion) {
+    let rt = build_rt();
+
+    for &n_subs in HOTPATH_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!("hotpath/native_socket_send/pub/subs={n_subs}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes(msg_size as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_native_pub_send_one(b, &rt, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/native_socket_send/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_push_send_one(b, &rt, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/native_socket_send/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_dealer_send_one(b, &rt, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_native_pub_send_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    n_subs: usize,
+    msg_size: usize,
+) {
+    let (mut pub_sock, stop, handles) = rt.block_on(async {
+        let mut p = PubSocket::new();
+        let bound = p
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pub bind")
+            .to_string();
+        let mut subs = Vec::with_capacity(n_subs);
+        for _ in 0..n_subs {
+            let mut sub = SubSocket::new();
+            sub.connect(bound.as_str()).await.expect("sub connect");
+            sub.subscribe("").await.expect("subscribe");
+            subs.push(sub);
+        }
+
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut handles = Vec::with_capacity(n_subs);
+
+        for mut sub in subs {
+            let stop_for_task = stop.clone();
+            handles.push(task::spawn(async move {
+                while !stop_for_task.load(Ordering::Relaxed) {
+                    match task::timeout(Duration::from_millis(20), sub.recv()).await {
+                        Ok(Ok(message)) => {
+                            black_box(message);
+                        }
+                        Ok(Err(_)) => break,
+                        Err(_) => {}
+                    }
+                }
+            }));
+        }
+
+        (p, stop, handles)
+    });
+    let payload = hotpath_payload(msg_size, 0xAB);
+
+    b.iter(|| {
+        rt.block_on(async {
+            pub_sock
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("pub send");
+        });
+    });
+
+    stop_native_drains(rt, stop, handles);
+}
+
+fn bench_native_push_send_one(b: &mut criterion::Bencher<'_>, rt: &BenchRuntime, msg_size: usize) {
+    let (mut push, stop, handle) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pull bind")
+            .to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_task = stop.clone();
+        let handle = task::spawn(async move {
+            while !stop_for_task.load(Ordering::Relaxed) {
+                match task::timeout(Duration::from_millis(20), pull.recv()).await {
+                    Ok(Ok(message)) => {
+                        black_box(message);
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => {}
+                }
+            }
+        });
+        (push, stop, handle)
+    });
+    let payload = hotpath_payload(msg_size, 0xCD);
+
+    b.iter(|| {
+        rt.block_on(async {
+            push.send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("push send");
+        });
+    });
+
+    stop_native_drains(rt, stop, vec![handle]);
+}
+
+fn bench_native_dealer_send_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut dealer, stop, handle) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_task = stop.clone();
+        let handle = task::spawn(async move {
+            while !stop_for_task.load(Ordering::Relaxed) {
+                match task::timeout(Duration::from_millis(20), router.recv()).await {
+                    Ok(Ok(message)) => {
+                        black_box(message);
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => {}
+                }
+            }
+        });
+        (dealer, stop, handle)
+    });
+    let payload = hotpath_payload(msg_size, 0xEF);
+
+    b.iter(|| {
+        rt.block_on(async {
+            dealer
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("dealer send");
+        });
+    });
+
+    stop_native_drains(rt, stop, vec![handle]);
+}
+
+fn bench_libzmq_socket_send(c: &mut Criterion) {
+    for &n_subs in HOTPATH_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!("hotpath/libzmq_socket_send/pub/subs={n_subs}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes(msg_size as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_pub_send_one(b, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/libzmq_socket_send/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_push_send_one(b, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/libzmq_socket_send/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_dealer_send_one(b, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_libzmq_pub_send_one(b: &mut criterion::Bencher<'_>, n_subs: usize, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pub_sock = ctx.socket(zmq2::PUB).expect("pub socket");
+    configure_libzmq_socket(&pub_sock);
+    pub_sock.bind(hotpath_native_endpoint()).expect("pub bind");
+    let bound = pub_sock
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut threads = Vec::with_capacity(n_subs);
+    let mut counters = Vec::with_capacity(n_subs);
+    for _ in 0..n_subs {
+        let ctx = ctx.clone();
+        let bound = bound.clone();
+        let stop_for_thread = stop.clone();
+        let counter = Arc::new(AtomicUsize::new(0));
+        counters.push(counter.clone());
+        threads.push(thread::spawn(move || {
+            let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+            configure_libzmq_socket(&sub);
+            sub.set_rcvtimeo(20).expect("rcvtimeo");
+            sub.connect(&bound).expect("sub connect");
+            sub.set_subscribe(b"").expect("subscribe");
+            while !stop_for_thread.load(Ordering::Relaxed) {
+                match sub.recv_bytes(0) {
+                    Ok(message) => {
+                        black_box(message);
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(zmq2::Error::EAGAIN) => {}
+                    Err(_) => break,
+                }
+            }
+        }));
+    }
+
+    sync_libzmq_pub_drain_threads(&pub_sock, &counters);
+    let payload = vec![0xAB; msg_size];
+    b.iter(|| libzmq_send_retry(&pub_sock, &payload));
+
+    join_libzmq_drains(stop, threads);
+}
+
+fn bench_libzmq_push_send_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    configure_libzmq_socket(&pull);
+    pull.set_rcvtimeo(20).expect("rcvtimeo");
+    pull.bind(hotpath_native_endpoint()).expect("pull bind");
+    let bound = pull
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_for_thread = stop.clone();
+    let thread = thread::spawn(move || {
+        while !stop_for_thread.load(Ordering::Relaxed) {
+            match pull.recv_bytes(0) {
+                Ok(message) => {
+                    black_box(message);
+                }
+                Err(zmq2::Error::EAGAIN) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    configure_libzmq_socket(&push);
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xCD; msg_size];
+    b.iter(|| libzmq_send_retry(&push, &payload));
+
+    join_libzmq_drains(stop, vec![thread]);
+}
+
+fn bench_libzmq_dealer_send_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    configure_libzmq_socket(&router);
+    router.set_rcvtimeo(20).expect("rcvtimeo");
+    router.bind(hotpath_native_endpoint()).expect("router bind");
+    let bound = router
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_for_thread = stop.clone();
+    let thread = thread::spawn(move || {
+        while !stop_for_thread.load(Ordering::Relaxed) {
+            match router.recv_multipart(0) {
+                Ok(message) => {
+                    black_box(message);
+                }
+                Err(zmq2::Error::EAGAIN) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    configure_libzmq_socket(&dealer);
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xEF; msg_size];
+    b.iter(|| libzmq_send_retry(&dealer, &payload));
+
+    join_libzmq_drains(stop, vec![thread]);
+}
+
+fn bench_native_delivered_latency(c: &mut Criterion) {
+    let rt = build_rt();
+
+    for &n_subs in HOTPATH_DELIVERED_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!(
+            "hotpath/native_delivered_latency/pub_fanout/subs={n_subs}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes((msg_size * n_subs) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_native_pub_delivered_one(b, &rt, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/native_delivered_latency/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_push_delivered_one(b, &rt, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/native_delivered_latency/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes((msg_size * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_dealer_delivered_one(b, &rt, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_native_pub_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    n_subs: usize,
+    msg_size: usize,
+) {
+    let (mut pub_sock, mut subs) = rt.block_on(async {
+        let mut p = PubSocket::new();
+        let bound = p
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pub bind")
+            .to_string();
+        let mut subs = Vec::with_capacity(n_subs);
+        for _ in 0..n_subs {
+            let mut sub = SubSocket::new();
+            sub.connect(bound.as_str()).await.expect("sub connect");
+            sub.subscribe("").await.expect("subscribe");
+            subs.push(sub);
+        }
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
+        (p, subs)
+    });
+    let payload = hotpath_payload(msg_size, 0xAB);
+
+    b.iter(|| {
+        rt.block_on(async {
+            pub_sock
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("pub send");
+            for sub in &mut subs {
+                let message = task::timeout(Duration::from_secs(1), sub.recv())
+                    .await
+                    .expect("sub timeout")
+                    .expect("sub recv");
+                black_box(message);
+            }
+        });
+    });
+}
+
+fn bench_native_push_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut push, mut pull) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pull bind")
+            .to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (push, pull)
+    });
+    let payload = hotpath_payload(msg_size, 0xCD);
+
+    b.iter(|| {
+        rt.block_on(async {
+            push.send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("push send");
+            black_box(pull.recv().await.expect("pull recv"));
+        });
+    });
+}
+
+fn bench_native_dealer_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut dealer, mut router) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (dealer, router)
+    });
+    let payload = hotpath_payload(msg_size, 0xEF);
+
+    b.iter(|| {
+        rt.block_on(async {
+            dealer
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("dealer send");
+            let message = router.recv().await.expect("router recv");
+            router.send(message).await.expect("router send");
+            black_box(dealer.recv().await.expect("dealer recv"));
+        });
+    });
+}
+
+fn bench_libzmq_delivered_latency(c: &mut Criterion) {
+    for &n_subs in HOTPATH_DELIVERED_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!(
+            "hotpath/libzmq_delivered_latency/pub_fanout/subs={n_subs}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes((msg_size * n_subs) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_pub_delivered_one(b, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/libzmq_delivered_latency/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_push_delivered_one(b, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/libzmq_delivered_latency/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes((msg_size * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_dealer_delivered_one(b, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_libzmq_pub_delivered_one(b: &mut criterion::Bencher<'_>, n_subs: usize, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pub_sock = ctx.socket(zmq2::PUB).expect("pub socket");
+    configure_libzmq_socket(&pub_sock);
+    pub_sock.bind(hotpath_native_endpoint()).expect("pub bind");
+    let bound = pub_sock
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let mut subs = Vec::with_capacity(n_subs);
+    for _ in 0..n_subs {
+        let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+        configure_libzmq_socket(&sub);
+        sub.set_rcvtimeo(1000).expect("rcvtimeo");
+        sub.connect(&bound).expect("sub connect");
+        sub.set_subscribe(b"").expect("subscribe");
+        subs.push(sub);
+    }
+
+    sync_libzmq_pub_subscribers(&pub_sock, &subs);
+    let payload = vec![0xAB; msg_size];
+    b.iter(|| {
+        pub_sock.send(&payload, 0).expect("pub send");
+        for sub in &subs {
+            black_box(sub.recv_bytes(0).expect("sub recv"));
+        }
+    });
+}
+
+fn bench_libzmq_push_delivered_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    configure_libzmq_socket(&pull);
+    pull.bind(hotpath_native_endpoint()).expect("pull bind");
+    let bound = pull
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    configure_libzmq_socket(&push);
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xCD; msg_size];
+    b.iter(|| {
+        push.send(&payload, 0).expect("push send");
+        black_box(pull.recv_bytes(0).expect("pull recv"));
+    });
+}
+
+fn bench_libzmq_dealer_delivered_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    configure_libzmq_socket(&router);
+    router.bind(hotpath_native_endpoint()).expect("router bind");
+    let bound = router
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    configure_libzmq_socket(&dealer);
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xEF; msg_size];
+    b.iter(|| {
+        dealer.send(&payload, 0).expect("dealer send");
+        let message = router.recv_multipart(0).expect("router recv");
+        router
+            .send_multipart(message, 0)
+            .expect("router echo multipart");
+        black_box(dealer.recv_bytes(0).expect("dealer recv"));
+    });
+}
+
 fn bench_libzmq_pub_sub(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("libzmq/pub_sub/{transport}/subs={n_subs}"));
             bench_runtime::configure_group(&mut group);
@@ -84,7 +841,7 @@ fn bench_libzmq_pub_sub_one(
 
     struct SubHandle {
         tx_drive: mpsc::Sender<()>,
-        rx_done: mpsc::Receiver<Vec<u8>>,
+        rx_done: mpsc::Receiver<Option<Vec<u8>>>,
         _thread: thread::JoinHandle<()>,
     }
 
@@ -96,10 +853,15 @@ fn bench_libzmq_pub_sub_one(
         let (tx_done, rx_done) = mpsc::channel();
         let thread = thread::spawn(move || {
             let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+            sub.set_rcvtimeo(20).expect("sub rcvtimeo");
             sub.connect(&bound).expect("sub connect");
             sub.set_subscribe(b"").expect("subscribe");
             while rx_drive.recv().is_ok() {
-                let got = sub.recv_bytes(0).expect("sub recv");
+                let got = match sub.recv_bytes(0) {
+                    Ok(message) => Some(message),
+                    Err(zmq2::Error::EAGAIN) => None,
+                    Err(error) => panic!("sub recv: {error:?}"),
+                };
                 if tx_done.send(got).is_err() {
                     break;
                 }
@@ -112,7 +874,29 @@ fn bench_libzmq_pub_sub_one(
         });
     }
 
-    thread::sleep(Duration::from_millis(100));
+    let sync_payload = vec![0xFF];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut ready = vec![false; subs.len()];
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                sub.tx_drive.send(()).expect("drive sync sub");
+            }
+        }
+        pub_sock.send(&sync_payload, 0).expect("libzmq pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                if let Some(message) = sub.rx_done.recv().expect("sync sub done") {
+                    black_box(message);
+                    ready[index] = true;
+                }
+            }
+        }
+    }
+
     let payload = vec![0xAB; msg_size];
     b.iter(|| {
         for sub in &subs {
@@ -120,14 +904,15 @@ fn bench_libzmq_pub_sub_one(
         }
         pub_sock.send(&payload, 0).expect("pub send");
         for sub in &subs {
-            black_box(sub.rx_done.recv().expect("sub done"));
+            let message = sub.rx_done.recv().expect("sub done").expect("sub payload");
+            black_box(message);
         }
     });
 }
 
 fn bench_zmqrs_pub_sub(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("zmqrs/pub_sub/{transport}/subs={n_subs}"));
             bench_runtime::configure_group(&mut group);
@@ -172,7 +957,7 @@ fn bench_zmqrs_pub_sub_one(
             s.subscribe("").await.expect("subscribe");
             subs.push(s);
         }
-        task::sleep(Duration::from_millis(100)).await;
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
         (p, subs)
     });
 
@@ -188,10 +973,14 @@ fn bench_zmqrs_pub_sub_one(
             black_box(future::join_all(recv_futures).await);
         });
     });
+
+    drop(subs);
+    let errors = rt.block_on(pub_sock.close());
+    assert!(errors.is_empty(), "pub close errors: {errors:?}");
 }
 
 fn bench_libzmq_req_rep(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/req_rep/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -242,7 +1031,7 @@ fn bench_libzmq_req_rep_one(b: &mut criterion::Bencher<'_>, msg_size: usize, end
 
 fn bench_zmqrs_req_rep(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/req_rep/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -288,10 +1077,14 @@ fn bench_zmqrs_req_rep_one(
             black_box(req.recv().await.expect("req recv"));
         });
     });
+
+    drop(req);
+    let errors = rt.block_on(rep.close());
+    assert!(errors.is_empty(), "rep close errors: {errors:?}");
 }
 
 fn bench_libzmq_push_pull(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/push_pull/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -325,7 +1118,7 @@ fn bench_libzmq_push_pull_one(b: &mut criterion::Bencher<'_>, msg_size: usize, e
 
 fn bench_zmqrs_push_pull(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/push_pull/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -366,10 +1159,14 @@ fn bench_zmqrs_push_pull_one(
             black_box(pull.recv().await.expect("pull recv"));
         });
     });
+
+    drop(push);
+    let errors = rt.block_on(pull.close());
+    assert!(errors.is_empty(), "pull close errors: {errors:?}");
 }
 
 fn bench_libzmq_dealer_router(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -421,7 +1218,7 @@ fn bench_libzmq_dealer_router_one(b: &mut criterion::Bencher<'_>, msg_size: usiz
 
 fn bench_zmqrs_dealer_router(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -465,6 +1262,10 @@ fn bench_zmqrs_dealer_router_one(
             black_box(dealer.recv().await.expect("dealer recv"));
         });
     });
+
+    drop(dealer);
+    let errors = rt.block_on(router.close());
+    assert!(errors.is_empty(), "router close errors: {errors:?}");
 }
 
 criterion_group!(
@@ -477,5 +1278,9 @@ criterion_group!(
     bench_zmqrs_req_rep,
     bench_zmqrs_push_pull,
     bench_zmqrs_dealer_router,
+    bench_native_socket_send,
+    bench_libzmq_socket_send,
+    bench_native_delivered_latency,
+    bench_libzmq_delivered_latency,
 );
 criterion_main!(benches);

--- a/benches/hotpath.rs
+++ b/benches/hotpath.rs
@@ -1,0 +1,232 @@
+//! Internal hot-path cost calibration benchmark.
+
+mod bench_runtime;
+
+use async_trait::async_trait;
+use bench_runtime::BenchRuntime;
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::channel::mpsc;
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+
+use zeromq::{__bench::Message, prelude::*, ZmqMessage, ZmqResult};
+
+const MSG_SIZES: &[usize] = &[64, 256, 1024];
+const BENCH_PEER_SEND_QUEUE_CAPACITY: usize = 100_000;
+
+struct NoopInherentSender;
+
+impl NoopInherentSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        black_box(message);
+        Ok(())
+    }
+}
+
+struct NoopTraitSender;
+
+#[async_trait]
+impl SocketSend for NoopTraitSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        black_box(message);
+        Ok(())
+    }
+}
+
+struct NestedNoopTraitSender;
+
+#[async_trait]
+impl SocketSend for NestedNoopTraitSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        nested_noop_send(message).await?;
+        Ok(())
+    }
+}
+
+async fn nested_noop_send(message: ZmqMessage) -> ZmqResult<()> {
+    black_box(message);
+    Ok(())
+}
+
+fn build_rt() -> BenchRuntime {
+    BenchRuntime::new()
+}
+
+fn payload(size: usize, byte: u8) -> Bytes {
+    Bytes::from(vec![byte; size])
+}
+
+fn bench_message_construct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/message_construct/from_bytes");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            let payload = payload(s, 0xA5);
+            b.iter(|| black_box(ZmqMessage::from(payload.clone())));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/message_construct/vecdeque_single_frame");
+    bench_runtime::configure_group(&mut group);
+    let payload = payload(64, 0xA5);
+    group.bench_function("with_capacity_push_back", |b| {
+        b.iter(|| {
+            let mut frames = VecDeque::with_capacity(1);
+            frames.push_back(payload.clone());
+            black_box(frames);
+        });
+    });
+    group.bench_function("from_array", |b| {
+        b.iter(|| black_box(VecDeque::from([payload.clone()])));
+    });
+    group.bench_function("vec_into", |b| {
+        b.iter(|| {
+            let frames: VecDeque<Bytes> = vec![payload.clone()].into();
+            black_box(frames);
+        });
+    });
+    group.finish();
+}
+
+fn bench_runtime_overhead(c: &mut Criterion) {
+    let rt = build_rt();
+    let mut group = c.benchmark_group("hotpath/runtime");
+    bench_runtime::configure_group(&mut group);
+    group.bench_function("block_on_noop", |b| {
+        b.iter(|| rt.block_on(async { black_box(()) }));
+    });
+    group.finish();
+}
+
+fn bench_async_send_overhead(c: &mut Criterion) {
+    let rt = build_rt();
+    let mut group = c.benchmark_group("hotpath/async_send_overhead");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("inherent_async", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x71);
+                let mut sender = NoopInherentSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("inherent async send");
+                    });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("async_trait", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x72);
+                let mut sender = NoopTraitSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("async trait send");
+                    });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("async_trait_nested_await", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x73);
+                let mut sender = NestedNoopTraitSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("nested async trait send");
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_backend_primitives(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/backend_primitives");
+    bench_runtime::configure_group(&mut group);
+
+    group.bench_function("parking_lot_mutex_lock", |b| {
+        let mutex = Mutex::new(());
+        b.iter(|| {
+            let guard = mutex.lock();
+            black_box(&*guard);
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_unit", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(1);
+        b.iter(|| {
+            sender.try_send(()).expect("try_send unit");
+            let _: () = receiver.try_recv().expect("try_recv unit");
+            black_box(());
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_message", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(1);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            sender.try_send(message).expect("try_send message");
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_message_cap_100k", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(BENCH_PEER_SEND_QUEUE_CAPACITY);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            sender.try_send(message).expect("try_send message");
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.bench_function("mutex_mpsc_try_send_recv_message", |b| {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let sender = Mutex::new(sender);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            {
+                let mut sender = sender.lock();
+                sender.try_send(message).expect("try_send message");
+            }
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_backend_primitives,
+    bench_async_send_overhead,
+    bench_runtime_overhead,
+    bench_message_construct,
+);
+criterion_main!(benches);

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -3,22 +3,30 @@
 mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::{channel::oneshot, select, FutureExt};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
 use zeromq::{
-    __async_rt::task, prelude::*, DealerSocket, PubSocket, RouterSocket, SubSocket, ZmqMessage,
+    __async_rt::task, prelude::*, DealerSocket, PubSocket, PullSocket, PushSocket, RouterSocket,
+    SubSocket, ZmqMessage,
 };
 
 const BATCH_SIZE: usize = 1024;
 const PIPELINE_SIZES: &[usize] = &[256, 4096];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
-const TRANSPORTS: &[&str] = &["tcp", "ipc"];
 
 static IPC_SEQ: AtomicU64 = AtomicU64::new(0);
+
+struct SubHandle {
+    tx_drive: mpsc::Sender<usize>,
+    rx_done: mpsc::Receiver<usize>,
+    _thread: thread::JoinHandle<()>,
+}
 
 fn ipc_path(tag: &str) -> String {
     let n = IPC_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -37,12 +45,73 @@ fn build_rt() -> BenchRuntime {
     BenchRuntime::new()
 }
 
+async fn drain_zmqrs_pub_sync_messages(subs: &mut [SubSocket]) {
+    for sub in subs {
+        loop {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                }
+                Ok(Err(error)) => panic!("sub sync drain recv: {error:?}"),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+async fn sync_zmqrs_pub_subscribers(
+    pub_sock: &mut PubSocket,
+    mut subs: Vec<SubSocket>,
+) -> Vec<SubSocket> {
+    let sync = ZmqMessage::from(vec![0xFF]);
+    let mut ready = Vec::with_capacity(subs.len());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !subs.is_empty() {
+        if std::time::Instant::now() > deadline {
+            panic!("zmqrs pub/sub sync timed out");
+        }
+        pub_sock.send(sync.clone()).await.expect("pub sync");
+        let mut waiting = Vec::new();
+        for mut sub in subs.drain(..) {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                    ready.push(sub);
+                }
+                Ok(Err(error)) => panic!("sub sync recv: {error:?}"),
+                Err(_) => waiting.push(sub),
+            }
+        }
+        subs = waiting;
+    }
+
+    // Subscribers that are already ready may still receive later sync messages during subscription propagation.
+    // Drain those leftovers before the benchmark so old sync frames are not counted as payload.
+    drain_zmqrs_pub_sync_messages(&mut ready).await;
+    ready
+}
+
+fn drain_libzmq_pub_sync_messages(subs: &[SubHandle]) {
+    loop {
+        let mut drained_any = false;
+        for sub in subs {
+            sub.tx_drive.send(BATCH_SIZE).expect("drive sync drain sub");
+        }
+        for sub in subs {
+            drained_any |= sub.rx_done.recv().expect("sync drain sub done") > 0;
+        }
+        if !drained_any {
+            break;
+        }
+    }
+}
+
 fn bench_zmqrs_pub_pipelined(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!(
-                "zmqrs/throughput/pub_fanout/{transport}/subs={n_subs}"
+                "zmqrs/throughput/pub_fanout/send_pressure/{transport}/subs={n_subs}"
             ));
             bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
@@ -80,29 +149,11 @@ fn bench_zmqrs_pub_pipelined_one(
             subs.push(s);
         }
 
-        let sync = ZmqMessage::from(vec![0xFF]);
-        let mut remaining = subs;
-        let mut ready = Vec::with_capacity(n_subs);
-        let deadline = std::time::Instant::now() + Duration::from_secs(10);
-        while !remaining.is_empty() {
-            if std::time::Instant::now() > deadline {
-                panic!("zmqrs pub/sub sync timed out");
-            }
-            p.send(sync.clone()).await.expect("pub sync");
-            let mut waiting = Vec::new();
-            for mut s in remaining.drain(..) {
-                match task::timeout(Duration::from_millis(5), s.recv()).await {
-                    Ok(Ok(_)) => ready.push(s),
-                    Ok(Err(e)) => panic!("sub sync recv: {e:?}"),
-                    Err(_) => waiting.push(s),
-                }
-            }
-            remaining = waiting;
-        }
+        let ready = sync_zmqrs_pub_subscribers(&mut p, subs).await;
         (p, ready)
     });
 
-    let payload = vec![0xAB; msg_size];
+    let payload = Bytes::from(vec![0xAB; msg_size]);
     b.iter(|| {
         rt.block_on(async {
             let sub_handles: Vec<_> = subs
@@ -136,10 +187,10 @@ fn bench_zmqrs_pub_pipelined_one(
 }
 
 fn bench_libzmq_pub_pipelined(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!(
-                "libzmq/throughput/pub_fanout/{transport}/subs={n_subs}"
+                "libzmq/throughput/pub_fanout/send_pressure/{transport}/subs={n_subs}"
             ));
             bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
@@ -176,12 +227,6 @@ fn bench_libzmq_pub_pipelined_one(
         .expect("last_endpoint")
         .unwrap();
 
-    struct SubHandle {
-        tx_drive: mpsc::Sender<usize>,
-        rx_done: mpsc::Receiver<()>,
-        _thread: thread::JoinHandle<()>,
-    }
-
     let mut subs = Vec::with_capacity(n_subs);
     for _ in 0..n_subs {
         let ctx = ctx.clone();
@@ -195,16 +240,18 @@ fn bench_libzmq_pub_pipelined_one(
             sub.connect(&bound).expect("sub connect");
             sub.set_subscribe(b"").expect("subscribe");
             while let Ok(n) = rx_drive.recv() {
+                let mut received = 0;
                 for _ in 0..n {
                     match sub.recv_bytes(0) {
                         Ok(m) => {
                             black_box(m);
+                            received += 1;
                         }
                         Err(zmq2::Error::EAGAIN) => break,
                         Err(e) => panic!("sub recv: {e:?}"),
                     }
                 }
-                if tx_done.send(()).is_err() {
+                if tx_done.send(received).is_err() {
                     break;
                 }
             }
@@ -216,7 +263,28 @@ fn bench_libzmq_pub_pipelined_one(
         });
     }
 
-    thread::sleep(Duration::from_millis(200));
+    let sync_payload = vec![0xFF];
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut ready = vec![false; subs.len()];
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if std::time::Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                sub.tx_drive.send(1).expect("drive sync sub");
+            }
+        }
+        pub_sock.send(&sync_payload, 0).expect("pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                ready[index] = sub.rx_done.recv().expect("sync sub done") > 0;
+            }
+        }
+    }
+    drain_libzmq_pub_sync_messages(&subs);
+
     let payload = vec![0xAB; msg_size];
     b.iter(|| {
         for sub in &subs {
@@ -226,14 +294,14 @@ fn bench_libzmq_pub_pipelined_one(
             pub_sock.send(&payload, 0).expect("pub send");
         }
         for sub in &subs {
-            sub.rx_done.recv().expect("sub done");
+            black_box(sub.rx_done.recv().expect("sub done"));
         }
     });
 }
 
 fn bench_zmqrs_dealer_router_pipelined(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/throughput/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
@@ -253,52 +321,163 @@ fn bench_zmqrs_dealer_router_one(
     transport: &str,
 ) {
     let endpoint = endpoint(&format!("zmqrs-dr-{msg_size}"), transport);
-    let (dealer_send, dealer_recv, router) = rt.block_on(async {
+    let (mut send, mut recv, router_task, stop_router) = rt.block_on(async {
         let mut r = RouterSocket::new();
         let bound = r.bind(&endpoint).await.expect("router bind").to_string();
         let mut d = DealerSocket::new();
         d.connect(bound.as_str()).await.expect("dealer connect");
         task::sleep(Duration::from_millis(50)).await;
         let (send, recv) = d.split();
-        (send, recv, r)
+
+        let (stop_router, stop_receiver) = oneshot::channel();
+        let router_task = task::spawn(async move {
+            let mut stop_receiver = stop_receiver.fuse();
+            loop {
+                select! {
+                    _ = stop_receiver => break,
+                    message = r.recv().fuse() => {
+                        match message {
+                            Ok(message) => {
+                                if r.send(message).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            }
+            r
+        });
+
+        (send, recv, router_task, stop_router)
     });
-    let mut dealer_send = Some(dealer_send);
-    let mut dealer_recv = Some(dealer_recv);
-    let mut router = Some(router);
-    let payload = vec![0xCD; msg_size];
+    let payload = Bytes::from(vec![0xCD; msg_size]);
 
     b.iter(|| {
-        let mut send = dealer_send.take().unwrap();
-        let mut recv = dealer_recv.take().unwrap();
-        let mut r = router.take().unwrap();
         rt.block_on(async {
-            let router_task = task::spawn(async move {
-                for _ in 0..BATCH_SIZE {
-                    let m = r.recv().await.expect("router recv");
-                    r.send(m).await.expect("router send");
-                }
-                r
-            });
-            let recv_task = task::spawn(async move {
-                for _ in 0..BATCH_SIZE {
-                    black_box(recv.recv().await.expect("dealer recv"));
-                }
-                recv
-            });
             for _ in 0..BATCH_SIZE {
                 send.send(ZmqMessage::from(payload.clone()))
                     .await
                     .expect("dealer send");
             }
-            dealer_recv.replace(recv_task.await.expect("dealer recv task"));
-            router.replace(router_task.await.expect("router task"));
-            dealer_send.replace(send);
+            for _ in 0..BATCH_SIZE {
+                black_box(recv.recv().await.expect("dealer recv"));
+            }
+        });
+    });
+
+    let _ = stop_router.send(());
+    rt.block_on(async {
+        let _ = router_task.await;
+    });
+}
+
+fn bench_zmqrs_dealer_router_one_way(c: &mut Criterion) {
+    let rt = build_rt();
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group = c.benchmark_group(format!(
+            "zmqrs/throughput/dealer_router_one_way/{transport}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_zmqrs_dealer_router_one_way_one(b, &rt, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_zmqrs_dealer_router_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-dr-one-way-{msg_size}"), transport);
+    let (mut router, mut send) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(&endpoint)
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+        let (send, _recv) = dealer.split();
+        (router, send)
+    });
+    let payload = Bytes::from(vec![0xCD; msg_size]);
+
+    b.iter(|| {
+        rt.block_on(async {
+            for _ in 0..BATCH_SIZE {
+                send.send(ZmqMessage::from(payload.clone()))
+                    .await
+                    .expect("dealer send");
+            }
+            for _ in 0..BATCH_SIZE {
+                black_box(router.recv().await.expect("router recv"));
+            }
+        });
+    });
+}
+
+fn bench_zmqrs_push_pull_one_way(c: &mut Criterion) {
+    let rt = build_rt();
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group =
+            c.benchmark_group(format!("zmqrs/throughput/push_pull_one_way/{transport}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_zmqrs_push_pull_one_way_one(b, &rt, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_zmqrs_push_pull_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-pp-one-way-{msg_size}"), transport);
+    let (mut pull, mut push) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull.bind(&endpoint).await.expect("pull bind").to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (pull, push)
+    });
+    let payload = Bytes::from(vec![0xEF; msg_size]);
+
+    b.iter(|| {
+        rt.block_on(async {
+            for _ in 0..BATCH_SIZE {
+                push.send(ZmqMessage::from(payload.clone()))
+                    .await
+                    .expect("push send");
+            }
+            for _ in 0..BATCH_SIZE {
+                black_box(pull.recv().await.expect("pull recv"));
+            }
         });
     });
 }
 
 fn bench_libzmq_dealer_router_pipelined(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/throughput/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
@@ -362,11 +541,106 @@ fn bench_libzmq_dealer_router_one(
     thread.join().ok();
 }
 
+fn bench_libzmq_dealer_router_one_way(c: &mut Criterion) {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group = c.benchmark_group(format!(
+            "libzmq/throughput/dealer_router_one_way/{transport}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_dealer_router_one_way_one(b, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_libzmq_dealer_router_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-dr-one-way-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    let hwm = (BATCH_SIZE * 4) as i32;
+    router.set_rcvhwm(hwm).expect("router rcvhwm");
+    router.set_rcvtimeo(100).expect("router timeout");
+    router.bind(&endpoint).expect("router bind");
+    let bound = router.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    dealer.set_sndhwm(hwm).expect("dealer sndhwm");
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+    let payload = vec![0xCD; msg_size];
+
+    b.iter(|| {
+        for _ in 0..BATCH_SIZE {
+            dealer.send(&payload, 0).expect("dealer send");
+        }
+        for _ in 0..BATCH_SIZE {
+            black_box(router.recv_multipart(0).expect("router recv"));
+        }
+    });
+}
+
+fn bench_libzmq_push_pull_one_way(c: &mut Criterion) {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group =
+            c.benchmark_group(format!("libzmq/throughput/push_pull_one_way/{transport}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_push_pull_one_way_one(b, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_libzmq_push_pull_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-pp-one-way-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    let hwm = (BATCH_SIZE * 4) as i32;
+    pull.set_rcvhwm(hwm).expect("pull rcvhwm");
+    pull.set_rcvtimeo(100).expect("pull timeout");
+    pull.bind(&endpoint).expect("pull bind");
+    let bound = pull.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    push.set_sndhwm(hwm).expect("push sndhwm");
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+    let payload = vec![0xEF; msg_size];
+
+    b.iter(|| {
+        for _ in 0..BATCH_SIZE {
+            push.send(&payload, 0).expect("push send");
+        }
+        for _ in 0..BATCH_SIZE {
+            black_box(pull.recv_bytes(0).expect("pull recv"));
+        }
+    });
+}
+
 criterion_group!(
     benches,
     bench_zmqrs_pub_pipelined,
     bench_zmqrs_dealer_router_pipelined,
+    bench_zmqrs_dealer_router_one_way,
+    bench_zmqrs_push_pull_one_way,
     bench_libzmq_pub_pipelined,
     bench_libzmq_dealer_router_pipelined,
+    bench_libzmq_dealer_router_one_way,
+    bench_libzmq_push_pull_one_way,
 );
 criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,6 +3,8 @@
 Criterion benches live in [`benches/`](../benches/). This branch carries a
 master-compatible subset of the newer benchmark suite so local results can be
 compared against the performance branch without pulling in branch-only APIs.
+Where useful, the suite includes side-by-side `libzmq` baselines through the
+`zmq2` dev dependency.
 
 ## Performance Suite
 
@@ -58,16 +60,174 @@ cargo bench --bench throughput -- --sample-size 10
 
 Results land under `target/criterion/`.
 
-## Bench Shape
+Socket and codec benchmarks share these optional environment controls:
+
+- `ZMQRS_BENCH_SAMPLE_SIZE`, default `10`
+- `ZMQRS_BENCH_MEASUREMENT_MS`, default `10000`
+- `ZMQRS_BENCH_WARMUP_MS`, default `2000`
+- `ZMQRS_BENCH_TRANSPORTS`, optional comma-separated transport filter for
+  `throughput` and `compare_libzmq`; supported values are `tcp` and `ipc`.
+  Invalid values fail fast instead of silently skipping transport cases.
+
+For TCP-only smoke checks, use:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench throughput -- --test
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench compare_libzmq -- --test
+```
+
+## Bench Targets
 
 The master-compatible set includes:
 
-- `codec`: encode/decode microbenchmarks through the hidden `zeromq::__bench`
-  export.
-- `compare_libzmq`: latency-style PUB/SUB, REQ/REP, PUSH/PULL, and
-  DEALER/ROUTER cases, side-by-side with libzmq through `zmq2`.
-- `throughput`: batched PUB fanout and DEALER/ROUTER throughput cases.
+- `codec`: pure ZMTP codec encode/decode microbenchmarks through the hidden
+  `zeromq::__bench` export. These do not create sockets or perform network I/O.
+  The encode benchmark includes `ZmqMessage` cloning and destination buffer
+  construction; decode includes greeting decode and input buffer construction.
+- `compare_libzmq`: one-message latency-style PUB/SUB, REQ/REP, PUSH/PULL, and
+  DEALER/ROUTER cases over TCP and IPC, side-by-side with libzmq through
+  `zmq2`. It also hosts the native/libzmq socket-send and delivered-latency
+  groups so comparison code stays in one bench target.
+- `throughput`: batched pipeline throughput for PUB/SUB fanout and
+  DEALER/ROUTER, plus one-way DEALER/ROUTER and PUSH/PULL receive-path
+  isolation. Existing `pub_fanout/send_pressure` numbers are send-pressure
+  oriented: receiver timeout paths may stop early, so those numbers must not be
+  read as strict delivered throughput unless the benchmark name explicitly says
+  so.
+- `hotpath`: focused internal hot-path experiments. The diagnostic groups
+  `message_construct`, `runtime`, `backend_primitives`, and
+  `async_send_overhead` are calibration aids for interpreting send-only gaps.
 
 The suite intentionally excludes branch-only sockets, security builders,
 engine internals, and `inproc` transport. libzmq peers run on OS threads;
 `zeromq` peers run on a fixed 2-worker Tokio runtime.
+
+## Reading Results
+
+Sender-side hot-path groups measure local send admission only. A successful
+`send().await` on an optimized queued path is not a transport flush or delivery
+acknowledgement.
+
+Delivered-latency benchmarks require a receiver to observe the message. They
+include runtime scheduling, blocking peer threads, transport behavior, and
+receive-path overhead.
+
+Throughput benchmarks measure a sustained batch. They are the right tool for
+checking whether batching, writer queue design, and receive-path changes improve
+real pipeline behavior.
+
+Criterion throughput is computed from the bytes declared by each benchmark:
+
+- One-way send or receive benchmarks use `msg_size`.
+- Fanout delivered benchmarks use `msg_size * subscriber_count`.
+- Roundtrip DEALER/ROUTER delivered benchmarks use `2 * msg_size`.
+- Some historical one-message comparison groups keep the older request-payload
+  convention and use `msg_size` even when a reply is sent. Compare those groups
+  by latency first, not by aggregate MiB/s.
+
+Do not use a single benchmark family as the whole performance truth. The current
+suite intentionally keeps sender hot path, delivered latency, and batch
+throughput separate because they answer different questions.
+
+## Send Semantics
+
+For sockets backed by `GenericSocketBackend`, such as PUSH, DEALER, and ROUTER,
+`send().await` completes when the message has been accepted into the local
+per-peer writer queue. The actual framed I/O is performed later by the peer
+writer task.
+
+This means a successful `send().await` does not prove that bytes have been
+flushed to the transport, received by the peer, or processed by the peer. It
+only proves that the local socket accepted responsibility for the message under
+the current queue and connection state.
+
+When the per-peer writer queue is full, non-PUB send paths preserve backpressure
+by waiting for queue capacity before returning. If the writer side is already
+closed, the send path reports an error and prunes the disconnected peer. A
+write failure that happens after a message was accepted into the local queue can
+still lose that queued message; later operations discover the closed writer
+through the normal disconnect path.
+
+PUB has intentionally weaker completion semantics. `PubSocket::send().await`
+returns after the message has been accepted into the local PUB fanout path, or
+after the message has been dropped according to PUB drop policy.
+
+The PUB sender does not wait for subscription matching, per-subscriber queue
+insertion, framed writes, transport flushes, or subscriber receives. If the PUB
+fanout queue is full, the whole published message is dropped and
+`send().await` still returns `Ok(())`. If an individual subscriber writer queue
+is full, delivery to that subscriber is dropped and other matching subscribers
+continue. If a subscriber writer is closed, that subscriber is removed and the
+current fanout continues for the remaining subscribers.
+
+For a single peer writer queue, messages that are accepted into that queue are
+written by one background writer task in queue order. Batching changes flush
+granularity, not the order in which a writer task feeds messages to the framed
+sink. For PUB, per-subscriber ordering is preserved for messages that actually
+enter that subscriber's writer queue. Drops can create gaps.
+
+No socket send path in this crate is a durability boundary. Dropping a socket,
+shutting down a backend, unbinding an endpoint, or closing the process can
+discard messages that were accepted into local queues but not yet written and
+received.
+
+Tests should not treat `send().await` as a flush barrier. Prefer observable
+protocol synchronization:
+
+- Use a receiver-side acknowledgement or a known sync frame when a test needs to
+  prove delivery.
+- Use time-bounded `recv` calls instead of fixed sleeps for final assertions.
+- For PUB/SUB tests, explicitly wait until every subscriber has received a sync
+  message before measuring or asserting payload delivery.
+- When interacting with blocking libzmq sockets, avoid blocking the async
+  runtime thread immediately after `send().await`; let the receiver-side
+  observation drive the assertion.
+
+## Known Limits
+
+- `compare_libzmq` has a known IPC `REQ/REP` multi-case teardown issue in the
+  current benchmark harness. A single case such as
+  `zmqrs/req_rep/ipc/16 --test` exits normally, while the broader
+  `zmqrs/req_rep/ipc --test` filter can print all success lines and still not
+  exit. Use `ZMQRS_BENCH_TRANSPORTS=tcp` for full harness smoke checks when IPC
+  is not the target of the run.
+- PUSH/PULL 64B send-only remains the main non-IPC microbenchmark gap after the
+  low-risk optimization pass. Use `hotpath/message_construct`,
+  `hotpath/backend_primitives`, and `hotpath/async_send_overhead` to calibrate
+  the remaining fixed costs before attributing the gap to one component.
+
+## Useful Commands
+
+Smoke compile:
+
+```sh
+cargo bench --no-run
+```
+
+Short hot-path socket-send run:
+
+```sh
+ZMQRS_BENCH_SAMPLE_SIZE=10 ZMQRS_BENCH_MEASUREMENT_MS=200 ZMQRS_BENCH_WARMUP_MS=50 \
+  cargo bench --bench compare_libzmq hotpath/native_socket_send/pub/subs=1/64
+```
+
+Longer native versus libzmq socket-send comparison:
+
+```sh
+ZMQRS_BENCH_SAMPLE_SIZE=20 ZMQRS_BENCH_MEASUREMENT_MS=3000 ZMQRS_BENCH_WARMUP_MS=1000 \
+  cargo bench --bench compare_libzmq hotpath/.+_socket_send
+```
+
+TCP-only throughput smoke:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp ZMQRS_BENCH_SAMPLE_SIZE=10 \
+ZMQRS_BENCH_MEASUREMENT_MS=300 ZMQRS_BENCH_WARMUP_MS=100 \
+  cargo bench --bench throughput
+```
+
+Full TCP-only benchmark harness check without running measurements:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench compare_libzmq -- --test
+```

--- a/examples/task_sink.rs
+++ b/examples/task_sink.rs
@@ -4,7 +4,7 @@ use std::error::Error;
 use std::io::Write;
 use std::time::Instant;
 
-use zeromq::{Socket, SocketRecv, SocketSend};
+use zeromq::{Socket, SocketRecv};
 
 #[async_helpers::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,8 @@
-use crate::codec::{FramedIo, Message, ZmqFramedRead, ZmqFramedWrite};
+use crate::async_rt;
+use crate::codec::{FramedIo, Message, ZmqFramedRead};
 use crate::fair_queue::QueueInner;
 use crate::util::PeerIdentity;
+use crate::write_queue::write_message_queue;
 use crate::{
     MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, ZmqError, ZmqResult,
 };
@@ -12,13 +14,35 @@ use futures::SinkExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 /// Sender for notifying reconnection tasks when a peer disconnects.
 pub(crate) type DisconnectNotifier = mpsc::Sender<PeerIdentity>;
+const PEER_SEND_QUEUE_CAPACITY: usize = 100_000;
 
 pub(crate) struct Peer {
-    pub(crate) send_queue: ZmqFramedWrite,
+    pub(crate) send_queue: mpsc::Sender<Message>,
+}
+
+#[derive(Clone)]
+struct SinglePeer {
+    peer_id: PeerIdentity,
+    send_queue: mpsc::Sender<Message>,
+}
+
+enum CachedSend {
+    Sent,
+    Full {
+        peer_id: PeerIdentity,
+        send_queue: mpsc::Sender<Message>,
+        message: Message,
+    },
+    Disconnected {
+        peer_id: PeerIdentity,
+        error: mpsc::SendError,
+    },
+    Miss(Message),
 }
 
 pub(crate) struct GenericSocketBackend {
@@ -28,6 +52,8 @@ pub(crate) struct GenericSocketBackend {
     socket_type: SocketType,
     socket_options: SocketOptions,
     pub(crate) socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
+    single_peer: Mutex<Option<SinglePeer>>,
+    peer_count: AtomicUsize,
     /// Notifiers for reconnection tasks - keyed by `peer_id`
     disconnect_notifiers: Mutex<HashMap<PeerIdentity, DisconnectNotifier>>,
 }
@@ -45,6 +71,8 @@ impl GenericSocketBackend {
             socket_type,
             socket_options: options,
             socket_monitor: Mutex::new(None),
+            single_peer: Mutex::new(None),
+            peer_count: AtomicUsize::new(0),
             disconnect_notifiers: Mutex::new(HashMap::new()),
         }
     }
@@ -67,7 +95,14 @@ impl GenericSocketBackend {
         self.disconnect_notifiers.lock().remove(peer_id);
     }
 
-    pub(crate) async fn send_round_robin(&self, message: Message) -> ZmqResult<PeerIdentity> {
+    pub(crate) async fn send_round_robin(&self, message: Message) -> ZmqResult<()> {
+        let Some(message) = self
+            .finish_cached_send(self.try_send_cached_single_peer(message, None))
+            .await?
+        else {
+            return Ok(());
+        };
+
         // In normal scenario this will always be only 1 iteration
         // There can be special case when peer has disconnected and his id is still in
         // RR queue This happens because SegQueue don't have an api to delete
@@ -92,13 +127,13 @@ impl GenericSocketBackend {
                 },
             };
             let send_result = match self.peers.get_async(&next_peer_id).await {
-                Some(mut peer) => peer.send_queue.send(message).await,
+                Some(mut peer) => send_to_peer_queue(&mut peer.send_queue, message).await,
                 None => continue,
             };
             return match send_result {
                 Ok(()) => {
-                    self.round_robin.push(next_peer_id.clone());
-                    Ok(next_peer_id)
+                    self.round_robin.push(next_peer_id);
+                    Ok(())
                 }
                 Err(e) => {
                     self.peer_disconnected(&next_peer_id);
@@ -106,6 +141,101 @@ impl GenericSocketBackend {
                 }
             };
         }
+    }
+
+    pub(crate) async fn send_to_peer(
+        &self,
+        peer_id: &PeerIdentity,
+        message: Message,
+    ) -> ZmqResult<()> {
+        let Some(message) = self
+            .finish_cached_send(self.try_send_cached_single_peer(message, Some(peer_id)))
+            .await?
+        else {
+            return Ok(());
+        };
+
+        // ROUTER already knows the target identity, so reuse the queued try_send fast path.
+        let send_result = match self.peers.get_async(peer_id).await {
+            Some(mut peer) => send_to_peer_queue(&mut peer.send_queue, message).await,
+            None => return Err(ZmqError::Other("Destination client not found by identity")),
+        };
+        match send_result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.peer_disconnected(peer_id);
+                Err(e.into())
+            }
+        }
+    }
+
+    fn try_send_cached_single_peer(
+        &self,
+        message: Message,
+        expected_peer_id: Option<&PeerIdentity>,
+    ) -> CachedSend {
+        if self.peer_count.load(Ordering::Relaxed) != 1 {
+            return CachedSend::Miss(message);
+        }
+
+        let mut single_peer = self.single_peer.lock();
+        let Some(single_peer) = single_peer.as_mut() else {
+            self.peer_count.store(self.peers.len(), Ordering::Relaxed);
+            return CachedSend::Miss(message);
+        };
+
+        if let Some(expected_peer_id) = expected_peer_id {
+            if single_peer.peer_id != *expected_peer_id {
+                return CachedSend::Miss(message);
+            }
+        }
+
+        // The single-peer case is the common PUSH/DEALER/ROUTER hot path, so try to enqueue without awaiting.
+        match single_peer.send_queue.try_send(message) {
+            Ok(()) => CachedSend::Sent,
+            Err(error) if error.is_full() => CachedSend::Full {
+                peer_id: single_peer.peer_id.clone(),
+                send_queue: single_peer.send_queue.clone(),
+                message: error.into_inner(),
+            },
+            Err(error) => CachedSend::Disconnected {
+                peer_id: single_peer.peer_id.clone(),
+                error: error.into_send_error(),
+            },
+        }
+    }
+
+    async fn finish_cached_send(&self, cached_send: CachedSend) -> ZmqResult<Option<Message>> {
+        match cached_send {
+            CachedSend::Sent => Ok(None),
+            CachedSend::Full {
+                peer_id,
+                mut send_queue,
+                message,
+            } => match send_queue.send(message).await {
+                Ok(()) => Ok(None),
+                Err(e) => {
+                    self.peer_disconnected(&peer_id);
+                    Err(e.into())
+                }
+            },
+            CachedSend::Disconnected { peer_id, error } => {
+                self.peer_disconnected(&peer_id);
+                Err(error.into())
+            }
+            CachedSend::Miss(message) => Ok(Some(message)),
+        }
+    }
+}
+
+async fn send_to_peer_queue(
+    send_queue: &mut mpsc::Sender<Message>,
+    message: Message,
+) -> Result<(), mpsc::SendError> {
+    match send_queue.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_full() => send_queue.send(error.into_inner()).await,
+        Err(error) => Err(error.into_send_error()),
     }
 }
 
@@ -120,6 +250,8 @@ impl SocketBackend for GenericSocketBackend {
 
     fn shutdown(&self) {
         self.peers.clear_sync();
+        self.single_peer.lock().take();
+        self.peer_count.store(0, Ordering::Relaxed);
         // Clear fair_queue streams to ensure TCP connections are closed
         // even when reconnect tasks still hold Arc references to the backend
         if let Some(inner) = &self.fair_queue_inner {
@@ -136,9 +268,17 @@ impl SocketBackend for GenericSocketBackend {
 impl MultiPeerBackend for GenericSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
+        let (queue_sender, queue_receiver) = mpsc::channel(PEER_SEND_QUEUE_CAPACITY);
         self.peers
-            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .upsert_async(
+                peer_id.clone(),
+                Peer {
+                    send_queue: queue_sender,
+                },
+            )
             .await;
+        async_rt::task::spawn(write_message_queue(queue_receiver, send_queue));
+        self.refresh_single_peer_cache();
         self.round_robin.push(peer_id.clone());
         match &self.fair_queue_inner {
             None => {}
@@ -150,6 +290,7 @@ impl MultiPeerBackend for GenericSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         self.peers.remove_sync(peer_id);
+        self.refresh_single_peer_cache();
         match &self.fair_queue_inner {
             None => {}
             Some(inner) => {
@@ -163,5 +304,177 @@ impl MultiPeerBackend for GenericSocketBackend {
             // will eventually notice the peer is gone
             let _ = notifier.try_send(peer_id.clone());
         }
+    }
+}
+
+impl GenericSocketBackend {
+    fn refresh_single_peer_cache(&self) {
+        let peer_count = self.peers.len();
+        self.peer_count.store(peer_count, Ordering::Relaxed);
+
+        let mut single_peer = self.single_peer.lock();
+        if peer_count == 1 {
+            *single_peer = self.peers.begin_sync().map(|peer| SinglePeer {
+                peer_id: peer.key().clone(),
+                send_queue: peer.send_queue.clone(),
+            });
+        } else {
+            *single_peer = None;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ZmqMessage;
+
+    use bytes::Bytes;
+    use futures::StreamExt;
+
+    fn message_with_frame(frame: &'static [u8]) -> Message {
+        Message::Message(ZmqMessage::from(Bytes::from_static(frame)))
+    }
+
+    fn first_frame(message: Message) -> Bytes {
+        let Message::Message(message) = message else {
+            panic!("unexpected queued message type");
+        };
+        message.get(0).expect("message frame").clone()
+    }
+
+    async fn insert_peer(
+        backend: &GenericSocketBackend,
+        peer_id: PeerIdentity,
+    ) -> (PeerIdentity, mpsc::Receiver<Message>) {
+        let (send_queue, recv_queue) = mpsc::channel(8);
+        backend
+            .peers
+            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .await;
+        backend.refresh_single_peer_cache();
+        (peer_id, recv_queue)
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_uses_single_peer_cache() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let (_peer_id, mut recv_queue) =
+            insert_peer(&backend, "peer-a".parse().expect("peer id")).await;
+
+        assert_eq!(1, backend.peer_count.load(Ordering::Relaxed));
+        assert!(backend.single_peer.lock().is_some());
+
+        backend
+            .send_round_robin(message_with_frame(b"payload"))
+            .await
+            .expect("send through single peer cache");
+
+        let queued = recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"payload"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_to_peer_uses_single_peer_cache_for_matching_identity() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::ROUTER, SocketOptions::default());
+        let (peer_id, mut recv_queue) =
+            insert_peer(&backend, "router-peer".parse().expect("peer id")).await;
+
+        assert_eq!(
+            Some(peer_id.clone()),
+            backend
+                .single_peer
+                .lock()
+                .as_ref()
+                .map(|peer| peer.peer_id.clone())
+        );
+
+        backend
+            .send_to_peer(&peer_id, message_with_frame(b"routed"))
+            .await
+            .expect("send to cached peer");
+
+        let queued = recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"routed"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_to_peer_routes_by_identity_with_multiple_peers() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::ROUTER, SocketOptions::default());
+        let (_first_peer_id, mut first_recv_queue) =
+            insert_peer(&backend, "router-peer-a".parse().expect("peer id")).await;
+        let (second_peer_id, mut second_recv_queue) =
+            insert_peer(&backend, "router-peer-b".parse().expect("peer id")).await;
+
+        assert_eq!(2, backend.peer_count.load(Ordering::Relaxed));
+        assert!(backend.single_peer.lock().is_none());
+
+        backend
+            .send_to_peer(&second_peer_id, message_with_frame(b"routed-b"))
+            .await
+            .expect("send to selected peer");
+
+        assert!(first_recv_queue.try_recv().is_err());
+        let queued = second_recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"routed-b"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_waits_when_cached_sender_is_full() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let peer_id: PeerIdentity = "full-peer".parse().expect("peer id");
+        let (mut send_queue, mut recv_queue) = mpsc::channel(1);
+        send_queue
+            .try_send(message_with_frame(b"prefilled"))
+            .expect("prefill peer queue");
+        backend
+            .peers
+            .upsert_async(peer_id, Peer { send_queue })
+            .await;
+        backend.refresh_single_peer_cache();
+
+        let send_future = backend.send_round_robin(message_with_frame(b"after-full"));
+        let recv_future = async {
+            let first = recv_queue.next().await.expect("prefilled message");
+            let second = recv_queue
+                .next()
+                .await
+                .expect("message sent after capacity frees");
+            (first, second)
+        };
+
+        let (send_result, (first, second)) = futures::join!(send_future, recv_future);
+
+        send_result.expect("send waits for cached sender capacity");
+        assert_eq!(Bytes::from_static(b"prefilled"), first_frame(first));
+        assert_eq!(Bytes::from_static(b"after-full"), first_frame(second));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_single_peer_cache_is_cleared_when_cached_sender_is_disconnected() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let peer_id: PeerIdentity = "closed-peer".parse().expect("peer id");
+        let (send_queue, recv_queue) = mpsc::channel(1);
+        drop(recv_queue);
+        backend
+            .peers
+            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .await;
+        backend.refresh_single_peer_cache();
+
+        let error = backend
+            .send_round_robin(message_with_frame(b"lost"))
+            .await
+            .expect_err("closed cached sender should fail");
+
+        assert!(matches!(error, ZmqError::BufferFull(_)));
+        assert_eq!(0, backend.peer_count.load(Ordering::Relaxed));
+        assert!(backend.single_peer.lock().is_none());
+        assert!(backend.peers.get_async(&peer_id).await.is_none());
     }
 }

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,7 +1,15 @@
 use crate::codec::ZmqCodec;
 
-use asynchronous_codec::{FramedRead, FramedWrite};
-use futures::{AsyncRead, AsyncWrite};
+use super::error::{CodecError, CodecResult};
+use super::Message;
+
+use asynchronous_codec::{Decoder, FramedWrite};
+use bytes::BytesMut;
+use futures::{ready, AsyncRead, AsyncWrite, Stream};
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
 pub trait FrameableRead: AsyncRead + Unpin + Send + Sync {}
@@ -9,8 +17,72 @@ impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
 pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {}
 impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
 
-pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
+
+const READ_CHUNK_SIZE: usize = 64 * 1024;
+
+/// ZMTP framed reader with a larger read chunk.
+///
+/// `asynchronous-codec` defaults to 8 KiB reads from the underlying transport.
+/// Raising the chunk to 64 KiB reduces read/poll loops on the framed read path
+/// during large IPC/TCP payload bursts.
+pub struct ZmqFramedRead {
+    inner: Box<dyn FrameableRead>,
+    codec: ZmqCodec,
+    buffer: BytesMut,
+    read_scratch: Box<[u8]>,
+}
+
+impl ZmqFramedRead {
+    fn new(inner: Box<dyn FrameableRead>) -> Self {
+        Self {
+            inner,
+            codec: ZmqCodec::new(),
+            buffer: BytesMut::with_capacity(READ_CHUNK_SIZE),
+            read_scratch: vec![0; READ_CHUNK_SIZE].into_boxed_slice(),
+        }
+    }
+}
+
+impl Stream for ZmqFramedRead {
+    type Item = CodecResult<Message>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        // Consume buffered data first; read from the transport only when the current buffer cannot produce a full message.
+        if let Some(item) = this.codec.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
+        loop {
+            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut this.read_scratch))?;
+            this.buffer.extend_from_slice(&this.read_scratch[..n]);
+
+            let ended = n == 0;
+            match this.codec.decode(&mut this.buffer)? {
+                Some(item) => return Poll::Ready(Some(Ok(item))),
+                None if ended => {
+                    // On EOF, give the decoder one final chance to consume the remaining buffer before reporting truncated input.
+                    if this.buffer.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    match this.codec.decode_eof(&mut this.buffer)? {
+                        Some(item) => return Poll::Ready(Some(Ok(item))),
+                        None if this.buffer.is_empty() => return Poll::Ready(None),
+                        None => {
+                            return Poll::Ready(Some(Err(CodecError::Io(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "bytes remaining in stream",
+                            )))));
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
 
 /// Equivalent to [`asynchronous_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
@@ -20,7 +92,7 @@ pub struct FramedIo {
 
 impl FramedIo {
     pub fn new(read_half: Box<dyn FrameableRead>, write_half: Box<dyn FrameableWrite>) -> Self {
-        let read_half = FramedRead::new(read_half, ZmqCodec::new());
+        let read_half = ZmqFramedRead::new(read_half);
         let write_half = FramedWrite::new(write_half, ZmqCodec::new());
         Self {
             read_half,
@@ -30,5 +102,81 @@ impl FramedIo {
 
     pub fn into_parts(self) -> (ZmqFramedRead, ZmqFramedWrite) {
         (self.read_half, self.write_half)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_rt;
+    use crate::codec::ZmqGreeting;
+
+    use bytes::{Bytes, BytesMut};
+    use futures::io::Cursor;
+    use futures::StreamExt;
+    use std::io::ErrorKind;
+
+    fn encoded_stream(frames: &[&[u8]]) -> Vec<u8> {
+        let mut bytes = BytesMut::from(ZmqGreeting::default());
+        for frame in frames {
+            bytes.extend_from_slice(&[0, frame.len() as u8]);
+            bytes.extend_from_slice(frame);
+        }
+        bytes.to_vec()
+    }
+
+    #[async_rt::test]
+    async fn test_zmq_framed_read_yields_buffered_messages_before_reading_more() {
+        let input = encoded_stream(&[b"first", b"second"]);
+        let mut reader = ZmqFramedRead::new(Box::new(Cursor::new(input)));
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Greeting(_)))
+        ));
+
+        let first = reader
+            .next()
+            .await
+            .expect("first message")
+            .expect("decode first");
+        let Message::Message(first) = first else {
+            panic!("unexpected first frame type");
+        };
+        assert_eq!(first.get(0), Some(&Bytes::from_static(b"first")));
+
+        let second = reader
+            .next()
+            .await
+            .expect("second message")
+            .expect("decode second");
+        let Message::Message(second) = second else {
+            panic!("unexpected second frame type");
+        };
+        assert_eq!(second.get(0), Some(&Bytes::from_static(b"second")));
+
+        assert!(reader.next().await.is_none());
+    }
+
+    #[async_rt::test]
+    async fn test_zmq_framed_read_reports_truncated_frame_at_eof() {
+        let mut input = BytesMut::from(ZmqGreeting::default()).to_vec();
+        input.extend_from_slice(&[0, 5, b'a']);
+        let mut reader = ZmqFramedRead::new(Box::new(Cursor::new(input)));
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Greeting(_)))
+        ));
+
+        let error = reader
+            .next()
+            .await
+            .expect("truncated frame should produce an item")
+            .expect_err("truncated frame should fail");
+        match error {
+            CodecError::Io(error) => assert_eq!(error.kind(), ErrorKind::UnexpectedEof),
+            other => panic!("unexpected error type: {other:?}"),
+        }
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -10,7 +10,7 @@ mod zmq_codec;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};
-pub(crate) use framed::{FrameableRead, FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
+pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
 pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub use zmq_codec::ZmqCodec;
 

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -5,7 +5,7 @@ use super::Message;
 use crate::ZmqMessage;
 
 use asynchronous_codec::{Decoder, Encoder};
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use bytes::{Buf, Bytes, BytesMut};
 
 use std::convert::TryFrom;
 
@@ -98,11 +98,20 @@ impl Decoder for ZmqCodec {
                 if frame.command {
                     return Ok(Some(Message::Command(ZmqCommand::try_from(data.freeze())?)));
                 }
+                let data = data.freeze();
+
+                if self.buffered_message.is_none() && !frame.more {
+                    return Ok(Some(Message::Message(
+                        ZmqMessage::from_decoded_single_frame(data),
+                    )));
+                }
 
                 // process incoming message frame
                 match &mut self.buffered_message {
-                    Some(v) => v.push_back(data.freeze()),
-                    None => self.buffered_message = Some(ZmqMessage::from(data.freeze())),
+                    Some(v) => v.push_back(data),
+                    None => {
+                        self.buffered_message = Some(ZmqMessage::from_decoded_single_frame(data));
+                    }
                 }
 
                 if frame.more {
@@ -129,14 +138,13 @@ fn encode_frame(frame: &Bytes, dst: &mut BytesMut, more: bool) {
     if len > 255 {
         flags |= 0b0000_0010;
         dst.reserve(len + 9);
+        let mut header = [0u8; 9];
+        header[0] = flags;
+        header[1..].copy_from_slice(&(len as u64).to_be_bytes());
+        dst.extend_from_slice(&header);
     } else {
         dst.reserve(len + 2);
-    }
-    dst.put_u8(flags);
-    if len > 255 {
-        dst.put_u64(len as u64);
-    } else {
-        dst.put_u8(len as u8);
+        dst.extend_from_slice(&[flags, len as u8]);
     }
     dst.extend_from_slice(frame.as_ref());
 }
@@ -209,5 +217,58 @@ pub(crate) mod tests {
             }
             _ => panic!("wrong message type"),
         }
+    }
+
+    #[test]
+    pub fn test_single_frame_message_decode_without_buffering() {
+        let mut bytes = BytesMut::from(&[0x00, 0x03, b'a', b'b', b'c'][..]);
+        let mut codec = ZmqCodec::new();
+        codec.waiting_for = 1;
+        codec.state = DecoderState::FrameHeader;
+
+        let message = codec
+            .decode(&mut bytes)
+            .expect("decode success")
+            .expect("single message");
+
+        match message {
+            Message::Message(m) => {
+                assert_eq!(1, m.len());
+                assert_eq!(Some(&Bytes::from_static(b"abc")), m.get(0));
+            }
+            _ => panic!("wrong message type"),
+        }
+        assert!(bytes.is_empty());
+        assert!(codec.buffered_message.is_none());
+    }
+
+    #[test]
+    pub fn test_short_message_encode_uses_compact_header() {
+        let mut codec = ZmqCodec::new();
+        let mut bytes = BytesMut::new();
+        let message = ZmqMessage::from(Bytes::from_static(b"abc"));
+
+        codec
+            .encode(Message::Message(message), &mut bytes)
+            .expect("encode success");
+
+        assert_eq!(bytes.as_ref(), &[0x00, 0x03, b'a', b'b', b'c']);
+    }
+
+    #[test]
+    pub fn test_long_message_encode_uses_8_byte_length_header() {
+        let mut codec = ZmqCodec::new();
+        let mut bytes = BytesMut::new();
+        let payload = Bytes::from(vec![0x5a; 256]);
+        let message = ZmqMessage::from(payload.clone());
+
+        codec
+            .encode(Message::Message(message), &mut bytes)
+            .expect("encode success");
+
+        assert_eq!(bytes.len(), 9 + payload.len());
+        assert_eq!(bytes[0], 0b0000_0010);
+        assert_eq!(&bytes[1..9], &(payload.len() as u64).to_be_bytes());
+        assert_eq!(&bytes[9..], payload.as_ref());
     }
 }

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -14,6 +14,7 @@ pub(crate) struct QueueInner<S, K: Clone> {
     counter: atomic::AtomicUsize,
     ready_queue: BinaryHeap<ReadyEvent<K>>,
     queued: HashSet<K>,
+    single_stream: Option<(K, Pin<Box<S>>)>,
     streams: HashMap<K, Pin<Box<S>>>,
     waker: Option<Waker>,
     /// Callback invoked when a stream ends (peer disconnected).
@@ -23,14 +24,40 @@ pub(crate) struct QueueInner<S, K: Clone> {
 
 impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     pub fn insert(&mut self, k: K, s: S) {
-        self.streams.insert(k.clone(), Box::pin(s));
-        self.push_ready(k);
+        let stream = Box::pin(s);
+        match self.single_stream.take() {
+            Some((single_key, _single_stream)) if single_key == k => {
+                self.single_stream = Some((k, stream));
+            }
+            Some((single_key, single_stream)) => {
+                // Restore the fair-queue path once a second peer connects so the single-peer fast path does not affect multi-peer polling semantics.
+                self.streams.insert(single_key.clone(), single_stream);
+                self.push_ready(single_key);
+                self.streams.insert(k.clone(), stream);
+                self.push_ready(k);
+            }
+            None if self.streams.is_empty() => {
+                self.single_stream = Some((k, stream));
+            }
+            None => {
+                self.streams.insert(k.clone(), stream);
+                self.push_ready(k);
+            }
+        }
         if let Some(w) = &self.waker {
             w.wake_by_ref();
         }
     }
 
     pub fn remove(&mut self, k: &K) {
+        if self
+            .single_stream
+            .as_ref()
+            .is_some_and(|(single_key, _)| single_key == k)
+        {
+            self.single_stream = None;
+            return;
+        }
         self.streams.remove(k);
         self.queued.remove(k);
     }
@@ -40,6 +67,7 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     /// Used during shutdown to ensure TCP connections are closed even when
     /// other components (like reconnect tasks) hold Arc references to the inner.
     pub fn clear(&mut self) {
+        self.single_stream = None;
         self.streams.clear();
         self.ready_queue.clear();
         self.queued.clear();
@@ -118,6 +146,31 @@ where
     #[allow(clippy::needless_continue)]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let fair_queue = self.get_mut();
+        let disconnected_single = {
+            let mut inner = fair_queue.inner.lock();
+            inner.waker = Some(cx.waker().clone());
+            if let Some((key, stream)) = inner.single_stream.as_mut() {
+                match stream.as_mut().poll_next(cx) {
+                    Poll::Ready(Some(item)) => {
+                        return Poll::Ready(Some((key.clone(), item)));
+                    }
+                    Poll::Ready(None) => {
+                        let key = key.clone();
+                        inner.single_stream = None;
+                        Some((key, inner.on_disconnect.clone()))
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                }
+            } else {
+                None
+            }
+        };
+        if let Some((key, Some(callback))) = disconnected_single {
+            callback(key);
+        }
+
         let mut remaining_ready = {
             let mut inner = fair_queue.inner.lock();
             inner.waker = Some(cx.waker().clone());
@@ -131,13 +184,7 @@ where
                 inner.waker = Some(cx.waker().clone());
                 let event = match inner.ready_queue.pop() {
                     Some(s) => s,
-                    None => {
-                        return if !inner.streams.is_empty() || fair_queue.block_on_no_clients {
-                            Poll::Pending
-                        } else {
-                            Poll::Ready(None)
-                        }
-                    }
+                    None => return queue_empty_poll(&inner, fair_queue.block_on_no_clients),
                 };
                 inner.queued.remove(&event.key);
                 match inner.streams.remove(&event.key) {
@@ -187,17 +234,27 @@ where
         let mut inner = fair_queue.inner.lock();
         inner.waker = Some(cx.waker().clone());
         let should_wake = !inner.ready_queue.is_empty();
-        let result = if !inner.streams.is_empty() || fair_queue.block_on_no_clients {
-            Poll::Pending
-        } else {
-            Poll::Ready(None)
-        };
+        let result = queue_empty_poll(&inner, fair_queue.block_on_no_clients);
         drop(inner);
 
         if should_wake {
             cx.waker().wake_by_ref();
         }
         result
+    }
+}
+
+fn queue_empty_poll<S, K: Clone>(
+    inner: &QueueInner<S, K>,
+    block_on_no_clients: bool,
+) -> Poll<Option<(K, S::Item)>>
+where
+    S: Stream,
+{
+    if inner.single_stream.is_some() || !inner.streams.is_empty() || block_on_no_clients {
+        Poll::Pending
+    } else {
+        Poll::Ready(None)
     }
 }
 
@@ -209,6 +266,7 @@ impl<S, K: Clone> FairQueue<S, K> {
                 counter: atomic::AtomicUsize::new(0),
                 ready_queue: BinaryHeap::new(),
                 queued: HashSet::new(),
+                single_stream: None,
                 streams: HashMap::new(),
                 waker: None,
                 on_disconnect: None,
@@ -239,6 +297,8 @@ mod test {
     use futures::{stream, Stream, StreamExt};
     use std::collections::VecDeque;
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::task::{Context, Poll};
 
     /// Test stream that yields Pending for the first N polls, then emits messages FIFO
@@ -390,6 +450,71 @@ mod test {
                 (1, "a3")
             ]
         );
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_single_stream_fast_path_yields_all_items() {
+        let stream = stream::iter(vec!["a1", "a2", "a3"]);
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            inner.lock().insert(1, stream);
+        }
+
+        let mut results = Vec::new();
+        while let Some(item) = fair_queue.next().await {
+            results.push(item);
+        }
+
+        assert_eq!(results, vec![(1, "a1"), (1, "a2"), (1, "a3")]);
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_promotes_single_stream_when_second_stream_is_inserted() {
+        let first = stream::iter(vec!["a1", "a2"]);
+        let second = stream::iter(vec!["b1", "b2"]);
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(1, first);
+            assert!(lock.single_stream.is_some());
+            assert!(lock.streams.is_empty());
+            assert!(lock.ready_queue.is_empty());
+
+            lock.insert(2, second);
+            assert!(lock.single_stream.is_none());
+            assert_eq!(lock.streams.len(), 2);
+            assert_eq!(lock.ready_queue.len(), 2);
+            assert_eq!(lock.queued.len(), 2);
+        }
+
+        let mut results = Vec::new();
+        while let Some(item) = fair_queue.next().await {
+            results.push(item);
+        }
+
+        assert_eq!(results, vec![(1, "a1"), (2, "b1"), (1, "a2"), (2, "b2")]);
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_single_stream_disconnect_invokes_callback() {
+        let stream = stream::iter(vec!["a1"]);
+        let disconnect_count = Arc::new(AtomicUsize::new(0));
+        let disconnect_count_for_callback = disconnect_count.clone();
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        fair_queue.set_on_disconnect(move |peer_id| {
+            assert_eq!(peer_id, 1);
+            disconnect_count_for_callback.fetch_add(1, Ordering::Relaxed);
+        });
+        {
+            let inner = fair_queue.inner();
+            inner.lock().insert(1, stream);
+        }
+
+        assert_eq!(fair_queue.next().await, Some((1, "a1")));
+        assert_eq!(fair_queue.next().await, None);
+        assert_eq!(disconnect_count.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -548,6 +673,10 @@ mod test {
             lock.insert(
                 "pending",
                 UnifiedStream::WakePending(WakePendingStream { poll_count: 0 }),
+            );
+            lock.insert(
+                "other",
+                UnifiedStream::CountPending(CountPendingStream { poll_count: 0 }),
             );
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod sub_backend;
 mod task_handle;
 mod transport;
 pub mod util;
+mod write_queue;
 mod xpub;
 mod xsub;
 
@@ -238,6 +239,17 @@ pub trait SocketRecv {
 
 #[async_trait]
 pub trait SocketSend {
+    /// Sends one message according to the socket type's send policy.
+    ///
+    /// For sockets backed by an internal writer queue, such as PUSH, DEALER,
+    /// and ROUTER, `Ok(())` means the message has entered the local per-peer
+    /// queue. It does not mean the message has been flushed to the transport,
+    /// received by the peer, or processed by the peer.
+    ///
+    /// PUB sockets have weaker completion semantics: `Ok(())` means the
+    /// message has entered the local fanout path, or was dropped by PUB's
+    /// normal drop policy when the local fanout queue or subscriber queue is
+    /// full.
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()>;
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -19,6 +19,12 @@ pub struct ZmqMessage {
 }
 
 impl ZmqMessage {
+    pub(crate) fn from_decoded_single_frame(frame: Bytes) -> Self {
+        let mut frames = VecDeque::with_capacity(2);
+        frames.push_back(frame);
+        Self { frames }
+    }
+
     pub fn push_back(&mut self, frame: Bytes) {
         self.frames.push_back(frame);
     }
@@ -97,9 +103,9 @@ impl From<Vec<u8>> for ZmqMessage {
 
 impl From<Bytes> for ZmqMessage {
     fn from(b: Bytes) -> Self {
-        Self {
-            frames: vec![b].into(),
-        }
+        let mut frames = VecDeque::with_capacity(1);
+        frames.push_back(b);
+        Self { frames }
     }
 }
 

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -4,33 +4,148 @@ use crate::error::ZmqResult;
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
+use crate::write_queue::write_message_queue;
 use crate::{async_rt, CaptureSocket, SocketOptions};
 use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, SocketType};
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use crossbeam_queue::ArrayQueue;
 use futures::channel::{mpsc, oneshot};
-use futures::lock::Mutex as AsyncMutex;
-use futures::{select, FutureExt, SinkExt, StreamExt};
+use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+
+const PUB_SEND_QUEUE_CAPACITY: usize = 100_000;
+type PubSendQueue = mpsc::Sender<Message>;
+
+fn subscription_matches(subscriptions: &[Vec<u8>], first_frame: &Bytes) -> bool {
+    subscriptions.iter().any(|sub_filter| {
+        sub_filter.len() <= first_frame.len()
+            && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
+    })
+}
+
+async fn send_to_subscriber(
+    backend: &PubSocketBackend,
+    peer_id: PeerIdentity,
+    mut send_queue: PubSendQueue,
+    message: &ZmqMessage,
+) -> ZmqResult<()> {
+    let message = Message::Message(message.clone());
+    let result = match send_queue.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_full() => {
+            // PUB drops messages for slow subscribers so one full queue does not backpressure all publishers.
+            drop(error.into_inner());
+            Ok(())
+        }
+        Err(error) => Err(error.into_send_error()),
+    };
+    if result.is_err() {
+        // Sending to a disconnected subscriber is equivalent to dropping the message and pruning the stale link.
+        // One stale subscriber must not interrupt fanout of the current message to other subscribers.
+        backend.peer_disconnected(&peer_id);
+    }
+
+    Ok(())
+}
 
 pub(crate) struct Subscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) send_queue: PubSendQueue,
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
 pub(crate) struct PubSocketBackend {
     subscribers: scc::HashMap<PeerIdentity, Subscriber>,
+    subscriber_count: AtomicUsize,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
 }
 
+struct PubFanoutQueue {
+    queue: Arc<ArrayQueue<ZmqMessage>>,
+    wake_sender: mpsc::UnboundedSender<()>,
+    wake_pending: Arc<AtomicBool>,
+}
+
+impl PubFanoutQueue {
+    fn publish(&self, message: ZmqMessage) -> ZmqResult<()> {
+        if self.queue.push(message).is_err() {
+            return Ok(());
+        }
+
+        if !self.wake_pending.load(Ordering::Acquire)
+            && !self.wake_pending.swap(true, Ordering::AcqRel)
+        {
+            let _ = self.wake_sender.unbounded_send(());
+        }
+
+        Ok(())
+    }
+}
+
+fn spawn_pub_fanout_queue(backend: Arc<PubSocketBackend>) -> PubFanoutQueue {
+    let queue = Arc::new(ArrayQueue::new(PUB_SEND_QUEUE_CAPACITY));
+    let wake_pending = Arc::new(AtomicBool::new(false));
+    let (wake_sender, mut wake_receiver) = mpsc::unbounded();
+    let worker_queue = queue.clone();
+    let worker_pending = wake_pending.clone();
+
+    async_rt::task::spawn(async move {
+        while wake_receiver.next().await.is_some() {
+            loop {
+                while let Some(message) = worker_queue.pop() {
+                    if let Err(error) = backend.fanout_message(message).await {
+                        log::error!("Error publishing fanout message: {:?}", error);
+                    }
+                }
+
+                worker_pending.store(false, Ordering::Release);
+                if worker_queue.is_empty() {
+                    break;
+                }
+
+                // New messages arrived between draining and sleeping, so this task keeps ownership of the batch.
+                worker_pending.store(true, Ordering::Release);
+            }
+        }
+    });
+
+    PubFanoutQueue {
+        queue,
+        wake_sender,
+        wake_pending,
+    }
+}
+
 impl PubSocketBackend {
+    async fn fanout_message(&self, message: ZmqMessage) -> ZmqResult<()> {
+        let first_frame = match message.get(0) {
+            Some(frame) => frame,
+            None => return Ok(()),
+        };
+
+        let mut targets = Vec::new();
+        let mut iter = self.subscribers.begin_async().await;
+        while let Some(subscriber) = iter {
+            if subscription_matches(&subscriber.subscriptions, first_frame) {
+                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
+            }
+            iter = subscriber.next_async().await;
+        }
+
+        for (peer_id, send_queue) in targets {
+            send_to_subscriber(self, peer_id, send_queue, &message).await?;
+        }
+
+        Ok(())
+    }
+
     fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
         let data = match message {
             Message::Message(m) => {
@@ -82,6 +197,7 @@ impl SocketBackend for PubSocketBackend {
 
     fn shutdown(&self) {
         self.subscribers.clear_sync();
+        self.subscriber_count.store(0, Ordering::Relaxed);
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -94,17 +210,23 @@ impl MultiPeerBackend for PubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (mut recv_queue, send_queue) = io.into_parts();
         // TODO provide handling for recv_queue
+        let (queue_sender, queue_receiver) = mpsc::channel(PUB_SEND_QUEUE_CAPACITY);
         let (sender, stop_receiver) = oneshot::channel();
-        self.subscribers
+        let old_subscriber = self
+            .subscribers
             .upsert_async(
                 peer_id.clone(),
                 Subscriber {
                     subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                    send_queue: queue_sender,
                     _subscription_coro_stop: sender,
                 },
             )
             .await;
+        if old_subscriber.is_none() {
+            self.subscriber_count.fetch_add(1, Ordering::Relaxed);
+        }
+        async_rt::task::spawn(write_message_queue(queue_receiver, send_queue));
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -139,12 +261,15 @@ impl MultiPeerBackend for PubSocketBackend {
         if let Some(monitor) = self.monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
         }
-        self.subscribers.remove_sync(peer_id);
+        if self.subscribers.remove_sync(peer_id).is_some() {
+            self.subscriber_count.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 }
 
 pub struct PubSocket {
     pub(crate) backend: Arc<PubSocketBackend>,
+    fanout_queue: PubFanoutQueue,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -157,49 +282,27 @@ impl Drop for PubSocket {
 #[async_trait]
 impl SocketSend for PubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
-        let first_frame = match message.get(0) {
-            Some(frame) => frame,
-            None => return Ok(()), // Empty message, nothing to publish
-        };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
+        PubSocket::send(self, message).await
+    }
+}
+
+impl PubSocket {
+    /// Enqueues one message into the local fanout path for current subscribers.
+    ///
+    /// `Ok(())` does not mean the message has been written to the transport or
+    /// received by a subscriber. When the fanout queue is full, PUB drops the
+    /// message according to its slow-consumer policy and still returns
+    /// `Ok(())`.
+    pub async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        if message.get(0).is_none() {
+            return Ok(());
         }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
+        if self.backend.subscriber_count.load(Ordering::Relaxed) == 0 {
+            return Ok(());
         }
-        for peer in dead_peers {
-            self.backend.peer_disconnected(&peer);
-        }
-        Ok(())
+
+        self.fanout_queue.publish(message)
     }
 }
 
@@ -208,12 +311,17 @@ impl CaptureSocket for PubSocket {}
 #[async_trait]
 impl Socket for PubSocket {
     fn with_options(options: SocketOptions) -> Self {
+        let backend = Arc::new(PubSocketBackend {
+            subscribers: scc::HashMap::new(),
+            subscriber_count: AtomicUsize::new(0),
+            socket_monitor: Mutex::new(None),
+            socket_options: options,
+        });
+        let fanout_queue = spawn_pub_fanout_queue(backend.clone());
+
         Self {
-            backend: Arc::new(PubSocketBackend {
-                subscribers: scc::HashMap::new(),
-                socket_monitor: Mutex::new(None),
-                socket_options: options,
-            }),
+            backend,
+            fanout_queue,
             binds: HashMap::new(),
         }
     }
@@ -241,6 +349,301 @@ mod tests {
     };
     use crate::ZmqResult;
     use std::net::IpAddr;
+
+    fn test_backend() -> PubSocketBackend {
+        PubSocketBackend {
+            subscribers: scc::HashMap::new(),
+            subscriber_count: AtomicUsize::new(0),
+            socket_monitor: Mutex::new(None),
+            socket_options: SocketOptions::default(),
+        }
+    }
+
+    async fn insert_test_subscriber(
+        backend: &PubSocketBackend,
+        peer_id: PeerIdentity,
+        subscriptions: Vec<Vec<u8>>,
+        queue_sender: PubSendQueue,
+    ) {
+        let (stop_sender, _stop_receiver) = oneshot::channel();
+        let old_subscriber = backend
+            .subscribers
+            .upsert_async(
+                peer_id,
+                Subscriber {
+                    subscriptions,
+                    send_queue: queue_sender,
+                    _subscription_coro_stop: stop_sender,
+                },
+            )
+            .await;
+        if old_subscriber.is_none() {
+            backend.subscriber_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn test_fanout_queue(capacity: usize) -> (PubFanoutQueue, mpsc::UnboundedReceiver<()>) {
+        let (wake_sender, wake_receiver) = mpsc::unbounded();
+        let fanout_queue = PubFanoutQueue {
+            queue: Arc::new(ArrayQueue::new(capacity)),
+            wake_sender,
+            wake_pending: Arc::new(AtomicBool::new(false)),
+        };
+        (fanout_queue, wake_receiver)
+    }
+
+    fn queued_frame(message: ZmqMessage) -> Bytes {
+        message.get(0).expect("queued frame").clone()
+    }
+
+    #[test]
+    fn test_fanout_queue_drops_new_message_when_full_without_extra_wake() {
+        let (fanout_queue, mut wake_receiver) = test_fanout_queue(1);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"first")))
+            .expect("publish first message");
+
+        assert_eq!(fanout_queue.queue.len(), 1);
+        assert!(fanout_queue.wake_pending.load(Ordering::Relaxed));
+        wake_receiver.try_recv().expect("first wake");
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"dropped")))
+            .expect("publish dropped message");
+
+        assert_eq!(fanout_queue.queue.len(), 1);
+        assert!(wake_receiver.try_recv().is_err());
+        assert_eq!(
+            queued_frame(fanout_queue.queue.pop().expect("queued message")),
+            Bytes::from_static(b"first")
+        );
+    }
+
+    #[test]
+    fn test_fanout_queue_wakes_again_after_pending_is_cleared() {
+        let (fanout_queue, mut wake_receiver) = test_fanout_queue(2);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"first")))
+            .expect("publish first message");
+        wake_receiver.try_recv().expect("first wake");
+        assert!(fanout_queue.queue.pop().is_some());
+
+        // Simulate the worker releasing pending after draining the current batch; the next publish must wake it again.
+        fanout_queue.wake_pending.store(false, Ordering::Release);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"second")))
+            .expect("publish second message");
+
+        wake_receiver.try_recv().expect("second wake");
+        assert_eq!(
+            queued_frame(fanout_queue.queue.pop().expect("queued message")),
+            Bytes::from_static(b"second")
+        );
+    }
+
+    #[async_rt::test]
+    async fn test_send_without_subscribers_does_not_enqueue_fanout_message() {
+        let mut socket = PubSocket::new();
+
+        socket
+            .send(ZmqMessage::from("dropped without subscribers"))
+            .await
+            .expect("send without subscribers");
+
+        assert!(socket.fanout_queue.queue.is_empty());
+    }
+
+    #[async_rt::test]
+    async fn test_replacing_subscriber_does_not_increment_subscriber_count() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (first_sender, _first_receiver) = mpsc::channel(8);
+        let (second_sender, _second_receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(&backend, peer_id.clone(), vec![vec![]], first_sender).await;
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![b"topic".to_vec()],
+            second_sender,
+        )
+        .await;
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.subscribers.len(), 1);
+    }
+
+    #[async_rt::test]
+    async fn test_shutdown_clears_subscriber_count() {
+        let backend = test_backend();
+        let (sender, _receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(&backend, PeerIdentity::new(), vec![vec![]], sender).await;
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+
+        backend.shutdown();
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 0);
+        assert!(backend.subscribers.is_empty());
+    }
+
+    #[async_rt::test]
+    async fn test_fanout_message_delivers_only_matching_subscribers() {
+        let backend = test_backend();
+        let matching_peer = PeerIdentity::new();
+        let non_matching_peer = PeerIdentity::new();
+        let (matching_sender, mut matching_receiver) = mpsc::channel(8);
+        let (non_matching_sender, mut non_matching_receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(
+            &backend,
+            matching_peer,
+            vec![b"topic.a".to_vec()],
+            matching_sender,
+        )
+        .await;
+        insert_test_subscriber(
+            &backend,
+            non_matching_peer,
+            vec![b"topic.b".to_vec()],
+            non_matching_sender,
+        )
+        .await;
+
+        backend
+            .fanout_message(ZmqMessage::from(Bytes::from_static(b"topic.a payload")))
+            .await
+            .expect("fanout message");
+
+        let matched = matching_receiver.try_recv().expect("matching subscriber");
+        let Message::Message(matched) = matched else {
+            panic!("unexpected queued message type");
+        };
+        assert_eq!(
+            matched.get(0),
+            Some(&Bytes::from_static(b"topic.a payload"))
+        );
+        assert!(non_matching_receiver.try_recv().is_err());
+    }
+
+    #[async_rt::test]
+    async fn test_disconnected_subscriber_is_dropped_without_send_error() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (queue_sender, queue_receiver) = mpsc::channel(1);
+        drop(queue_receiver);
+
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![vec![]],
+            queue_sender.clone(),
+        )
+        .await;
+
+        let result = send_to_subscriber(
+            &backend,
+            peer_id.clone(),
+            queue_sender,
+            &ZmqMessage::from("payload"),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(backend.subscribers.get_sync(&peer_id).is_none());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[async_rt::test]
+    async fn test_stale_subscriber_does_not_interrupt_fanout_to_matching_peer() {
+        let backend = test_backend();
+        let stale_peer = PeerIdentity::new();
+        let live_peer = PeerIdentity::new();
+        let (stale_sender, stale_receiver) = mpsc::channel(1);
+        let (live_sender, mut live_receiver) = mpsc::channel(8);
+        drop(stale_receiver);
+
+        insert_test_subscriber(&backend, stale_peer.clone(), vec![vec![]], stale_sender).await;
+        insert_test_subscriber(&backend, live_peer.clone(), vec![vec![]], live_sender).await;
+
+        backend
+            .fanout_message(ZmqMessage::from(Bytes::from_static(b"payload")))
+            .await
+            .expect("fanout with stale subscriber");
+
+        let queued = live_receiver.try_recv().expect("live subscriber message");
+        let Message::Message(message) = queued else {
+            panic!("unexpected queued message type");
+        };
+        assert_eq!(message.get(0), Some(&Bytes::from_static(b"payload")));
+
+        assert!(backend.subscribers.get_sync(&stale_peer).is_none());
+        assert!(backend.subscribers.get_sync(&live_peer).is_some());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[async_rt::test]
+    async fn test_full_subscriber_queue_drops_message_without_disconnect() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (mut queue_sender, mut queue_receiver) = mpsc::channel(1);
+
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![vec![]],
+            queue_sender.clone(),
+        )
+        .await;
+
+        let mut prefilled_count = 0;
+        loop {
+            let message = Message::Message(ZmqMessage::from(format!(
+                "already queued {prefilled_count}"
+            )));
+            match queue_sender.try_send(message) {
+                Ok(()) => prefilled_count += 1,
+                Err(error) if error.is_full() => {
+                    drop(error.into_inner());
+                    break;
+                }
+                Err(error) => panic!("unexpected queue prefill error: {error:?}"),
+            }
+        }
+        assert!(prefilled_count > 0);
+
+        let result = send_to_subscriber(
+            &backend,
+            peer_id.clone(),
+            queue_sender,
+            &ZmqMessage::from("dropped payload"),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(backend.subscribers.get_sync(&peer_id).is_some());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+
+        let mut queued_messages = Vec::new();
+        while let Ok(queued) = queue_receiver.try_recv() {
+            let Message::Message(message) = queued else {
+                panic!("unexpected queued message type");
+            };
+            queued_messages.push(String::try_from(message).unwrap());
+        }
+
+        assert_eq!(queued_messages.len(), prefilled_count);
+        assert!(queued_messages
+            .iter()
+            .all(|message| message.starts_with("already queued ")));
+        assert!(!queued_messages
+            .iter()
+            .any(|message| message == "dropped payload"));
+    }
 
     #[async_rt::test]
     async fn test_bind_to_any_port() -> ZmqResult<()> {

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,7 +11,7 @@ use crate::{Socket, SocketBackend};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -105,13 +105,9 @@ impl SocketSend for RouterSocket {
             ));
         }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
-        match self.backend.peers.get_async(&peer_id).await {
-            Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
-                Ok(())
-            }
-            None => Err(ZmqError::Other("Destination client not found by identity")),
-        }
+        self.backend
+            .send_to_peer(&peer_id, Message::Message(message))
+            .await
     }
 }
 
@@ -180,13 +176,10 @@ impl SocketSend for RouterSendHalf {
             ));
         }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
-        match self.inner.backend.peers.get_async(&peer_id).await {
-            Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
-                Ok(())
-            }
-            None => Err(ZmqError::Other("Destination client not found by identity")),
-        }
+        self.inner
+            .backend
+            .send_to_peer(&peer_id, Message::Message(message))
+            .await
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
-use crate::codec::{CodecResult, FramedIo};
+use crate::codec::{CodecResult, FramedIo, ZmqFramedRead};
 use crate::*;
 
-use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use rand::Rng;
@@ -100,7 +99,7 @@ impl From<PeerIdentity> for Vec<u8> {
 pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>,
-    pub(crate) recv_queue: FramedRead<Box<dyn FrameableRead>, ZmqCodec>,
+    pub(crate) recv_queue: ZmqFramedRead,
 }
 
 /// Given the result of the greetings exchange, determines the version of the

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -1,0 +1,112 @@
+use crate::codec::{Message, ZmqFramedWrite};
+
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+
+const WRITE_BATCH_LIMIT: usize = 128;
+
+/// Writes queued socket messages into the underlying framed sink in small batches.
+pub(crate) async fn write_message_queue(
+    mut queue_receiver: mpsc::Receiver<Message>,
+    mut send_queue: ZmqFramedWrite,
+) {
+    while let Some(message) = queue_receiver.next().await {
+        // When backlog already exists, feed a batch before flushing once to avoid per-message flush cost during bursts.
+        if send_queue.feed(message).await.is_err() {
+            break;
+        }
+
+        for _ in 1..WRITE_BATCH_LIMIT {
+            let message = match queue_receiver.try_recv() {
+                Ok(message) => message,
+                Err(_) => break,
+            };
+            if send_queue.feed(message).await.is_err() {
+                return;
+            }
+        }
+
+        if send_queue.flush().await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::ZmqCodec;
+    use crate::ZmqMessage;
+
+    use bytes::Bytes;
+    use futures::{AsyncWrite, SinkExt};
+    use parking_lot::Mutex;
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    #[derive(Default)]
+    struct WriteStats {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    struct RecordingWrite {
+        stats: Arc<Mutex<WriteStats>>,
+    }
+
+    impl AsyncWrite for RecordingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let mut stats = self.stats.lock();
+            stats.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.stats.lock().flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[crate::async_rt::test]
+    async fn test_write_message_queue_batches_ready_messages_into_one_flush() {
+        let (mut sender, receiver) = mpsc::channel(8);
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"a"))))
+            .await
+            .expect("send first message");
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"b"))))
+            .await
+            .expect("send second message");
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"c"))))
+            .await
+            .expect("send third message");
+        drop(sender);
+
+        let stats = Arc::new(Mutex::new(WriteStats::default()));
+        let writer = RecordingWrite {
+            stats: Arc::clone(&stats),
+        };
+        let send_queue = ZmqFramedWrite::new(Box::new(writer), ZmqCodec::new());
+
+        write_message_queue(receiver, send_queue).await;
+
+        let stats = stats.lock();
+        assert_eq!(1, stats.flushes);
+        assert_eq!(
+            stats.bytes,
+            vec![0x00, 0x01, b'a', 0x00, 0x01, b'b', 0x00, 0x01, b'c']
+        );
+    }
+}

--- a/tests/compliance/mod.rs
+++ b/tests/compliance/mod.rs
@@ -1,4 +1,10 @@
 use std::convert::TryInto;
+use std::panic;
+use std::thread;
+use std::time::Duration;
+
+use futures::channel::oneshot;
+use zeromq::__async_rt as async_rt;
 
 /// NOTE: This will block. Careful when using in async code.
 #[allow(dead_code)]
@@ -33,4 +39,47 @@ pub fn setup_monitor(
         .connect(monitor_endpoint)
         .expect("Failed to connect monitor");
     their_monitor
+}
+
+#[allow(dead_code)]
+pub async fn join_thread<T>(
+    handle: thread::JoinHandle<T>,
+    timeout: Duration,
+    label: &'static str,
+) -> T
+where
+    T: Send + 'static,
+{
+    let (sender, receiver) = oneshot::channel();
+    thread::spawn(move || {
+        let _ = sender.send(handle.join());
+    });
+
+    let joined = async_rt::task::timeout(timeout, receiver)
+        .await
+        .unwrap_or_else(|_| panic!("{label}: thread join timed out"))
+        .unwrap_or_else(|_| panic!("{label}: join relay dropped"));
+
+    match joined {
+        Ok(value) => value,
+        Err(payload) => panic::resume_unwind(payload),
+    }
+}
+
+#[allow(dead_code)]
+pub async fn recv_string_on_thread(
+    socket: zmq2::Socket,
+    timeout: Duration,
+    label: &'static str,
+) -> (zmq2::Socket, String) {
+    let handle = thread::spawn(move || {
+        let received = socket.recv_string(0);
+        (socket, received)
+    });
+    let (socket, received) = join_thread(handle, timeout, label).await;
+    let message = received
+        .unwrap_or_else(|error| panic!("{label}: failed to recv: {error}"))
+        .unwrap_or_else(|bytes| panic!("{label}: invalid UTF-8: {bytes:?}"));
+
+    (socket, message)
 }

--- a/tests/pub_sub_compliant_reverse.rs
+++ b/tests/pub_sub_compliant_reverse.rs
@@ -3,6 +3,7 @@
 //! Tests that our zmq.rs PUB socket correctly broadcasts to libzmq SUB sockets.
 
 mod compliance;
+use compliance::join_thread;
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -85,12 +86,10 @@ mod test {
                 our_pub.send(msg).await.expect("Failed to send");
             }
 
-            // Wait a bit for messages to propagate, then verify
-            async_rt::task::sleep(Duration::from_millis(500)).await;
-
             // Join all subscriber threads and verify they received messages
             for handle in sub_handles {
-                let (idx, received) = handle.join().expect("Sub thread panicked");
+                let (idx, received) =
+                    join_thread(handle, Duration::from_secs(5), "subscriber receiver").await;
                 // Each sub should receive at least some messages (slow joiner may miss early ones)
                 assert!(!received.is_empty(), "Sub {} received no messages", idx);
                 println!("Sub {} received {} messages", idx, received.len());
@@ -195,9 +194,11 @@ mod test {
         }
 
         // Wait and check results
-        let topic1_msgs = topic1_handle.join().expect("topic1 thread panicked");
-        let topic2_msgs = topic2_handle.join().expect("topic2 thread panicked");
-        let all_msgs = all_handle.join().expect("all thread panicked");
+        let topic1_msgs =
+            join_thread(topic1_handle, Duration::from_secs(3), "topic1 receiver").await;
+        let topic2_msgs =
+            join_thread(topic2_handle, Duration::from_secs(3), "topic2 receiver").await;
+        let all_msgs = join_thread(all_handle, Duration::from_secs(3), "all receiver").await;
 
         assert_eq!(
             topic1_msgs,

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -4,7 +4,7 @@
 //! after the peer restarts.
 
 mod compliance;
-use compliance::setup_monitor;
+use compliance::{recv_string_on_thread, setup_monitor};
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -201,10 +201,8 @@ mod test {
             .await
             .expect("Failed to send");
 
-        let msg = their_sub
-            .recv_string(0)
-            .expect("Failed to recv")
-            .expect("Invalid UTF8");
+        let (their_sub, msg) =
+            recv_string_on_thread(their_sub, Duration::from_secs(5), "initial SUB recv").await;
         assert_eq!(msg, "initial-message");
         println!("Phase 2: Initial communication verified");
 
@@ -273,10 +271,12 @@ mod test {
             .await
             .expect("Failed to send");
 
-        let msg = their_sub_fresh
-            .recv_string(0)
-            .expect("Failed to recv with fresh SUB - our PUB may have a bug")
-            .expect("Invalid UTF8");
+        let (_their_sub_fresh, msg) = recv_string_on_thread(
+            their_sub_fresh,
+            Duration::from_secs(5),
+            "fresh SUB recv after PUB restart",
+        )
+        .await;
         assert_eq!(msg, "reconnected-message");
         println!("Phase 6: Fresh SUB received message!");
 

--- a/tests/router_dealer_compliant.rs
+++ b/tests/router_dealer_compliant.rs
@@ -3,7 +3,7 @@
 //! Tests identity-based routing between zmq.rs and libzmq implementations.
 
 mod compliance;
-use compliance::{get_monitor_event, setup_monitor};
+use compliance::{get_monitor_event, join_thread, setup_monitor};
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -58,6 +58,9 @@ mod test {
         let ctx = zmq2::Context::new();
         let identity = b"dealer-identity-1";
         let (their_dealer, _their_monitor) = setup_their_dealer(&ctx, &bind_endpoint, identity);
+        their_dealer
+            .set_rcvtimeo(3000)
+            .expect("Failed to set dealer recv timeout");
 
         // Allow connection and handshake to complete
         async_rt::task::sleep(Duration::from_millis(200)).await;
@@ -98,7 +101,7 @@ mod test {
             our_router.send(reply).await.expect("Failed to send");
         }
 
-        dealer_handle.join().expect("Dealer thread panicked");
+        join_thread(dealer_handle, Duration::from_secs(5), "dealer thread").await;
     }
 
     // =========================================================================
@@ -207,6 +210,9 @@ mod test {
                 .set_identity(identity.as_bytes())
                 .expect("Failed to set identity");
             their_dealer
+                .set_rcvtimeo(3000)
+                .expect("Failed to set dealer recv timeout");
+            their_dealer
                 .connect(&bind_endpoint)
                 .expect("Failed to connect");
 
@@ -244,7 +250,7 @@ mod test {
         }
 
         for handle in dealer_handles {
-            handle.join().expect("Dealer thread panicked");
+            join_thread(handle, Duration::from_secs(5), "dealer thread").await;
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR moves socket writes out of the foreground `send()` path and into bounded writer queues, then batches ready writes before flushing. The main goal is to reduce peer-backed send cost without changing the public socket API.

Main changes:

- add a shared batched writer queue helper for framed socket writes
- add per-peer writer queues and a single-peer sender fast path in the generic backend
- route ROUTER sends through the shared backend send helper
- move PUB fanout behind a local fanout queue with per-subscriber writer queues
- keep PUB publishing non-blocking for slow subscribers by dropping on full fanout or subscriber queues
- add codec, framed-read, and fair-queue hot-path improvements
- expand benchmarks so send admission, delivered latency, and batch throughput are measured separately

## Review guide

Suggested review order:

1. `src/write_queue.rs`: shared batching behavior and flush boundary.
2. `src/backend.rs` and `src/router.rs`: generic peer send path, single-peer cache, and ROUTER reuse of the backend helper.
3. `src/pub.rs`: PUB fanout queue, subscriber writer queues, and drop behavior for slow subscribers.
4. `src/codec/*`, `src/fair_queue.rs`, and `src/message.rs`: smaller hot-path changes.
5. `benches/*` and `docs/BENCHMARKS.md`: benchmark coverage and result interpretation.

The highest-risk semantic change is PUB send completion. The other socket send paths still preserve local queue backpressure.

## Behavior notes

`PubSocket::send().await` is intentionally lighter after this change. It now means the message was accepted into the local PUB fanout path, or dropped according to PUB policy. It is not a delivery or transport-flush barrier.

For non-PUB peer-backed sockets, `send().await` still preserves queue backpressure. The foreground path accepts the message into the local per-peer writer queue, and the background writer task performs framed I/O in queue order.

For each peer writer queue, accepted messages are still fed to the framed sink in queue order. Batching changes flush granularity, not per-peer ordering for messages that were accepted into the queue.

## Benchmark scope

The benchmark suite now separates three different questions:

- send-admission cost: how quickly `send()` accepts a message into the local socket path
- delivered latency: how long until a peer observes a single message
- batch throughput: sustained pipeline throughput under batched sends

These are local macOS arm64 measurements. They are meant to show direction and order of magnitude; network benchmarks are scheduler-sensitive.

## Send-admission benchmarks

### 256B before/after socket-send cost

The main result is native improvement: peer-backed 256B send-admission costs moved from microseconds to sub-microsecond values. PUB fanout no longer scales linearly in the foreground `send()` path.

The libzmq columns are included as baseline context. The before and after libzmq values come from the corresponding local runs, so the most reliable reading is the native before/after improvement and the order-of-magnitude gap reduction.

| workload | before native | after native | native improvement | before gap vs libzmq | after gap vs libzmq | before libzmq | after libzmq |
|---|---:|---:|---:|---:|---:|---:|---:|
| PUB, 0 sub | 218.4 ns | 98.245 ns | 2.22x faster | 1.19x slower | 1.00x | 183.9 ns | 98.135 ns |
| PUB, 1 sub | 6,428.8 ns | 181.95 ns | 35.33x faster | 19.45x slower | 1.62x slower | 330.6 ns | 112.30 ns |
| PUB, 4 subs | 26,034.2 ns | 192.87 ns | 134.98x faster | 20.03x slower | 1.74x slower | 1,299.9 ns | 110.76 ns |
| PUSH/PULL | 4,286.3 ns | 382.21 ns | 11.21x faster | 24.75x slower | 1.28x slower | 173.2 ns | 297.85 ns |
| DEALER/ROUTER | 5,026.2 ns | 391.27 ns | 12.85x faster | 14.06x slower | 1.42x slower | 357.4 ns | 275.91 ns |

Native send-admission improvement summary:

- PUB with 1 subscriber: 35.33x faster, reducing the libzmq gap from 19.45x slower to 1.62x slower
- PUB with 4 subscribers: 134.98x faster, reducing the libzmq gap from 20.03x slower to 1.74x slower
- PUSH/PULL: 11.21x faster, reducing the libzmq gap from 24.75x slower to 1.28x slower
- DEALER/ROUTER: 12.85x faster, reducing the libzmq gap from 14.06x slower to 1.42x slower

### Final send-only hot-path subset

This later targeted subset checks the remaining small-message gaps after the low-risk optimization pass.

| workload | size | after native | after libzmq | after native vs libzmq |
|---|---:|---:|---:|---:|
| PUSH/PULL | 64B | 330.23 ns | 142.28 ns | 2.32x slower |
| DEALER/ROUTER | 64B | 263.30 ns | 221.21 ns | 1.19x slower |
| PUSH/PULL | 256B | 337.52 ns | 273.13 ns | 1.24x slower |
| DEALER/ROUTER | 256B | 329.48 ns | 282.37 ns | 1.17x slower |

## Delivered-latency benchmarks

Delivered-latency benches require a peer to observe the message. These are separate from send-admission numbers because they include scheduling, transport, blocking peer threads for libzmq, and receive-path costs.

| workload | size | after native | after libzmq | native latency speedup vs libzmq |
|---|---:|---:|---:|---:|
| PUB fanout, 1 sub | 256B | 28.735 us | 85.851 us | 2.99x faster |
| PUB fanout, 4 subs | 256B | 50.790 us | 93.061 us | 1.83x faster |
| PUSH/PULL | 256B | 25.037 us | 46.459 us | 1.86x faster |
| DEALER/ROUTER | 256B | 50.520 us | 93.545 us | 1.85x faster |

## Batch-throughput benchmarks

### DEALER/ROUTER throughput matrix

The key before/after point is `DEALER/ROUTER tcp 256B`: it changed from `9.2927 ms / 26.903 MiB/s` before this optimization to `793.25 us / 315.16 MiB/s` in a later TCP smoke run, which is an 11.71x throughput improvement and an 11.72x elapsed-time improvement.

The broader matrix below is from the current diff throughput run with both TCP and IPC transports.

| transport | size | after zmqrs | after libzmq | native elapsed-time vs libzmq |
|---|---:|---:|---:|---:|
| TCP | 256B | 987.77 us / 253.10 MiB/s | 1.4158 ms / 176.57 MiB/s | 1.43x faster |
| TCP | 4096B | 2.7516 ms / 1.4196 GiB/s | 12.891 ms / 310.28 MiB/s | 4.68x faster |
| IPC | 256B | 854.24 us / 292.66 MiB/s | 893.87 us / 279.68 MiB/s | 1.05x faster |
| IPC | 4096B | 6.5765 ms / 608.22 MiB/s | 4.7475 ms / 842.54 MiB/s | 1.39x slower |

### PUB fanout throughput matrix

| transport | subscribers | size | after zmqrs | after libzmq | native elapsed-time vs libzmq |
|---|---:|---:|---:|---:|---:|
| TCP | 1 | 256B | 691.90 us / 361.32 MiB/s | 794.34 us / 314.73 MiB/s | 1.15x faster |
| TCP | 1 | 4096B | 1.6093 ms / 2.4273 GiB/s | 7.3610 ms / 543.40 MiB/s | 4.57x faster |
| TCP | 8 | 256B | 4.6646 ms / 428.76 MiB/s | 7.4259 ms / 269.33 MiB/s | 1.59x faster |
| TCP | 8 | 4096B | 10.323 ms / 3.0272 GiB/s | 85.612 ms / 373.78 MiB/s | 8.29x faster |
| TCP | 64 | 256B | 25.219 ms / 634.44 MiB/s | 40.971 ms / 390.52 MiB/s | 1.62x faster |
| TCP | 64 | 4096B | 76.861 ms / 3.2526 GiB/s | 465.15 ms / 550.36 MiB/s | 6.05x faster |
| IPC | 1 | 256B | 719.04 us / 347.68 MiB/s | 586.99 us / 425.90 MiB/s | 1.23x slower |
| IPC | 1 | 4096B | 2.5156 ms / 1.5528 GiB/s | 2.2850 ms / 1.7095 GiB/s | 1.10x slower |
| IPC | 8 | 256B | 3.2114 ms / 622.78 MiB/s | 3.8267 ms / 522.64 MiB/s | 1.19x faster |
| IPC | 8 | 4096B | 14.183 ms / 2.2034 GiB/s | 45.666 ms / 700.74 MiB/s | 3.22x faster |
| IPC | 64 | 256B | 21.826 ms / 733.06 MiB/s | 34.027 ms / 470.22 MiB/s | 1.56x faster |
| IPC | 64 | 4096B | 95.115 ms / 2.6284 GiB/s | 355.58 ms / 719.95 MiB/s | 3.74x faster |

### TCP-only smoke after all retained changes

This shorter smoke run confirms the final retained diff still has the expected TCP direction after the benchmark-only cleanup and boundary decisions.

| workload | after zmqrs | after libzmq | native elapsed-time speedup vs libzmq |
|---|---:|---:|---:|
| PUB TCP 1 sub 256B | 512.29 us / 488.00 MiB/s | 831.75 us / 300.57 MiB/s | 1.62x faster |
| PUB TCP 1 sub 4096B | 1.6960 ms / 2.3032 GiB/s | 7.6618 ms / 522.07 MiB/s | 4.52x faster |
| PUB TCP 8 subs 256B | 3.6284 ms / 551.21 MiB/s | 6.6879 ms / 299.05 MiB/s | 1.84x faster |
| PUB TCP 8 subs 4096B | 8.3504 ms / 3.7423 GiB/s | 67.880 ms / 471.42 MiB/s | 8.13x faster |
| PUB TCP 64 subs 256B | 23.728 ms / 674.31 MiB/s | 52.403 ms / 305.33 MiB/s | 2.21x faster |
| PUB TCP 64 subs 4096B | 65.829 ms / 3.7977 GiB/s | 483.92 ms / 529.01 MiB/s | 7.35x faster |
| DEALER/ROUTER TCP 256B | 793.25 us / 315.16 MiB/s | 2.0009 ms / 124.94 MiB/s | 2.52x faster |
| DEALER/ROUTER TCP 4096B | 2.6511 ms / 1.4735 GiB/s | 20.655 ms / 193.65 MiB/s | 7.79x faster |
| DEALER/ROUTER one-way TCP 256B | 574.31 us / 435.30 MiB/s | 612.67 us / 408.05 MiB/s | 1.07x faster |
| DEALER/ROUTER one-way TCP 4096B | 1.6105 ms / 2.4255 GiB/s | 4.5604 ms / 877.12 MiB/s | 2.83x faster |
| PUSH/PULL one-way TCP 256B | 411.52 us / 607.50 MiB/s | 568.16 us / 440.02 MiB/s | 1.38x faster |
| PUSH/PULL one-way TCP 4096B | 2.2909 ms / 1.7051 GiB/s | 4.7813 ms / 836.59 MiB/s | 2.09x faster |

## Codec microbenchmarks

Codec is not the main small-message peer-send bottleneck, but the retained codec changes still reduce fixed costs in targeted cases.

| workload | result |
|---|---:|
| `codec/encode/frames=1/256` | 67.799 ns, about 7.58% faster |
| `codec/encode/frames=2/4096` | 197.10 ns, about 6.82% faster |
| `codec/decode/frames=1/4096` | 228.94 ns -> 218.86 ns, about 1.05x faster |

## Known limits

- `PUSH/PULL` 64B send-admission is still slower than libzmq, although it is now sub-microsecond. Chasing that further likely needs a message representation or low-allocation send API change.
- IPC large-payload throughput still has a remaining gap in some cases. This PR keeps the low-risk read and fair-queue improvements, but does not try to fully redesign the IPC path.
- `compare_libzmq` has a known IPC `REQ/REP` multi-case teardown issue in the current benchmark harness. TCP-only harness checks can be run with `ZMQRS_BENCH_TRANSPORTS=tcp`.

## Validation

Recorded local validation for this diff:

- `cargo fmt --check`
- `git diff --check`
- `cargo bench --bench hotpath --no-run`
- `cargo bench --bench throughput --no-run`
- `cargo bench --bench compare_libzmq --no-run`
- `cargo bench --bench hotpath -- --test`
- `ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench throughput -- --test`
- `ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench compare_libzmq -- --test`
- `cargo test`
- `cargo test --no-run`
- `cargo clippy --all-targets -- -D warnings`

The clippy run still prints existing renamed/removed lint warnings, but exits successfully.