### PR TITLE
Add hotpath benchmark coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,3 +70,7 @@ harness = false
 [[bench]]
 name = "throughput"
 harness = false
+
+[[bench]]
+name = "hotpath"
+harness = false

--- a/benches/bench_runtime.rs
+++ b/benches/bench_runtime.rs
@@ -3,14 +3,19 @@ use std::time::Duration;
 
 use criterion::{measurement::WallTime, BenchmarkGroup};
 
+#[allow(dead_code)]
+pub const DEFAULT_TRANSPORTS: &[&str] = &["tcp", "ipc"];
+
 #[cfg(feature = "tokio-runtime")]
 use tokio::runtime::{Builder, Runtime};
 
+#[allow(dead_code)]
 pub struct BenchRuntime {
     #[cfg(feature = "tokio-runtime")]
     inner: Runtime,
 }
 
+#[allow(dead_code)]
 impl BenchRuntime {
     pub fn new() -> Self {
         #[cfg(feature = "tokio-runtime")]
@@ -69,6 +74,33 @@ pub fn configure_group(group: &mut BenchmarkGroup<'_, WallTime>) {
         "ZMQRS_BENCH_WARMUP_MS",
         2_000,
     )));
+}
+
+#[allow(dead_code)]
+pub fn selected_transports(supported: &'static [&'static str]) -> Vec<&'static str> {
+    let Some(filter) = std::env::var("ZMQRS_BENCH_TRANSPORTS")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+    else {
+        return supported.to_vec();
+    };
+
+    let selected: Vec<_> = supported
+        .iter()
+        .copied()
+        .filter(|transport| {
+            filter
+                .split(',')
+                .any(|candidate| candidate.trim() == *transport)
+        })
+        .collect();
+
+    assert!(
+        !selected.is_empty(),
+        "ZMQRS_BENCH_TRANSPORTS must include at least one of: {}",
+        supported.join(",")
+    );
+    selected
 }
 
 fn env_usize(name: &str, default: usize) -> usize {

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -1,5 +1,7 @@
 //! Pure codec microbenchmarks: no sockets, no I/O.
 
+mod bench_runtime;
+
 use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Bytes, BytesMut};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
@@ -22,6 +24,7 @@ fn build_message(frame_count: usize, frame_size: usize) -> ZmqMessage {
 
 fn bench_encode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/encode");
+    bench_runtime::configure_group(&mut group);
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);
@@ -48,6 +51,7 @@ fn bench_encode(c: &mut Criterion) {
 
 fn bench_decode(c: &mut Criterion) {
     let mut group = c.benchmark_group("codec/decode");
+    bench_runtime::configure_group(&mut group);
     for &frames in MULTIPART_FRAME_COUNTS {
         for &size in FRAME_SIZES {
             let m = build_message(frames, size);

--- a/benches/compare_libzmq.rs
+++ b/benches/compare_libzmq.rs
@@ -8,12 +8,13 @@
 mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::future;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use zeromq::{
     __async_rt::task, prelude::*, DealerSocket, PubSocket, PullSocket, PushSocket, RepSocket,
@@ -22,7 +23,12 @@ use zeromq::{
 
 const MSG_SIZES: &[usize] = &[16, 256, 4096, 65536];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
-const TRANSPORTS: &[&str] = &["tcp", "ipc"];
+const HOTPATH_MSG_SIZES: &[usize] = &[64, 256, 1024];
+const HOTPATH_PUB_SUB_COUNTS: &[usize] = &[0, 1, 4];
+const HOTPATH_DELIVERED_PUB_SUB_COUNTS: &[usize] = &[1, 4];
+const HOTPATH_ZMQ2_HWM: i32 = 100_000;
+
+type NativeJoinHandle = task::JoinHandle<()>;
 
 static IPC_SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -43,8 +49,759 @@ fn build_rt() -> BenchRuntime {
     BenchRuntime::new()
 }
 
+async fn drain_zmqrs_pub_sync_messages(subs: &mut [SubSocket]) {
+    for sub in subs {
+        loop {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                }
+                Ok(Err(error)) => panic!("zmqrs pub sync drain recv: {error:?}"),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+async fn sync_zmqrs_pub_subscribers(
+    pub_sock: &mut PubSocket,
+    mut subs: Vec<SubSocket>,
+) -> Vec<SubSocket> {
+    let sync = ZmqMessage::from(vec![0xFF]);
+    let mut ready = Vec::with_capacity(subs.len());
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !subs.is_empty() {
+        if Instant::now() > deadline {
+            panic!("zmqrs pub/sub sync timed out");
+        }
+        pub_sock.send(sync.clone()).await.expect("zmqrs pub sync");
+        let mut waiting = Vec::new();
+        for mut sub in subs.drain(..) {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                    ready.push(sub);
+                }
+                Ok(Err(error)) => panic!("zmqrs sub sync recv: {error:?}"),
+                Err(_) => waiting.push(sub),
+            }
+        }
+        subs = waiting;
+    }
+
+    // Subscribers that are already ready may receive later sync frames during subscription propagation; drain before timing.
+    drain_zmqrs_pub_sync_messages(&mut ready).await;
+    ready
+}
+
+fn hotpath_payload(size: usize, byte: u8) -> Bytes {
+    Bytes::from(vec![byte; size])
+}
+
+fn hotpath_native_endpoint() -> &'static str {
+    "tcp://127.0.0.1:0"
+}
+
+fn stop_native_drains(rt: &BenchRuntime, stop: Arc<AtomicBool>, handles: Vec<NativeJoinHandle>) {
+    stop.store(true, Ordering::Relaxed);
+    rt.block_on(async {
+        for handle in handles {
+            let _ = handle.await;
+        }
+    });
+}
+
+fn configure_libzmq_socket(socket: &zmq2::Socket) {
+    socket.set_linger(0).expect("linger");
+    socket.set_sndhwm(HOTPATH_ZMQ2_HWM).expect("sndhwm");
+    socket.set_rcvhwm(HOTPATH_ZMQ2_HWM).expect("rcvhwm");
+}
+
+fn libzmq_send_retry(socket: &zmq2::Socket, payload: &[u8]) {
+    loop {
+        match socket.send(payload, zmq2::DONTWAIT) {
+            Ok(()) => return,
+            Err(zmq2::Error::EAGAIN) => std::hint::spin_loop(),
+            Err(e) => panic!("libzmq send: {e:?}"),
+        }
+    }
+}
+
+fn join_libzmq_drains(stop: Arc<AtomicBool>, threads: Vec<thread::JoinHandle<()>>) {
+    stop.store(true, Ordering::Relaxed);
+    for thread in threads {
+        thread.join().expect("drain thread");
+    }
+}
+
+fn sync_libzmq_pub_subscribers(pub_sock: &zmq2::Socket, subs: &[zmq2::Socket]) {
+    let sync_payload = [0xFFu8];
+    let mut ready = vec![false; subs.len()];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+        pub_sock
+            .send(&sync_payload[..], 0)
+            .expect("libzmq pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                match sub.recv_bytes(zmq2::DONTWAIT) {
+                    Ok(message) => {
+                        black_box(message);
+                        ready[index] = true;
+                    }
+                    Err(zmq2::Error::EAGAIN) => {}
+                    Err(error) => panic!("libzmq sub sync recv: {error:?}"),
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    loop {
+        let mut drained_any = false;
+        for sub in subs {
+            loop {
+                match sub.recv_bytes(zmq2::DONTWAIT) {
+                    Ok(message) => {
+                        black_box(message);
+                        drained_any = true;
+                    }
+                    Err(zmq2::Error::EAGAIN) => break,
+                    Err(error) => panic!("libzmq sub sync drain recv: {error:?}"),
+                }
+            }
+        }
+        if !drained_any {
+            break;
+        }
+    }
+}
+
+fn sync_libzmq_pub_drain_threads(pub_sock: &zmq2::Socket, counters: &[Arc<AtomicUsize>]) {
+    let sync_payload = [0xFFu8];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while counters
+        .iter()
+        .any(|counter| counter.load(Ordering::Relaxed) == 0)
+    {
+        if Instant::now() > deadline {
+            panic!("libzmq pub drain thread sync timed out");
+        }
+        pub_sock
+            .send(&sync_payload[..], 0)
+            .expect("libzmq pub drain sync");
+        thread::sleep(Duration::from_millis(1));
+    }
+
+    let mut previous: usize = counters
+        .iter()
+        .map(|counter| counter.load(Ordering::Relaxed))
+        .sum();
+    loop {
+        thread::sleep(Duration::from_millis(2));
+        let current: usize = counters
+            .iter()
+            .map(|counter| counter.load(Ordering::Relaxed))
+            .sum();
+        if current == previous {
+            break;
+        }
+        previous = current;
+    }
+}
+
+fn bench_native_socket_send(c: &mut Criterion) {
+    let rt = build_rt();
+
+    for &n_subs in HOTPATH_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!("hotpath/native_socket_send/pub/subs={n_subs}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes(msg_size as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_native_pub_send_one(b, &rt, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/native_socket_send/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_push_send_one(b, &rt, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/native_socket_send/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_dealer_send_one(b, &rt, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_native_pub_send_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    n_subs: usize,
+    msg_size: usize,
+) {
+    let (mut pub_sock, stop, handles) = rt.block_on(async {
+        let mut p = PubSocket::new();
+        let bound = p
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pub bind")
+            .to_string();
+        let mut subs = Vec::with_capacity(n_subs);
+        for _ in 0..n_subs {
+            let mut sub = SubSocket::new();
+            sub.connect(bound.as_str()).await.expect("sub connect");
+            sub.subscribe("").await.expect("subscribe");
+            subs.push(sub);
+        }
+
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut handles = Vec::with_capacity(n_subs);
+
+        for mut sub in subs {
+            let stop_for_task = stop.clone();
+            handles.push(task::spawn(async move {
+                while !stop_for_task.load(Ordering::Relaxed) {
+                    match task::timeout(Duration::from_millis(20), sub.recv()).await {
+                        Ok(Ok(message)) => {
+                            black_box(message);
+                        }
+                        Ok(Err(_)) => break,
+                        Err(_) => {}
+                    }
+                }
+            }));
+        }
+
+        (p, stop, handles)
+    });
+    let payload = hotpath_payload(msg_size, 0xAB);
+
+    b.iter(|| {
+        rt.block_on(async {
+            pub_sock
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("pub send");
+        });
+    });
+
+    stop_native_drains(rt, stop, handles);
+}
+
+fn bench_native_push_send_one(b: &mut criterion::Bencher<'_>, rt: &BenchRuntime, msg_size: usize) {
+    let (mut push, stop, handle) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pull bind")
+            .to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_task = stop.clone();
+        let handle = task::spawn(async move {
+            while !stop_for_task.load(Ordering::Relaxed) {
+                match task::timeout(Duration::from_millis(20), pull.recv()).await {
+                    Ok(Ok(message)) => {
+                        black_box(message);
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => {}
+                }
+            }
+        });
+        (push, stop, handle)
+    });
+    let payload = hotpath_payload(msg_size, 0xCD);
+
+    b.iter(|| {
+        rt.block_on(async {
+            push.send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("push send");
+        });
+    });
+
+    stop_native_drains(rt, stop, vec![handle]);
+}
+
+fn bench_native_dealer_send_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut dealer, stop, handle) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+
+        let stop = Arc::new(AtomicBool::new(false));
+        let stop_for_task = stop.clone();
+        let handle = task::spawn(async move {
+            while !stop_for_task.load(Ordering::Relaxed) {
+                match task::timeout(Duration::from_millis(20), router.recv()).await {
+                    Ok(Ok(message)) => {
+                        black_box(message);
+                    }
+                    Ok(Err(_)) => break,
+                    Err(_) => {}
+                }
+            }
+        });
+        (dealer, stop, handle)
+    });
+    let payload = hotpath_payload(msg_size, 0xEF);
+
+    b.iter(|| {
+        rt.block_on(async {
+            dealer
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("dealer send");
+        });
+    });
+
+    stop_native_drains(rt, stop, vec![handle]);
+}
+
+fn bench_libzmq_socket_send(c: &mut Criterion) {
+    for &n_subs in HOTPATH_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!("hotpath/libzmq_socket_send/pub/subs={n_subs}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes(msg_size as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_pub_send_one(b, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/libzmq_socket_send/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_push_send_one(b, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/libzmq_socket_send/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_dealer_send_one(b, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_libzmq_pub_send_one(b: &mut criterion::Bencher<'_>, n_subs: usize, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pub_sock = ctx.socket(zmq2::PUB).expect("pub socket");
+    configure_libzmq_socket(&pub_sock);
+    pub_sock.bind(hotpath_native_endpoint()).expect("pub bind");
+    let bound = pub_sock
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let mut threads = Vec::with_capacity(n_subs);
+    let mut counters = Vec::with_capacity(n_subs);
+    for _ in 0..n_subs {
+        let ctx = ctx.clone();
+        let bound = bound.clone();
+        let stop_for_thread = stop.clone();
+        let counter = Arc::new(AtomicUsize::new(0));
+        counters.push(counter.clone());
+        threads.push(thread::spawn(move || {
+            let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+            configure_libzmq_socket(&sub);
+            sub.set_rcvtimeo(20).expect("rcvtimeo");
+            sub.connect(&bound).expect("sub connect");
+            sub.set_subscribe(b"").expect("subscribe");
+            while !stop_for_thread.load(Ordering::Relaxed) {
+                match sub.recv_bytes(0) {
+                    Ok(message) => {
+                        black_box(message);
+                        counter.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(zmq2::Error::EAGAIN) => {}
+                    Err(_) => break,
+                }
+            }
+        }));
+    }
+
+    sync_libzmq_pub_drain_threads(&pub_sock, &counters);
+    let payload = vec![0xAB; msg_size];
+    b.iter(|| libzmq_send_retry(&pub_sock, &payload));
+
+    join_libzmq_drains(stop, threads);
+}
+
+fn bench_libzmq_push_send_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    configure_libzmq_socket(&pull);
+    pull.set_rcvtimeo(20).expect("rcvtimeo");
+    pull.bind(hotpath_native_endpoint()).expect("pull bind");
+    let bound = pull
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_for_thread = stop.clone();
+    let thread = thread::spawn(move || {
+        while !stop_for_thread.load(Ordering::Relaxed) {
+            match pull.recv_bytes(0) {
+                Ok(message) => {
+                    black_box(message);
+                }
+                Err(zmq2::Error::EAGAIN) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    configure_libzmq_socket(&push);
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xCD; msg_size];
+    b.iter(|| libzmq_send_retry(&push, &payload));
+
+    join_libzmq_drains(stop, vec![thread]);
+}
+
+fn bench_libzmq_dealer_send_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    configure_libzmq_socket(&router);
+    router.set_rcvtimeo(20).expect("rcvtimeo");
+    router.bind(hotpath_native_endpoint()).expect("router bind");
+    let bound = router
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_for_thread = stop.clone();
+    let thread = thread::spawn(move || {
+        while !stop_for_thread.load(Ordering::Relaxed) {
+            match router.recv_multipart(0) {
+                Ok(message) => {
+                    black_box(message);
+                }
+                Err(zmq2::Error::EAGAIN) => {}
+                Err(_) => break,
+            }
+        }
+    });
+
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    configure_libzmq_socket(&dealer);
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xEF; msg_size];
+    b.iter(|| libzmq_send_retry(&dealer, &payload));
+
+    join_libzmq_drains(stop, vec![thread]);
+}
+
+fn bench_native_delivered_latency(c: &mut Criterion) {
+    let rt = build_rt();
+
+    for &n_subs in HOTPATH_DELIVERED_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!(
+            "hotpath/native_delivered_latency/pub_fanout/subs={n_subs}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes((msg_size * n_subs) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_native_pub_delivered_one(b, &rt, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/native_delivered_latency/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_push_delivered_one(b, &rt, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/native_delivered_latency/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes((msg_size * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_native_dealer_delivered_one(b, &rt, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_native_pub_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    n_subs: usize,
+    msg_size: usize,
+) {
+    let (mut pub_sock, mut subs) = rt.block_on(async {
+        let mut p = PubSocket::new();
+        let bound = p
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pub bind")
+            .to_string();
+        let mut subs = Vec::with_capacity(n_subs);
+        for _ in 0..n_subs {
+            let mut sub = SubSocket::new();
+            sub.connect(bound.as_str()).await.expect("sub connect");
+            sub.subscribe("").await.expect("subscribe");
+            subs.push(sub);
+        }
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
+        (p, subs)
+    });
+    let payload = hotpath_payload(msg_size, 0xAB);
+
+    b.iter(|| {
+        rt.block_on(async {
+            pub_sock
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("pub send");
+            for sub in &mut subs {
+                let message = task::timeout(Duration::from_secs(1), sub.recv())
+                    .await
+                    .expect("sub timeout")
+                    .expect("sub recv");
+                black_box(message);
+            }
+        });
+    });
+}
+
+fn bench_native_push_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut push, mut pull) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("pull bind")
+            .to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (push, pull)
+    });
+    let payload = hotpath_payload(msg_size, 0xCD);
+
+    b.iter(|| {
+        rt.block_on(async {
+            push.send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("push send");
+            black_box(pull.recv().await.expect("pull recv"));
+        });
+    });
+}
+
+fn bench_native_dealer_delivered_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+) {
+    let (mut dealer, mut router) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(hotpath_native_endpoint())
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (dealer, router)
+    });
+    let payload = hotpath_payload(msg_size, 0xEF);
+
+    b.iter(|| {
+        rt.block_on(async {
+            dealer
+                .send(ZmqMessage::from(payload.clone()))
+                .await
+                .expect("dealer send");
+            let message = router.recv().await.expect("router recv");
+            router.send(message).await.expect("router send");
+            black_box(dealer.recv().await.expect("dealer recv"));
+        });
+    });
+}
+
+fn bench_libzmq_delivered_latency(c: &mut Criterion) {
+    for &n_subs in HOTPATH_DELIVERED_PUB_SUB_COUNTS {
+        let mut group = c.benchmark_group(format!(
+            "hotpath/libzmq_delivered_latency/pub_fanout/subs={n_subs}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in HOTPATH_MSG_SIZES {
+            group.throughput(Throughput::Bytes((msg_size * n_subs) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_pub_delivered_one(b, n_subs, s);
+            });
+        }
+        group.finish();
+    }
+
+    let mut group = c.benchmark_group("hotpath/libzmq_delivered_latency/push_pull");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_push_delivered_one(b, s);
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/libzmq_delivered_latency/dealer_router");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in HOTPATH_MSG_SIZES {
+        group.throughput(Throughput::Bytes((msg_size * 2) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            bench_libzmq_dealer_delivered_one(b, s);
+        });
+    }
+    group.finish();
+}
+
+fn bench_libzmq_pub_delivered_one(b: &mut criterion::Bencher<'_>, n_subs: usize, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pub_sock = ctx.socket(zmq2::PUB).expect("pub socket");
+    configure_libzmq_socket(&pub_sock);
+    pub_sock.bind(hotpath_native_endpoint()).expect("pub bind");
+    let bound = pub_sock
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+
+    let mut subs = Vec::with_capacity(n_subs);
+    for _ in 0..n_subs {
+        let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+        configure_libzmq_socket(&sub);
+        sub.set_rcvtimeo(1000).expect("rcvtimeo");
+        sub.connect(&bound).expect("sub connect");
+        sub.set_subscribe(b"").expect("subscribe");
+        subs.push(sub);
+    }
+
+    sync_libzmq_pub_subscribers(&pub_sock, &subs);
+    let payload = vec![0xAB; msg_size];
+    b.iter(|| {
+        pub_sock.send(&payload, 0).expect("pub send");
+        for sub in &subs {
+            black_box(sub.recv_bytes(0).expect("sub recv"));
+        }
+    });
+}
+
+fn bench_libzmq_push_delivered_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    configure_libzmq_socket(&pull);
+    pull.bind(hotpath_native_endpoint()).expect("pull bind");
+    let bound = pull
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    configure_libzmq_socket(&push);
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xCD; msg_size];
+    b.iter(|| {
+        push.send(&payload, 0).expect("push send");
+        black_box(pull.recv_bytes(0).expect("pull recv"));
+    });
+}
+
+fn bench_libzmq_dealer_delivered_one(b: &mut criterion::Bencher<'_>, msg_size: usize) {
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    configure_libzmq_socket(&router);
+    router.bind(hotpath_native_endpoint()).expect("router bind");
+    let bound = router
+        .get_last_endpoint()
+        .expect("last_endpoint")
+        .expect("bound endpoint");
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    configure_libzmq_socket(&dealer);
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+
+    let payload = vec![0xEF; msg_size];
+    b.iter(|| {
+        dealer.send(&payload, 0).expect("dealer send");
+        let message = router.recv_multipart(0).expect("router recv");
+        router
+            .send_multipart(message, 0)
+            .expect("router echo multipart");
+        black_box(dealer.recv_bytes(0).expect("dealer recv"));
+    });
+}
+
 fn bench_libzmq_pub_sub(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("libzmq/pub_sub/{transport}/subs={n_subs}"));
             bench_runtime::configure_group(&mut group);
@@ -84,7 +841,7 @@ fn bench_libzmq_pub_sub_one(
 
     struct SubHandle {
         tx_drive: mpsc::Sender<()>,
-        rx_done: mpsc::Receiver<Vec<u8>>,
+        rx_done: mpsc::Receiver<Option<Vec<u8>>>,
         _thread: thread::JoinHandle<()>,
     }
 
@@ -96,10 +853,15 @@ fn bench_libzmq_pub_sub_one(
         let (tx_done, rx_done) = mpsc::channel();
         let thread = thread::spawn(move || {
             let sub = ctx.socket(zmq2::SUB).expect("sub socket");
+            sub.set_rcvtimeo(20).expect("sub rcvtimeo");
             sub.connect(&bound).expect("sub connect");
             sub.set_subscribe(b"").expect("subscribe");
             while rx_drive.recv().is_ok() {
-                let got = sub.recv_bytes(0).expect("sub recv");
+                let got = match sub.recv_bytes(0) {
+                    Ok(message) => Some(message),
+                    Err(zmq2::Error::EAGAIN) => None,
+                    Err(error) => panic!("sub recv: {error:?}"),
+                };
                 if tx_done.send(got).is_err() {
                     break;
                 }
@@ -112,7 +874,29 @@ fn bench_libzmq_pub_sub_one(
         });
     }
 
-    thread::sleep(Duration::from_millis(100));
+    let sync_payload = vec![0xFF];
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut ready = vec![false; subs.len()];
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                sub.tx_drive.send(()).expect("drive sync sub");
+            }
+        }
+        pub_sock.send(&sync_payload, 0).expect("libzmq pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                if let Some(message) = sub.rx_done.recv().expect("sync sub done") {
+                    black_box(message);
+                    ready[index] = true;
+                }
+            }
+        }
+    }
+
     let payload = vec![0xAB; msg_size];
     b.iter(|| {
         for sub in &subs {
@@ -120,14 +904,15 @@ fn bench_libzmq_pub_sub_one(
         }
         pub_sock.send(&payload, 0).expect("pub send");
         for sub in &subs {
-            black_box(sub.rx_done.recv().expect("sub done"));
+            let message = sub.rx_done.recv().expect("sub done").expect("sub payload");
+            black_box(message);
         }
     });
 }
 
 fn bench_zmqrs_pub_sub(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!("zmqrs/pub_sub/{transport}/subs={n_subs}"));
             bench_runtime::configure_group(&mut group);
@@ -172,7 +957,7 @@ fn bench_zmqrs_pub_sub_one(
             s.subscribe("").await.expect("subscribe");
             subs.push(s);
         }
-        task::sleep(Duration::from_millis(100)).await;
+        let subs = sync_zmqrs_pub_subscribers(&mut p, subs).await;
         (p, subs)
     });
 
@@ -188,10 +973,14 @@ fn bench_zmqrs_pub_sub_one(
             black_box(future::join_all(recv_futures).await);
         });
     });
+
+    drop(subs);
+    let errors = rt.block_on(pub_sock.close());
+    assert!(errors.is_empty(), "pub close errors: {errors:?}");
 }
 
 fn bench_libzmq_req_rep(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/req_rep/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -242,7 +1031,7 @@ fn bench_libzmq_req_rep_one(b: &mut criterion::Bencher<'_>, msg_size: usize, end
 
 fn bench_zmqrs_req_rep(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/req_rep/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -288,10 +1077,14 @@ fn bench_zmqrs_req_rep_one(
             black_box(req.recv().await.expect("req recv"));
         });
     });
+
+    drop(req);
+    let errors = rt.block_on(rep.close());
+    assert!(errors.is_empty(), "rep close errors: {errors:?}");
 }
 
 fn bench_libzmq_push_pull(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/push_pull/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -325,7 +1118,7 @@ fn bench_libzmq_push_pull_one(b: &mut criterion::Bencher<'_>, msg_size: usize, e
 
 fn bench_zmqrs_push_pull(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/push_pull/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -366,10 +1159,14 @@ fn bench_zmqrs_push_pull_one(
             black_box(pull.recv().await.expect("pull recv"));
         });
     });
+
+    drop(push);
+    let errors = rt.block_on(pull.close());
+    assert!(errors.is_empty(), "pull close errors: {errors:?}");
 }
 
 fn bench_libzmq_dealer_router(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -421,7 +1218,7 @@ fn bench_libzmq_dealer_router_one(b: &mut criterion::Bencher<'_>, msg_size: usiz
 
 fn bench_zmqrs_dealer_router(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in MSG_SIZES {
@@ -465,6 +1262,10 @@ fn bench_zmqrs_dealer_router_one(
             black_box(dealer.recv().await.expect("dealer recv"));
         });
     });
+
+    drop(dealer);
+    let errors = rt.block_on(router.close());
+    assert!(errors.is_empty(), "router close errors: {errors:?}");
 }
 
 criterion_group!(
@@ -477,5 +1278,9 @@ criterion_group!(
     bench_zmqrs_req_rep,
     bench_zmqrs_push_pull,
     bench_zmqrs_dealer_router,
+    bench_native_socket_send,
+    bench_libzmq_socket_send,
+    bench_native_delivered_latency,
+    bench_libzmq_delivered_latency,
 );
 criterion_main!(benches);

--- a/benches/hotpath.rs
+++ b/benches/hotpath.rs
@@ -1,0 +1,232 @@
+//! Internal hot-path cost calibration benchmark.
+
+mod bench_runtime;
+
+use async_trait::async_trait;
+use bench_runtime::BenchRuntime;
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::channel::mpsc;
+use parking_lot::Mutex;
+use std::collections::VecDeque;
+
+use zeromq::{__bench::Message, prelude::*, ZmqMessage, ZmqResult};
+
+const MSG_SIZES: &[usize] = &[64, 256, 1024];
+const BENCH_PEER_SEND_QUEUE_CAPACITY: usize = 100_000;
+
+struct NoopInherentSender;
+
+impl NoopInherentSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        black_box(message);
+        Ok(())
+    }
+}
+
+struct NoopTraitSender;
+
+#[async_trait]
+impl SocketSend for NoopTraitSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        black_box(message);
+        Ok(())
+    }
+}
+
+struct NestedNoopTraitSender;
+
+#[async_trait]
+impl SocketSend for NestedNoopTraitSender {
+    async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        nested_noop_send(message).await?;
+        Ok(())
+    }
+}
+
+async fn nested_noop_send(message: ZmqMessage) -> ZmqResult<()> {
+    black_box(message);
+    Ok(())
+}
+
+fn build_rt() -> BenchRuntime {
+    BenchRuntime::new()
+}
+
+fn payload(size: usize, byte: u8) -> Bytes {
+    Bytes::from(vec![byte; size])
+}
+
+fn bench_message_construct(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/message_construct/from_bytes");
+    bench_runtime::configure_group(&mut group);
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+            let payload = payload(s, 0xA5);
+            b.iter(|| black_box(ZmqMessage::from(payload.clone())));
+        });
+    }
+    group.finish();
+
+    let mut group = c.benchmark_group("hotpath/message_construct/vecdeque_single_frame");
+    bench_runtime::configure_group(&mut group);
+    let payload = payload(64, 0xA5);
+    group.bench_function("with_capacity_push_back", |b| {
+        b.iter(|| {
+            let mut frames = VecDeque::with_capacity(1);
+            frames.push_back(payload.clone());
+            black_box(frames);
+        });
+    });
+    group.bench_function("from_array", |b| {
+        b.iter(|| black_box(VecDeque::from([payload.clone()])));
+    });
+    group.bench_function("vec_into", |b| {
+        b.iter(|| {
+            let frames: VecDeque<Bytes> = vec![payload.clone()].into();
+            black_box(frames);
+        });
+    });
+    group.finish();
+}
+
+fn bench_runtime_overhead(c: &mut Criterion) {
+    let rt = build_rt();
+    let mut group = c.benchmark_group("hotpath/runtime");
+    bench_runtime::configure_group(&mut group);
+    group.bench_function("block_on_noop", |b| {
+        b.iter(|| rt.block_on(async { black_box(()) }));
+    });
+    group.finish();
+}
+
+fn bench_async_send_overhead(c: &mut Criterion) {
+    let rt = build_rt();
+    let mut group = c.benchmark_group("hotpath/async_send_overhead");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("inherent_async", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x71);
+                let mut sender = NoopInherentSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("inherent async send");
+                    });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("async_trait", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x72);
+                let mut sender = NoopTraitSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("async trait send");
+                    });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("async_trait_nested_await", msg_size),
+            &msg_size,
+            |b, &s| {
+                let payload = payload(s, 0x73);
+                let mut sender = NestedNoopTraitSender;
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .send(ZmqMessage::from(payload.clone()))
+                            .await
+                            .expect("nested async trait send");
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_backend_primitives(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/backend_primitives");
+    bench_runtime::configure_group(&mut group);
+
+    group.bench_function("parking_lot_mutex_lock", |b| {
+        let mutex = Mutex::new(());
+        b.iter(|| {
+            let guard = mutex.lock();
+            black_box(&*guard);
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_unit", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(1);
+        b.iter(|| {
+            sender.try_send(()).expect("try_send unit");
+            let _: () = receiver.try_recv().expect("try_recv unit");
+            black_box(());
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_message", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(1);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            sender.try_send(message).expect("try_send message");
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.bench_function("futures_mpsc_try_send_recv_message_cap_100k", |b| {
+        let (mut sender, mut receiver) = mpsc::channel(BENCH_PEER_SEND_QUEUE_CAPACITY);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            sender.try_send(message).expect("try_send message");
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.bench_function("mutex_mpsc_try_send_recv_message", |b| {
+        let (sender, mut receiver) = mpsc::channel(1);
+        let sender = Mutex::new(sender);
+        let payload = payload(64, 0x5A);
+        b.iter(|| {
+            let message = Message::Message(ZmqMessage::from(payload.clone()));
+            {
+                let mut sender = sender.lock();
+                sender.try_send(message).expect("try_send message");
+            }
+            black_box(receiver.try_recv().expect("try_recv message"));
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_backend_primitives,
+    bench_async_send_overhead,
+    bench_runtime_overhead,
+    bench_message_construct,
+);
+criterion_main!(benches);

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -3,22 +3,30 @@
 mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
+use bytes::Bytes;
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use futures::{channel::oneshot, select, FutureExt};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;
 use std::time::Duration;
 
 use zeromq::{
-    __async_rt::task, prelude::*, DealerSocket, PubSocket, RouterSocket, SubSocket, ZmqMessage,
+    __async_rt::task, prelude::*, DealerSocket, PubSocket, PullSocket, PushSocket, RouterSocket,
+    SubSocket, ZmqMessage,
 };
 
 const BATCH_SIZE: usize = 1024;
 const PIPELINE_SIZES: &[usize] = &[256, 4096];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
-const TRANSPORTS: &[&str] = &["tcp", "ipc"];
 
 static IPC_SEQ: AtomicU64 = AtomicU64::new(0);
+
+struct SubHandle {
+    tx_drive: mpsc::Sender<usize>,
+    rx_done: mpsc::Receiver<usize>,
+    _thread: thread::JoinHandle<()>,
+}
 
 fn ipc_path(tag: &str) -> String {
     let n = IPC_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -37,12 +45,73 @@ fn build_rt() -> BenchRuntime {
     BenchRuntime::new()
 }
 
+async fn drain_zmqrs_pub_sync_messages(subs: &mut [SubSocket]) {
+    for sub in subs {
+        loop {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                }
+                Ok(Err(error)) => panic!("sub sync drain recv: {error:?}"),
+                Err(_) => break,
+            }
+        }
+    }
+}
+
+async fn sync_zmqrs_pub_subscribers(
+    pub_sock: &mut PubSocket,
+    mut subs: Vec<SubSocket>,
+) -> Vec<SubSocket> {
+    let sync = ZmqMessage::from(vec![0xFF]);
+    let mut ready = Vec::with_capacity(subs.len());
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    while !subs.is_empty() {
+        if std::time::Instant::now() > deadline {
+            panic!("zmqrs pub/sub sync timed out");
+        }
+        pub_sock.send(sync.clone()).await.expect("pub sync");
+        let mut waiting = Vec::new();
+        for mut sub in subs.drain(..) {
+            match task::timeout(Duration::from_millis(5), sub.recv()).await {
+                Ok(Ok(message)) => {
+                    black_box(message);
+                    ready.push(sub);
+                }
+                Ok(Err(error)) => panic!("sub sync recv: {error:?}"),
+                Err(_) => waiting.push(sub),
+            }
+        }
+        subs = waiting;
+    }
+
+    // Subscribers that are already ready may still receive later sync messages during subscription propagation.
+    // Drain those leftovers before the benchmark so old sync frames are not counted as payload.
+    drain_zmqrs_pub_sync_messages(&mut ready).await;
+    ready
+}
+
+fn drain_libzmq_pub_sync_messages(subs: &[SubHandle]) {
+    loop {
+        let mut drained_any = false;
+        for sub in subs {
+            sub.tx_drive.send(BATCH_SIZE).expect("drive sync drain sub");
+        }
+        for sub in subs {
+            drained_any |= sub.rx_done.recv().expect("sync drain sub done") > 0;
+        }
+        if !drained_any {
+            break;
+        }
+    }
+}
+
 fn bench_zmqrs_pub_pipelined(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!(
-                "zmqrs/throughput/pub_fanout/{transport}/subs={n_subs}"
+                "zmqrs/throughput/pub_fanout/send_pressure/{transport}/subs={n_subs}"
             ));
             bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
@@ -80,29 +149,11 @@ fn bench_zmqrs_pub_pipelined_one(
             subs.push(s);
         }
 
-        let sync = ZmqMessage::from(vec![0xFF]);
-        let mut remaining = subs;
-        let mut ready = Vec::with_capacity(n_subs);
-        let deadline = std::time::Instant::now() + Duration::from_secs(10);
-        while !remaining.is_empty() {
-            if std::time::Instant::now() > deadline {
-                panic!("zmqrs pub/sub sync timed out");
-            }
-            p.send(sync.clone()).await.expect("pub sync");
-            let mut waiting = Vec::new();
-            for mut s in remaining.drain(..) {
-                match task::timeout(Duration::from_millis(5), s.recv()).await {
-                    Ok(Ok(_)) => ready.push(s),
-                    Ok(Err(e)) => panic!("sub sync recv: {e:?}"),
-                    Err(_) => waiting.push(s),
-                }
-            }
-            remaining = waiting;
-        }
+        let ready = sync_zmqrs_pub_subscribers(&mut p, subs).await;
         (p, ready)
     });
 
-    let payload = vec![0xAB; msg_size];
+    let payload = Bytes::from(vec![0xAB; msg_size]);
     b.iter(|| {
         rt.block_on(async {
             let sub_handles: Vec<_> = subs
@@ -136,10 +187,10 @@ fn bench_zmqrs_pub_pipelined_one(
 }
 
 fn bench_libzmq_pub_pipelined(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         for &n_subs in SUB_COUNTS {
             let mut group = c.benchmark_group(format!(
-                "libzmq/throughput/pub_fanout/{transport}/subs={n_subs}"
+                "libzmq/throughput/pub_fanout/send_pressure/{transport}/subs={n_subs}"
             ));
             bench_runtime::configure_group(&mut group);
             for &msg_size in PIPELINE_SIZES {
@@ -176,12 +227,6 @@ fn bench_libzmq_pub_pipelined_one(
         .expect("last_endpoint")
         .unwrap();
 
-    struct SubHandle {
-        tx_drive: mpsc::Sender<usize>,
-        rx_done: mpsc::Receiver<()>,
-        _thread: thread::JoinHandle<()>,
-    }
-
     let mut subs = Vec::with_capacity(n_subs);
     for _ in 0..n_subs {
         let ctx = ctx.clone();
@@ -195,16 +240,18 @@ fn bench_libzmq_pub_pipelined_one(
             sub.connect(&bound).expect("sub connect");
             sub.set_subscribe(b"").expect("subscribe");
             while let Ok(n) = rx_drive.recv() {
+                let mut received = 0;
                 for _ in 0..n {
                     match sub.recv_bytes(0) {
                         Ok(m) => {
                             black_box(m);
+                            received += 1;
                         }
                         Err(zmq2::Error::EAGAIN) => break,
                         Err(e) => panic!("sub recv: {e:?}"),
                     }
                 }
-                if tx_done.send(()).is_err() {
+                if tx_done.send(received).is_err() {
                     break;
                 }
             }
@@ -216,7 +263,28 @@ fn bench_libzmq_pub_pipelined_one(
         });
     }
 
-    thread::sleep(Duration::from_millis(200));
+    let sync_payload = vec![0xFF];
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let mut ready = vec![false; subs.len()];
+    while ready.iter().any(|is_ready| !*is_ready) {
+        if std::time::Instant::now() > deadline {
+            panic!("libzmq pub/sub sync timed out");
+        }
+
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                sub.tx_drive.send(1).expect("drive sync sub");
+            }
+        }
+        pub_sock.send(&sync_payload, 0).expect("pub sync");
+        for (index, sub) in subs.iter().enumerate() {
+            if !ready[index] {
+                ready[index] = sub.rx_done.recv().expect("sync sub done") > 0;
+            }
+        }
+    }
+    drain_libzmq_pub_sync_messages(&subs);
+
     let payload = vec![0xAB; msg_size];
     b.iter(|| {
         for sub in &subs {
@@ -226,14 +294,14 @@ fn bench_libzmq_pub_pipelined_one(
             pub_sock.send(&payload, 0).expect("pub send");
         }
         for sub in &subs {
-            sub.rx_done.recv().expect("sub done");
+            black_box(sub.rx_done.recv().expect("sub done"));
         }
     });
 }
 
 fn bench_zmqrs_dealer_router_pipelined(c: &mut Criterion) {
     let rt = build_rt();
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("zmqrs/throughput/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
@@ -253,52 +321,163 @@ fn bench_zmqrs_dealer_router_one(
     transport: &str,
 ) {
     let endpoint = endpoint(&format!("zmqrs-dr-{msg_size}"), transport);
-    let (dealer_send, dealer_recv, router) = rt.block_on(async {
+    let (mut send, mut recv, router_task, stop_router) = rt.block_on(async {
         let mut r = RouterSocket::new();
         let bound = r.bind(&endpoint).await.expect("router bind").to_string();
         let mut d = DealerSocket::new();
         d.connect(bound.as_str()).await.expect("dealer connect");
         task::sleep(Duration::from_millis(50)).await;
         let (send, recv) = d.split();
-        (send, recv, r)
+
+        let (stop_router, stop_receiver) = oneshot::channel();
+        let router_task = task::spawn(async move {
+            let mut stop_receiver = stop_receiver.fuse();
+            loop {
+                select! {
+                    _ = stop_receiver => break,
+                    message = r.recv().fuse() => {
+                        match message {
+                            Ok(message) => {
+                                if r.send(message).await.is_err() {
+                                    break;
+                                }
+                            }
+                            Err(_) => break,
+                        }
+                    }
+                }
+            }
+            r
+        });
+
+        (send, recv, router_task, stop_router)
     });
-    let mut dealer_send = Some(dealer_send);
-    let mut dealer_recv = Some(dealer_recv);
-    let mut router = Some(router);
-    let payload = vec![0xCD; msg_size];
+    let payload = Bytes::from(vec![0xCD; msg_size]);
 
     b.iter(|| {
-        let mut send = dealer_send.take().unwrap();
-        let mut recv = dealer_recv.take().unwrap();
-        let mut r = router.take().unwrap();
         rt.block_on(async {
-            let router_task = task::spawn(async move {
-                for _ in 0..BATCH_SIZE {
-                    let m = r.recv().await.expect("router recv");
-                    r.send(m).await.expect("router send");
-                }
-                r
-            });
-            let recv_task = task::spawn(async move {
-                for _ in 0..BATCH_SIZE {
-                    black_box(recv.recv().await.expect("dealer recv"));
-                }
-                recv
-            });
             for _ in 0..BATCH_SIZE {
                 send.send(ZmqMessage::from(payload.clone()))
                     .await
                     .expect("dealer send");
             }
-            dealer_recv.replace(recv_task.await.expect("dealer recv task"));
-            router.replace(router_task.await.expect("router task"));
-            dealer_send.replace(send);
+            for _ in 0..BATCH_SIZE {
+                black_box(recv.recv().await.expect("dealer recv"));
+            }
+        });
+    });
+
+    let _ = stop_router.send(());
+    rt.block_on(async {
+        let _ = router_task.await;
+    });
+}
+
+fn bench_zmqrs_dealer_router_one_way(c: &mut Criterion) {
+    let rt = build_rt();
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group = c.benchmark_group(format!(
+            "zmqrs/throughput/dealer_router_one_way/{transport}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_zmqrs_dealer_router_one_way_one(b, &rt, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_zmqrs_dealer_router_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-dr-one-way-{msg_size}"), transport);
+    let (mut router, mut send) = rt.block_on(async {
+        let mut router = RouterSocket::new();
+        let bound = router
+            .bind(&endpoint)
+            .await
+            .expect("router bind")
+            .to_string();
+        let mut dealer = DealerSocket::new();
+        dealer
+            .connect(bound.as_str())
+            .await
+            .expect("dealer connect");
+        task::sleep(Duration::from_millis(50)).await;
+        let (send, _recv) = dealer.split();
+        (router, send)
+    });
+    let payload = Bytes::from(vec![0xCD; msg_size]);
+
+    b.iter(|| {
+        rt.block_on(async {
+            for _ in 0..BATCH_SIZE {
+                send.send(ZmqMessage::from(payload.clone()))
+                    .await
+                    .expect("dealer send");
+            }
+            for _ in 0..BATCH_SIZE {
+                black_box(router.recv().await.expect("router recv"));
+            }
+        });
+    });
+}
+
+fn bench_zmqrs_push_pull_one_way(c: &mut Criterion) {
+    let rt = build_rt();
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group =
+            c.benchmark_group(format!("zmqrs/throughput/push_pull_one_way/{transport}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_zmqrs_push_pull_one_way_one(b, &rt, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_zmqrs_push_pull_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-pp-one-way-{msg_size}"), transport);
+    let (mut pull, mut push) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull.bind(&endpoint).await.expect("pull bind").to_string();
+        let mut push = PushSocket::new();
+        push.connect(bound.as_str()).await.expect("push connect");
+        task::sleep(Duration::from_millis(50)).await;
+        (pull, push)
+    });
+    let payload = Bytes::from(vec![0xEF; msg_size]);
+
+    b.iter(|| {
+        rt.block_on(async {
+            for _ in 0..BATCH_SIZE {
+                push.send(ZmqMessage::from(payload.clone()))
+                    .await
+                    .expect("push send");
+            }
+            for _ in 0..BATCH_SIZE {
+                black_box(pull.recv().await.expect("pull recv"));
+            }
         });
     });
 }
 
 fn bench_libzmq_dealer_router_pipelined(c: &mut Criterion) {
-    for &transport in TRANSPORTS {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
         let mut group = c.benchmark_group(format!("libzmq/throughput/dealer_router/{transport}"));
         bench_runtime::configure_group(&mut group);
         for &msg_size in PIPELINE_SIZES {
@@ -362,11 +541,106 @@ fn bench_libzmq_dealer_router_one(
     thread.join().ok();
 }
 
+fn bench_libzmq_dealer_router_one_way(c: &mut Criterion) {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group = c.benchmark_group(format!(
+            "libzmq/throughput/dealer_router_one_way/{transport}"
+        ));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_dealer_router_one_way_one(b, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_libzmq_dealer_router_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-dr-one-way-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let router = ctx.socket(zmq2::ROUTER).expect("router socket");
+    let hwm = (BATCH_SIZE * 4) as i32;
+    router.set_rcvhwm(hwm).expect("router rcvhwm");
+    router.set_rcvtimeo(100).expect("router timeout");
+    router.bind(&endpoint).expect("router bind");
+    let bound = router.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    let dealer = ctx.socket(zmq2::DEALER).expect("dealer socket");
+    dealer.set_sndhwm(hwm).expect("dealer sndhwm");
+    dealer.connect(&bound).expect("dealer connect");
+    thread::sleep(Duration::from_millis(50));
+    let payload = vec![0xCD; msg_size];
+
+    b.iter(|| {
+        for _ in 0..BATCH_SIZE {
+            dealer.send(&payload, 0).expect("dealer send");
+        }
+        for _ in 0..BATCH_SIZE {
+            black_box(router.recv_multipart(0).expect("router recv"));
+        }
+    });
+}
+
+fn bench_libzmq_push_pull_one_way(c: &mut Criterion) {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        let mut group =
+            c.benchmark_group(format!("libzmq/throughput/push_pull_one_way/{transport}"));
+        bench_runtime::configure_group(&mut group);
+        for &msg_size in PIPELINE_SIZES {
+            group.throughput(Throughput::Bytes((BATCH_SIZE * msg_size) as u64));
+            group.bench_with_input(BenchmarkId::from_parameter(msg_size), &msg_size, |b, &s| {
+                bench_libzmq_push_pull_one_way_one(b, s, transport);
+            });
+        }
+        group.finish();
+    }
+}
+
+fn bench_libzmq_push_pull_one_way_one(
+    b: &mut criterion::Bencher<'_>,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-pp-one-way-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    let hwm = (BATCH_SIZE * 4) as i32;
+    pull.set_rcvhwm(hwm).expect("pull rcvhwm");
+    pull.set_rcvtimeo(100).expect("pull timeout");
+    pull.bind(&endpoint).expect("pull bind");
+    let bound = pull.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    let push = ctx.socket(zmq2::PUSH).expect("push socket");
+    push.set_sndhwm(hwm).expect("push sndhwm");
+    push.connect(&bound).expect("push connect");
+    thread::sleep(Duration::from_millis(50));
+    let payload = vec![0xEF; msg_size];
+
+    b.iter(|| {
+        for _ in 0..BATCH_SIZE {
+            push.send(&payload, 0).expect("push send");
+        }
+        for _ in 0..BATCH_SIZE {
+            black_box(pull.recv_bytes(0).expect("pull recv"));
+        }
+    });
+}
+
 criterion_group!(
     benches,
     bench_zmqrs_pub_pipelined,
     bench_zmqrs_dealer_router_pipelined,
+    bench_zmqrs_dealer_router_one_way,
+    bench_zmqrs_push_pull_one_way,
     bench_libzmq_pub_pipelined,
     bench_libzmq_dealer_router_pipelined,
+    bench_libzmq_dealer_router_one_way,
+    bench_libzmq_push_pull_one_way,
 );
 criterion_main!(benches);

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,6 +3,8 @@
 Criterion benches live in [`benches/`](../benches/). This branch carries a
 master-compatible subset of the newer benchmark suite so local results can be
 compared against the performance branch without pulling in branch-only APIs.
+Where useful, the suite includes side-by-side `libzmq` baselines through the
+`zmq2` dev dependency.
 
 ## Performance Suite
 
@@ -58,16 +60,116 @@ cargo bench --bench throughput -- --sample-size 10
 
 Results land under `target/criterion/`.
 
-## Bench Shape
+Socket and codec benchmarks share these optional environment controls:
+
+- `ZMQRS_BENCH_SAMPLE_SIZE`, default `10`
+- `ZMQRS_BENCH_MEASUREMENT_MS`, default `10000`
+- `ZMQRS_BENCH_WARMUP_MS`, default `2000`
+- `ZMQRS_BENCH_TRANSPORTS`, optional comma-separated transport filter for
+  `throughput` and `compare_libzmq`; supported values are `tcp` and `ipc`.
+  Invalid values fail fast instead of silently skipping transport cases.
+
+For TCP-only smoke checks, use:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench throughput -- --test
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench compare_libzmq -- --test
+```
+
+## Bench Targets
 
 The master-compatible set includes:
 
-- `codec`: encode/decode microbenchmarks through the hidden `zeromq::__bench`
-  export.
-- `compare_libzmq`: latency-style PUB/SUB, REQ/REP, PUSH/PULL, and
-  DEALER/ROUTER cases, side-by-side with libzmq through `zmq2`.
-- `throughput`: batched PUB fanout and DEALER/ROUTER throughput cases.
+- `codec`: pure ZMTP codec encode/decode microbenchmarks through the hidden
+  `zeromq::__bench` export. These do not create sockets or perform network I/O.
+  The encode benchmark includes `ZmqMessage` cloning and destination buffer
+  construction; decode includes greeting decode and input buffer construction.
+- `compare_libzmq`: one-message latency-style PUB/SUB, REQ/REP, PUSH/PULL, and
+  DEALER/ROUTER cases over TCP and IPC, side-by-side with libzmq through
+  `zmq2`. It also hosts the native/libzmq socket-send and delivered-latency
+  groups so comparison code stays in one bench target.
+- `throughput`: batched pipeline throughput for PUB/SUB fanout and
+  DEALER/ROUTER, plus one-way DEALER/ROUTER and PUSH/PULL receive-path
+  isolation. Existing `pub_fanout/send_pressure` numbers are send-pressure
+  oriented: receiver timeout paths may stop early, so those numbers must not be
+  read as strict delivered throughput unless the benchmark name explicitly says
+  so.
+- `hotpath`: focused internal hot-path experiments. The diagnostic groups
+  `message_construct`, `runtime`, `backend_primitives`, and
+  `async_send_overhead` are calibration aids for interpreting send-only gaps.
 
 The suite intentionally excludes branch-only sockets, security builders,
 engine internals, and `inproc` transport. libzmq peers run on OS threads;
 `zeromq` peers run on a fixed 2-worker Tokio runtime.
+
+## Reading Results
+
+Sender-side hot-path groups measure local send admission only. A successful
+`send().await` on an optimized queued path is not a transport flush or delivery
+acknowledgement.
+
+Delivered-latency benchmarks require a receiver to observe the message. They
+include runtime scheduling, blocking peer threads, transport behavior, and
+receive-path overhead.
+
+Throughput benchmarks measure a sustained batch. They are the right tool for
+checking whether batching, writer queue design, and receive-path changes improve
+real pipeline behavior.
+
+Criterion throughput is computed from the bytes declared by each benchmark:
+
+- One-way send or receive benchmarks use `msg_size`.
+- Fanout delivered benchmarks use `msg_size * subscriber_count`.
+- Roundtrip DEALER/ROUTER delivered benchmarks use `2 * msg_size`.
+- Some historical one-message comparison groups keep the older request-payload
+  convention and use `msg_size` even when a reply is sent. Compare those groups
+  by latency first, not by aggregate MiB/s.
+
+Do not use a single benchmark family as the whole performance truth. The current
+suite intentionally keeps sender hot path, delivered latency, and batch
+throughput separate because they answer different questions.
+
+## Known Limits
+
+- `compare_libzmq` has a known IPC `REQ/REP` multi-case teardown issue in the
+  current benchmark harness. A single case such as
+  `zmqrs/req_rep/ipc/16 --test` exits normally, while the broader
+  `zmqrs/req_rep/ipc --test` filter can print all success lines and still not
+  exit. Use `ZMQRS_BENCH_TRANSPORTS=tcp` for full harness smoke checks when IPC
+  is not the target of the run.
+
+## Useful Commands
+
+Smoke compile:
+
+```sh
+cargo bench --no-run
+```
+
+Short hot-path socket-send run:
+
+```sh
+ZMQRS_BENCH_SAMPLE_SIZE=10 ZMQRS_BENCH_MEASUREMENT_MS=200 ZMQRS_BENCH_WARMUP_MS=50 \
+  cargo bench --bench compare_libzmq hotpath/native_socket_send/pub/subs=1/64
+```
+
+Longer native versus libzmq socket-send comparison:
+
+```sh
+ZMQRS_BENCH_SAMPLE_SIZE=20 ZMQRS_BENCH_MEASUREMENT_MS=3000 ZMQRS_BENCH_WARMUP_MS=1000 \
+  cargo bench --bench compare_libzmq hotpath/.+_socket_send
+```
+
+TCP-only throughput smoke:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp ZMQRS_BENCH_SAMPLE_SIZE=10 \
+ZMQRS_BENCH_MEASUREMENT_MS=300 ZMQRS_BENCH_WARMUP_MS=100 \
+  cargo bench --bench throughput
+```
+
+Full TCP-only benchmark harness check without running measurements:
+
+```sh
+ZMQRS_BENCH_TRANSPORTS=tcp cargo bench --bench compare_libzmq -- --test
+```


### PR DESCRIPTION
## Summary

This splits the benchmark-only part out of #267 so it can be reviewed independently.

Changes:

- add a `hotpath` benchmark target for send-admission and delivered-latency comparisons
- add environment-based transport filtering for `throughput` and `compare_libzmq`
- extend benchmark documentation with benchmark families, result interpretation, and useful smoke commands
- keep the documentation limited to behavior that is true on current `master`; queued-send semantics will be documented in the later production PRs

## Validation

- `cargo fmt --check`
- `cargo bench --no-run`

## Follow-up

This PR is intentionally benchmark/documentation only. Production changes for queued sends, batching, PUB fanout, framed read, and FairQueue are split into separate PRs.