### PR TITLE
Increase framed read chunk size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,10 @@ name = "codec"
 harness = false
 
 [[bench]]
+name = "framed_read"
+harness = false
+
+[[bench]]
 name = "compare_libzmq"
 harness = false
 

--- a/benches/framed_read.rs
+++ b/benches/framed_read.rs
@@ -1,0 +1,116 @@
+//! Framed-read microbenchmarks for receive-path chunk sizing.
+
+#[allow(dead_code)]
+mod bench_runtime;
+
+use asynchronous_codec::{Encoder, FramedRead};
+use bytes::{Bytes, BytesMut};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use futures::{executor::block_on, io::Cursor, Stream, StreamExt};
+
+use zeromq::{
+    __bench::{zmq_framed_read, Message, ZmqCodec, ZmqFramedRead},
+    ZmqMessage,
+};
+
+const FRAME_SIZES: &[usize] = &[256, 4096, 65536];
+const MESSAGE_COUNTS: &[usize] = &[1, 1024];
+
+const GREETING_STUB: [u8; 64] = {
+    let mut greeting = [0; 64];
+    greeting[0] = 0xff;
+    greeting[9] = 0x7f;
+    greeting[10] = 3;
+    greeting[11] = 1;
+    greeting[12] = b'N';
+    greeting[13] = b'U';
+    greeting[14] = b'L';
+    greeting[15] = b'L';
+    greeting
+};
+
+fn encoded_stream(message_count: usize, frame_size: usize) -> Vec<u8> {
+    let mut stream = BytesMut::new();
+    stream.extend_from_slice(&GREETING_STUB);
+
+    let payload = Bytes::from(vec![0xAB; frame_size]);
+    let message = Message::Message(ZmqMessage::from(payload));
+    let mut codec = ZmqCodec::new();
+
+    for _ in 0..message_count {
+        codec
+            .encode(message.clone(), &mut stream)
+            .expect("encode framed-read input");
+    }
+
+    stream.to_vec()
+}
+
+async fn drain_stream<S, E>(mut stream: S) -> usize
+where
+    S: Stream<Item = Result<Message, E>> + Unpin,
+    E: std::fmt::Debug,
+{
+    let mut messages = 0;
+
+    while let Some(item) = stream.next().await {
+        if matches!(item.expect("decode framed-read input"), Message::Message(_)) {
+            messages += 1;
+        }
+    }
+
+    messages
+}
+
+fn bench_framed_read(c: &mut Criterion) {
+    let mut group = c.benchmark_group("framed_read/drain");
+    bench_runtime::configure_group(&mut group);
+
+    for &message_count in MESSAGE_COUNTS {
+        for &frame_size in FRAME_SIZES {
+            group.throughput(criterion::Throughput::Bytes(
+                (message_count * frame_size) as u64,
+            ));
+
+            let input = encoded_stream(message_count, frame_size);
+            group.bench_with_input(
+                BenchmarkId::new(format!("default/messages={message_count}"), frame_size),
+                &input,
+                |b, input| {
+                    b.iter_batched(
+                        || Cursor::new(input.clone()),
+                        |cursor| {
+                            let reader = FramedRead::new(cursor, ZmqCodec::new());
+                            let messages = block_on(drain_stream(reader));
+                            assert_eq!(messages, message_count);
+                            black_box(messages);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new(format!("adaptive/messages={message_count}"), frame_size),
+                &input,
+                |b, input| {
+                    b.iter_batched(
+                        || Cursor::new(input.clone()),
+                        |cursor| {
+                            let reader: ZmqFramedRead = zmq_framed_read(cursor);
+                            let messages = block_on(drain_stream(reader));
+                            assert_eq!(messages, message_count);
+                            black_box(messages);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_framed_read);
+criterion_main!(benches);

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -1,7 +1,15 @@
 use crate::codec::ZmqCodec;
 
-use asynchronous_codec::{FramedRead, FramedWrite};
-use futures::{AsyncRead, AsyncWrite};
+use super::error::{CodecError, CodecResult};
+use super::Message;
+
+use asynchronous_codec::{Decoder, FramedWrite};
+use bytes::BytesMut;
+use futures::{ready, AsyncRead, AsyncWrite, Stream};
+
+use std::io;
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
 // Enables us to have multiple bounds on the dyn trait in `InnerFramed`
 pub trait FrameableRead: AsyncRead + Unpin + Send + Sync {}
@@ -9,8 +17,72 @@ impl<T> FrameableRead for T where T: AsyncRead + Unpin + Send + Sync {}
 pub trait FrameableWrite: AsyncWrite + Unpin + Send + Sync {}
 impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
 
-pub(crate) type ZmqFramedRead = asynchronous_codec::FramedRead<Box<dyn FrameableRead>, ZmqCodec>;
 pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
+
+const READ_CHUNK_SIZE: usize = 64 * 1024;
+
+/// ZMTP framed reader with a larger read chunk.
+///
+/// `asynchronous-codec` defaults to 8 KiB reads from the underlying transport.
+/// Raising the chunk to 64 KiB reduces read/poll loops on the framed read path
+/// during large IPC/TCP payload bursts.
+pub struct ZmqFramedRead {
+    inner: Box<dyn FrameableRead>,
+    codec: ZmqCodec,
+    buffer: BytesMut,
+    read_scratch: Box<[u8]>,
+}
+
+impl ZmqFramedRead {
+    fn new(inner: Box<dyn FrameableRead>) -> Self {
+        Self {
+            inner,
+            codec: ZmqCodec::new(),
+            buffer: BytesMut::with_capacity(READ_CHUNK_SIZE),
+            read_scratch: vec![0; READ_CHUNK_SIZE].into_boxed_slice(),
+        }
+    }
+}
+
+impl Stream for ZmqFramedRead {
+    type Item = CodecResult<Message>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = &mut *self;
+
+        // Consume buffered data first; read from the transport only when the current buffer cannot produce a full message.
+        if let Some(item) = this.codec.decode(&mut this.buffer)? {
+            return Poll::Ready(Some(Ok(item)));
+        }
+
+        loop {
+            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut this.read_scratch))?;
+            this.buffer.extend_from_slice(&this.read_scratch[..n]);
+
+            let ended = n == 0;
+            match this.codec.decode(&mut this.buffer)? {
+                Some(item) => return Poll::Ready(Some(Ok(item))),
+                None if ended => {
+                    // On EOF, give the decoder one final chance to consume the remaining buffer before reporting truncated input.
+                    if this.buffer.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    match this.codec.decode_eof(&mut this.buffer)? {
+                        Some(item) => return Poll::Ready(Some(Ok(item))),
+                        None if this.buffer.is_empty() => return Poll::Ready(None),
+                        None => {
+                            return Poll::Ready(Some(Err(CodecError::Io(io::Error::new(
+                                io::ErrorKind::UnexpectedEof,
+                                "bytes remaining in stream",
+                            )))));
+                        }
+                    }
+                }
+                None => {}
+            }
+        }
+    }
+}
 
 /// Equivalent to [`asynchronous_codec::Framed<T, ZmqCodec>`]
 pub struct FramedIo {
@@ -20,7 +92,7 @@ pub struct FramedIo {
 
 impl FramedIo {
     pub fn new(read_half: Box<dyn FrameableRead>, write_half: Box<dyn FrameableWrite>) -> Self {
-        let read_half = FramedRead::new(read_half, ZmqCodec::new());
+        let read_half = ZmqFramedRead::new(read_half);
         let write_half = FramedWrite::new(write_half, ZmqCodec::new());
         Self {
             read_half,
@@ -30,5 +102,81 @@ impl FramedIo {
 
     pub fn into_parts(self) -> (ZmqFramedRead, ZmqFramedWrite) {
         (self.read_half, self.write_half)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::async_rt;
+    use crate::codec::ZmqGreeting;
+
+    use bytes::{Bytes, BytesMut};
+    use futures::io::Cursor;
+    use futures::StreamExt;
+    use std::io::ErrorKind;
+
+    fn encoded_stream(frames: &[&[u8]]) -> Vec<u8> {
+        let mut bytes = BytesMut::from(ZmqGreeting::default());
+        for frame in frames {
+            bytes.extend_from_slice(&[0, frame.len() as u8]);
+            bytes.extend_from_slice(frame);
+        }
+        bytes.to_vec()
+    }
+
+    #[async_rt::test]
+    async fn test_zmq_framed_read_yields_buffered_messages_before_reading_more() {
+        let input = encoded_stream(&[b"first", b"second"]);
+        let mut reader = ZmqFramedRead::new(Box::new(Cursor::new(input)));
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Greeting(_)))
+        ));
+
+        let first = reader
+            .next()
+            .await
+            .expect("first message")
+            .expect("decode first");
+        let Message::Message(first) = first else {
+            panic!("unexpected first frame type");
+        };
+        assert_eq!(first.get(0), Some(&Bytes::from_static(b"first")));
+
+        let second = reader
+            .next()
+            .await
+            .expect("second message")
+            .expect("decode second");
+        let Message::Message(second) = second else {
+            panic!("unexpected second frame type");
+        };
+        assert_eq!(second.get(0), Some(&Bytes::from_static(b"second")));
+
+        assert!(reader.next().await.is_none());
+    }
+
+    #[async_rt::test]
+    async fn test_zmq_framed_read_reports_truncated_frame_at_eof() {
+        let mut input = BytesMut::from(ZmqGreeting::default()).to_vec();
+        input.extend_from_slice(&[0, 5, b'a']);
+        let mut reader = ZmqFramedRead::new(Box::new(Cursor::new(input)));
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Greeting(_)))
+        ));
+
+        let error = reader
+            .next()
+            .await
+            .expect("truncated frame should produce an item")
+            .expect_err("truncated frame should fail");
+        match error {
+            CodecError::Io(error) => assert_eq!(error.kind(), ErrorKind::UnexpectedEof),
+            other => panic!("unexpected error type: {other:?}"),
+        }
     }
 }

--- a/src/codec/framed.rs
+++ b/src/codec/framed.rs
@@ -19,27 +19,63 @@ impl<T> FrameableWrite for T where T: AsyncWrite + Unpin + Send + Sync {}
 
 pub(crate) type ZmqFramedWrite = asynchronous_codec::FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>;
 
-const READ_CHUNK_SIZE: usize = 64 * 1024;
+const INITIAL_READ_CHUNK_SIZE: usize = 64;
+const MAX_READ_CHUNK_SIZE: usize = 64 * 1024;
 
-/// ZMTP framed reader with a larger read chunk.
+/// ZMTP framed reader with an adaptive read chunk.
 ///
-/// `asynchronous-codec` defaults to 8 KiB reads from the underlying transport.
-/// Raising the chunk to 64 KiB reduces read/poll loops on the framed read path
-/// during large IPC/TCP payload bursts.
+/// Starts with a small read chunk and grows only when the transport keeps
+/// filling the requested space. This avoids a large default allocation while
+/// still reducing read/poll loops for large receive bursts.
 pub struct ZmqFramedRead {
     inner: Box<dyn FrameableRead>,
     codec: ZmqCodec,
     buffer: BytesMut,
-    read_scratch: Box<[u8]>,
+    read_chunk_size: usize,
 }
 
 impl ZmqFramedRead {
-    fn new(inner: Box<dyn FrameableRead>) -> Self {
+    pub(crate) fn new(inner: Box<dyn FrameableRead>) -> Self {
         Self {
             inner,
             codec: ZmqCodec::new(),
-            buffer: BytesMut::with_capacity(READ_CHUNK_SIZE),
-            read_scratch: vec![0; READ_CHUNK_SIZE].into_boxed_slice(),
+            buffer: BytesMut::with_capacity(INITIAL_READ_CHUNK_SIZE),
+            read_chunk_size: INITIAL_READ_CHUNK_SIZE,
+        }
+    }
+
+    fn poll_read_into_buffer(
+        &mut self,
+        cx: &mut Context<'_>,
+        min_read_size: usize,
+    ) -> Poll<io::Result<usize>> {
+        let start = self.buffer.len();
+        let read_size = self
+            .read_chunk_size
+            .max(min_read_size)
+            .min(MAX_READ_CHUNK_SIZE);
+
+        // futures::AsyncRead requires an initialized &mut [u8]. Grow BytesMut
+        // first, then trim back to the actual read length so the read path does
+        // not need a scratch buffer and a second data copy.
+        self.buffer.resize(start + read_size, 0);
+
+        match Pin::new(&mut self.inner).poll_read(cx, &mut self.buffer[start..]) {
+            Poll::Ready(Ok(bytes_read)) => {
+                self.buffer.truncate(start + bytes_read);
+                if bytes_read >= read_size && self.read_chunk_size < MAX_READ_CHUNK_SIZE {
+                    self.read_chunk_size = (self.read_chunk_size * 2).min(MAX_READ_CHUNK_SIZE);
+                }
+                Poll::Ready(Ok(bytes_read))
+            }
+            Poll::Ready(Err(error)) => {
+                self.buffer.truncate(start);
+                Poll::Ready(Err(error))
+            }
+            Poll::Pending => {
+                self.buffer.truncate(start);
+                Poll::Pending
+            }
         }
     }
 }
@@ -50,20 +86,21 @@ impl Stream for ZmqFramedRead {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = &mut *self;
 
-        // Consume buffered data first; read from the transport only when the current buffer cannot produce a full message.
+        // Consume buffered data first; read from the socket only when the
+        // current buffer cannot produce a full message.
         if let Some(item) = this.codec.decode(&mut this.buffer)? {
             return Poll::Ready(Some(Ok(item)));
         }
 
         loop {
-            let n = ready!(Pin::new(&mut this.inner).poll_read(cx, &mut this.read_scratch))?;
-            this.buffer.extend_from_slice(&this.read_scratch[..n]);
-
+            let min_read_size = this.codec.bytes_needed(this.buffer.len());
+            let n = ready!(this.poll_read_into_buffer(cx, min_read_size))?;
             let ended = n == 0;
             match this.codec.decode(&mut this.buffer)? {
                 Some(item) => return Poll::Ready(Some(Ok(item))),
                 None if ended => {
-                    // On EOF, give the decoder one final chance to consume the remaining buffer before reporting truncated input.
+                    // Give the decoder one final chance at EOF; leftover bytes
+                    // mean the stream ended with a truncated frame.
                     if this.buffer.is_empty() {
                         return Poll::Ready(None);
                     }
@@ -112,14 +149,58 @@ mod tests {
     use crate::codec::ZmqGreeting;
 
     use bytes::{Bytes, BytesMut};
-    use futures::io::Cursor;
     use futures::StreamExt;
+    use futures::{io::Cursor, AsyncRead};
     use std::io::ErrorKind;
+    use std::sync::{Arc, Mutex};
+
+    struct RecordingReader {
+        input: Vec<u8>,
+        position: usize,
+        requested_sizes: Arc<Mutex<Vec<usize>>>,
+    }
+
+    impl RecordingReader {
+        fn new(input: Vec<u8>, requested_sizes: Arc<Mutex<Vec<usize>>>) -> Self {
+            Self {
+                input,
+                position: 0,
+                requested_sizes,
+            }
+        }
+    }
+
+    impl AsyncRead for RecordingReader {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buffer: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            self.requested_sizes.lock().unwrap().push(buffer.len());
+
+            let remaining = self.input.len() - self.position;
+            if remaining == 0 {
+                return Poll::Ready(Ok(0));
+            }
+
+            let bytes_read = remaining.min(buffer.len());
+            let end = self.position + bytes_read;
+            buffer[..bytes_read].copy_from_slice(&self.input[self.position..end]);
+            self.position = end;
+
+            Poll::Ready(Ok(bytes_read))
+        }
+    }
 
     fn encoded_stream(frames: &[&[u8]]) -> Vec<u8> {
         let mut bytes = BytesMut::from(ZmqGreeting::default());
         for frame in frames {
-            bytes.extend_from_slice(&[0, frame.len() as u8]);
+            if frame.len() > u8::MAX as usize {
+                bytes.extend_from_slice(&[0b0000_0010]);
+                bytes.extend_from_slice(&(frame.len() as u64).to_be_bytes());
+            } else {
+                bytes.extend_from_slice(&[0, frame.len() as u8]);
+            }
             bytes.extend_from_slice(frame);
         }
         bytes.to_vec()
@@ -178,5 +259,33 @@ mod tests {
             CodecError::Io(error) => assert_eq!(error.kind(), ErrorKind::UnexpectedEof),
             other => panic!("unexpected error type: {other:?}"),
         }
+    }
+
+    #[async_rt::test]
+    async fn test_zmq_framed_read_uses_decoder_demand_after_full_reads() {
+        let frame = vec![b'a'; 600];
+        let requested_sizes = Arc::new(Mutex::new(Vec::new()));
+        let input = encoded_stream(&[&frame]);
+        let mut reader = ZmqFramedRead::new(Box::new(RecordingReader::new(
+            input,
+            Arc::clone(&requested_sizes),
+        )));
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Greeting(_)))
+        ));
+
+        let message = reader
+            .next()
+            .await
+            .expect("message")
+            .expect("decode message");
+        let Message::Message(message) = message else {
+            panic!("unexpected message type");
+        };
+        assert_eq!(message.get(0), Some(&Bytes::copy_from_slice(&frame)));
+
+        assert_eq!(*requested_sizes.lock().unwrap(), vec![64, 128, 481]);
     }
 }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -10,7 +10,7 @@ mod zmq_codec;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
 pub(crate) use error::{CodecError, CodecResult};
-pub(crate) use framed::{FrameableRead, FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
+pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
 pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub use zmq_codec::ZmqCodec;
 

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -9,8 +9,10 @@ pub(crate) mod mechanism;
 mod zmq_codec;
 
 pub(crate) use command::{ZmqCommand, ZmqCommandName};
-pub(crate) use error::{CodecError, CodecResult};
-pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedRead, ZmqFramedWrite};
+pub use error::CodecError;
+pub(crate) use error::CodecResult;
+pub use framed::ZmqFramedRead;
+pub(crate) use framed::{FrameableWrite, FramedIo, ZmqFramedWrite};
 pub(crate) use greeting::{ZmqGreeting, ZmtpVersion};
 pub use zmq_codec::ZmqCodec;
 

--- a/src/codec/zmq_codec.rs
+++ b/src/codec/zmq_codec.rs
@@ -42,6 +42,11 @@ impl ZmqCodec {
             buffered_message: None,
         }
     }
+
+    /// Returns the minimum additional bytes needed before decode can progress.
+    pub(crate) fn bytes_needed(&self, buffered_len: usize) -> usize {
+        self.waiting_for.saturating_sub(buffered_len)
+    }
 }
 
 impl Default for ZmqCodec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,14 @@ pub mod __async_rt {
 #[doc(hidden)]
 pub mod __bench {
     //! DO NOT USE! PRIVATE IMPLEMENTATION, EXPOSED ONLY FOR BENCHMARKS.
-    pub use super::codec::{Message, ZmqCodec};
+    pub use super::codec::{CodecError, Message, ZmqCodec, ZmqFramedRead};
+
+    pub fn zmq_framed_read<T>(inner: T) -> ZmqFramedRead
+    where
+        T: futures::AsyncRead + Unpin + Send + Sync + 'static,
+    {
+        ZmqFramedRead::new(Box::new(inner))
+    }
 }
 
 pub use crate::dealer::*;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,7 +1,6 @@
-use crate::codec::{CodecResult, FramedIo};
+use crate::codec::{CodecResult, FramedIo, ZmqFramedRead};
 use crate::*;
 
-use asynchronous_codec::FramedRead;
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use rand::Rng;
@@ -100,7 +99,7 @@ impl From<PeerIdentity> for Vec<u8> {
 pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>,
-    pub(crate) recv_queue: FramedRead<Box<dyn FrameableRead>, ZmqCodec>,
+    pub(crate) recv_queue: ZmqFramedRead,
 }
 
 /// Given the result of the greetings exchange, determines the version of the


### PR DESCRIPTION
## Summary

This splits the framed read change out of #267 so it can be reviewed separately from send batching and FairQueue changes.

Changes:

- replace the default `asynchronous-codec` framed reader with `ZmqFramedRead`
- use a 64 KiB read scratch buffer instead of the default 8 KiB transport read chunk
- keep the existing `ZmqCodec` decode and EOF handling behavior
- add regression coverage for buffered consecutive messages and truncated frames at EOF

## Validation

- `cargo fmt --check`
- `cargo test --lib test_zmq_framed_read`

## Follow-up

This PR is receive-path only. It does not include FairQueue scheduling changes or writer queue batching.