### PR TITLE
Use shared bounded write queue for PUB

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ mod sub_backend;
 mod task_handle;
 mod transport;
 pub mod util;
+mod write_queue;
 mod xpub;
 mod xsub;
 

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -27,29 +27,20 @@ fn subscription_matches(subscriptions: &[Vec<u8>], first_frame: &Bytes) -> bool 
     })
 }
 
-async fn send_to_subscriber(
-    backend: &PubSocketBackend,
-    peer_id: PeerIdentity,
-    mut send_queue: PubSendQueue,
-    message: &ZmqMessage,
-) -> ZmqResult<()> {
+fn send_to_subscriber(mut send_queue: PubSendQueue, message: &ZmqMessage) {
     let message = Message::Message(message.clone());
-    let result = match send_queue.try_send(message) {
-        Ok(()) => Ok(()),
+    match send_queue.try_send(message) {
+        Ok(()) => {}
         Err(error) if error.is_full() => {
             // PUB drops messages for slow subscribers so one full queue does not backpressure all publishers.
             drop(error.into_inner());
-            Ok(())
         }
-        Err(error) => Err(error.into_send_error()),
-    };
-    if result.is_err() {
-        // Sending to a disconnected subscriber is equivalent to dropping the message and pruning the stale link.
-        // One stale subscriber must not interrupt fanout of the current message to other subscribers.
-        backend.peer_disconnected(&peer_id);
+        Err(error) => {
+            // The writer task owns transport error detection and subscriber cleanup.
+            // A closed local queue is treated as a dropped PUB message on this send path.
+            drop(error.into_inner());
+        }
     }
-
-    Ok(())
 }
 
 pub(crate) struct Subscriber {
@@ -140,7 +131,18 @@ impl MultiPeerBackend for PubSocketBackend {
                 },
             )
             .await;
-        async_rt::task::spawn(write_message_queue(queue_receiver, send_queue));
+        let writer_backend = self.clone();
+        let writer_peer_id = peer_id.clone();
+        async_rt::task::spawn(async move {
+            if let Err(error) = write_message_queue(queue_receiver, send_queue).await {
+                log::debug!(
+                    "Error sending message to subscriber {:?}: {:?}",
+                    writer_peer_id,
+                    error
+                );
+                writer_backend.peer_disconnected(&writer_peer_id);
+            }
+        });
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -197,17 +199,12 @@ impl SocketSend for PubSocket {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
         while let Some(subscriber) = iter {
             if subscription_matches(&subscriber.subscriptions, first_frame) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
+                send_to_subscriber(subscriber.send_queue.clone(), &message);
             }
             iter = subscriber.next_async().await;
-        }
-
-        for (peer_id, send_queue) in targets {
-            send_to_subscriber(self.backend.as_ref(), peer_id, send_queue, &message).await?;
         }
         Ok(())
     }
@@ -322,7 +319,7 @@ mod tests {
     }
 
     #[async_rt::test]
-    async fn test_stale_subscriber_does_not_interrupt_fanout_to_matching_peer() {
+    async fn test_closed_subscriber_queue_does_not_interrupt_fanout_to_matching_peer() {
         let mut socket = PubSocket::new();
         let stale_peer = PeerIdentity::new();
         let live_peer = PeerIdentity::new();
@@ -358,7 +355,7 @@ mod tests {
         };
         assert_eq!(message.get(0), Some(&Bytes::from_static(b"payload")));
 
-        assert!(socket.backend.subscribers.get_sync(&stale_peer).is_none());
+        assert!(socket.backend.subscribers.get_sync(&stale_peer).is_some());
         assert!(socket.backend.subscribers.get_sync(&live_peer).is_some());
     }
 
@@ -392,15 +389,8 @@ mod tests {
         }
         assert!(prefilled_count > 0);
 
-        let result = send_to_subscriber(
-            &backend,
-            peer_id.clone(),
-            queue_sender,
-            &ZmqMessage::from("dropped payload"),
-        )
-        .await;
+        send_to_subscriber(queue_sender, &ZmqMessage::from("dropped payload"));
 
-        assert!(result.is_ok());
         assert!(backend.subscribers.get_sync(&peer_id).is_some());
 
         let mut queued_messages = Vec::new();
@@ -421,7 +411,7 @@ mod tests {
     }
 
     #[async_rt::test]
-    async fn test_send_to_subscriber_prunes_disconnected_sender() {
+    async fn test_send_to_subscriber_drops_closed_queue_without_disconnect() {
         let backend = test_backend();
         let peer_id = PeerIdentity::new();
         let (queue_sender, queue_receiver) = mpsc::channel(1);
@@ -435,16 +425,9 @@ mod tests {
         )
         .await;
 
-        send_to_subscriber(
-            &backend,
-            peer_id.clone(),
-            queue_sender,
-            &ZmqMessage::from("payload"),
-        )
-        .await
-        .expect("send to disconnected subscriber");
+        send_to_subscriber(queue_sender, &ZmqMessage::from("payload"));
 
-        assert!(backend.subscribers.get_sync(&peer_id).is_none());
+        assert!(backend.subscribers.get_sync(&peer_id).is_some());
     }
 
     #[async_rt::test]

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -4,23 +4,57 @@ use crate::error::ZmqResult;
 use crate::message::*;
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
+use crate::write_queue::write_message_queue;
 use crate::{async_rt, CaptureSocket, SocketOptions};
 use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, SocketType};
 
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::channel::{mpsc, oneshot};
-use futures::lock::Mutex as AsyncMutex;
-use futures::{select, FutureExt, SinkExt, StreamExt};
+use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
+
+const PUB_SEND_QUEUE_CAPACITY: usize = 100_000;
+type PubSendQueue = mpsc::Sender<Message>;
+
+fn subscription_matches(subscriptions: &[Vec<u8>], first_frame: &Bytes) -> bool {
+    subscriptions.iter().any(|sub_filter| {
+        sub_filter.len() <= first_frame.len()
+            && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
+    })
+}
+
+async fn send_to_subscriber(
+    backend: &PubSocketBackend,
+    peer_id: PeerIdentity,
+    mut send_queue: PubSendQueue,
+    message: &ZmqMessage,
+) -> ZmqResult<()> {
+    let message = Message::Message(message.clone());
+    let result = match send_queue.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_full() => {
+            // PUB drops messages for slow subscribers so one full queue does not backpressure all publishers.
+            drop(error.into_inner());
+            Ok(())
+        }
+        Err(error) => Err(error.into_send_error()),
+    };
+    if result.is_err() {
+        // Sending to a disconnected subscriber is equivalent to dropping the message and pruning the stale link.
+        // One stale subscriber must not interrupt fanout of the current message to other subscribers.
+        backend.peer_disconnected(&peer_id);
+    }
+
+    Ok(())
+}
 
 pub(crate) struct Subscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) send_queue: PubSendQueue,
     _subscription_coro_stop: oneshot::Sender<()>,
 }
 
@@ -94,17 +128,19 @@ impl MultiPeerBackend for PubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (mut recv_queue, send_queue) = io.into_parts();
         // TODO provide handling for recv_queue
+        let (queue_sender, queue_receiver) = mpsc::channel(PUB_SEND_QUEUE_CAPACITY);
         let (sender, stop_receiver) = oneshot::channel();
         self.subscribers
             .upsert_async(
                 peer_id.clone(),
                 Subscriber {
                     subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                    send_queue: queue_sender,
                     _subscription_coro_stop: sender,
                 },
             )
             .await;
+        async_rt::task::spawn(write_message_queue(queue_receiver, send_queue));
         let backend = self;
         let peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -164,40 +200,14 @@ impl SocketSend for PubSocket {
         let mut targets = Vec::new();
         let mut iter = self.backend.subscribers.begin_async().await;
         while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
+            if subscription_matches(&subscriber.subscriptions, first_frame) {
                 targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
             }
             iter = subscriber.next_async().await;
         }
 
-        let mut dead_peers = Vec::new();
         for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
-        for peer in dead_peers {
-            self.backend.peer_disconnected(&peer);
+            send_to_subscriber(self.backend.as_ref(), peer_id, send_queue, &message).await?;
         }
         Ok(())
     }
@@ -241,6 +251,201 @@ mod tests {
     };
     use crate::ZmqResult;
     use std::net::IpAddr;
+
+    fn test_backend() -> PubSocketBackend {
+        PubSocketBackend {
+            subscribers: scc::HashMap::new(),
+            socket_monitor: Mutex::new(None),
+            socket_options: SocketOptions::default(),
+        }
+    }
+
+    async fn insert_test_subscriber(
+        backend: &PubSocketBackend,
+        peer_id: PeerIdentity,
+        subscriptions: Vec<Vec<u8>>,
+        queue_sender: PubSendQueue,
+    ) {
+        let (stop_sender, _stop_receiver) = oneshot::channel();
+        backend
+            .subscribers
+            .upsert_async(
+                peer_id,
+                Subscriber {
+                    subscriptions,
+                    send_queue: queue_sender,
+                    _subscription_coro_stop: stop_sender,
+                },
+            )
+            .await;
+    }
+
+    #[async_rt::test]
+    async fn test_pub_send_queues_only_matching_subscribers() {
+        let mut socket = PubSocket::new();
+        let matching_peer = PeerIdentity::new();
+        let non_matching_peer = PeerIdentity::new();
+        let (matching_sender, mut matching_receiver) = mpsc::channel(8);
+        let (non_matching_sender, mut non_matching_receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(
+            socket.backend.as_ref(),
+            matching_peer,
+            vec![b"topic.a".to_vec()],
+            matching_sender,
+        )
+        .await;
+        insert_test_subscriber(
+            socket.backend.as_ref(),
+            non_matching_peer,
+            vec![b"topic.b".to_vec()],
+            non_matching_sender,
+        )
+        .await;
+
+        <PubSocket as SocketSend>::send(
+            &mut socket,
+            ZmqMessage::from(Bytes::from_static(b"topic.a payload")),
+        )
+        .await
+        .expect("publish message");
+
+        let matched = matching_receiver.try_recv().expect("matching subscriber");
+        let Message::Message(matched) = matched else {
+            panic!("unexpected queued message type");
+        };
+        assert_eq!(
+            matched.get(0),
+            Some(&Bytes::from_static(b"topic.a payload"))
+        );
+        assert!(non_matching_receiver.try_recv().is_err());
+    }
+
+    #[async_rt::test]
+    async fn test_stale_subscriber_does_not_interrupt_fanout_to_matching_peer() {
+        let mut socket = PubSocket::new();
+        let stale_peer = PeerIdentity::new();
+        let live_peer = PeerIdentity::new();
+        let (stale_sender, stale_receiver) = mpsc::channel(1);
+        let (live_sender, mut live_receiver) = mpsc::channel(8);
+        drop(stale_receiver);
+
+        insert_test_subscriber(
+            socket.backend.as_ref(),
+            stale_peer.clone(),
+            vec![vec![]],
+            stale_sender,
+        )
+        .await;
+        insert_test_subscriber(
+            socket.backend.as_ref(),
+            live_peer.clone(),
+            vec![vec![]],
+            live_sender,
+        )
+        .await;
+
+        <PubSocket as SocketSend>::send(
+            &mut socket,
+            ZmqMessage::from(Bytes::from_static(b"payload")),
+        )
+        .await
+        .expect("publish with stale subscriber");
+
+        let queued = live_receiver.try_recv().expect("live subscriber message");
+        let Message::Message(message) = queued else {
+            panic!("unexpected queued message type");
+        };
+        assert_eq!(message.get(0), Some(&Bytes::from_static(b"payload")));
+
+        assert!(socket.backend.subscribers.get_sync(&stale_peer).is_none());
+        assert!(socket.backend.subscribers.get_sync(&live_peer).is_some());
+    }
+
+    #[async_rt::test]
+    async fn test_full_subscriber_queue_drops_message_without_disconnect() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (mut queue_sender, mut queue_receiver) = mpsc::channel(1);
+
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![vec![]],
+            queue_sender.clone(),
+        )
+        .await;
+
+        let mut prefilled_count = 0;
+        loop {
+            let message = Message::Message(ZmqMessage::from(format!(
+                "already queued {prefilled_count}"
+            )));
+            match queue_sender.try_send(message) {
+                Ok(()) => prefilled_count += 1,
+                Err(error) if error.is_full() => {
+                    drop(error.into_inner());
+                    break;
+                }
+                Err(error) => panic!("unexpected queue prefill error: {error:?}"),
+            }
+        }
+        assert!(prefilled_count > 0);
+
+        let result = send_to_subscriber(
+            &backend,
+            peer_id.clone(),
+            queue_sender,
+            &ZmqMessage::from("dropped payload"),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        assert!(backend.subscribers.get_sync(&peer_id).is_some());
+
+        let mut queued_messages = Vec::new();
+        while let Ok(queued) = queue_receiver.try_recv() {
+            let Message::Message(message) = queued else {
+                panic!("unexpected queued message type");
+            };
+            queued_messages.push(String::try_from(message).unwrap());
+        }
+
+        assert_eq!(queued_messages.len(), prefilled_count);
+        assert!(queued_messages
+            .iter()
+            .all(|message| message.starts_with("already queued ")));
+        assert!(!queued_messages
+            .iter()
+            .any(|message| message == "dropped payload"));
+    }
+
+    #[async_rt::test]
+    async fn test_send_to_subscriber_prunes_disconnected_sender() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (queue_sender, queue_receiver) = mpsc::channel(1);
+        drop(queue_receiver);
+
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![vec![]],
+            queue_sender.clone(),
+        )
+        .await;
+
+        send_to_subscriber(
+            &backend,
+            peer_id.clone(),
+            queue_sender,
+            &ZmqMessage::from("payload"),
+        )
+        .await
+        .expect("send to disconnected subscriber");
+
+        assert!(backend.subscribers.get_sync(&peer_id).is_none());
+    }
 
     #[async_rt::test]
     async fn test_bind_to_any_port() -> ZmqResult<()> {

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -1,0 +1,112 @@
+use crate::codec::{Message, ZmqFramedWrite};
+
+use futures::channel::mpsc;
+use futures::{SinkExt, StreamExt};
+
+const WRITE_BATCH_LIMIT: usize = 128;
+
+/// Writes queued socket messages into the underlying framed sink in small batches.
+pub(crate) async fn write_message_queue(
+    mut queue_receiver: mpsc::Receiver<Message>,
+    mut send_queue: ZmqFramedWrite,
+) {
+    while let Some(message) = queue_receiver.next().await {
+        // When backlog already exists, feed a batch before flushing once to avoid per-message flush cost during bursts.
+        if send_queue.feed(message).await.is_err() {
+            break;
+        }
+
+        for _ in 1..WRITE_BATCH_LIMIT {
+            let message = match queue_receiver.try_recv() {
+                Ok(message) => message,
+                Err(_) => break,
+            };
+            if send_queue.feed(message).await.is_err() {
+                return;
+            }
+        }
+
+        if send_queue.flush().await.is_err() {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codec::ZmqCodec;
+    use crate::ZmqMessage;
+
+    use bytes::Bytes;
+    use futures::{AsyncWrite, SinkExt};
+    use parking_lot::Mutex;
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::task::{Context, Poll};
+
+    #[derive(Default)]
+    struct WriteStats {
+        bytes: Vec<u8>,
+        flushes: usize,
+    }
+
+    struct RecordingWrite {
+        stats: Arc<Mutex<WriteStats>>,
+    }
+
+    impl AsyncWrite for RecordingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            let mut stats = self.stats.lock();
+            stats.bytes.extend_from_slice(buf);
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            self.stats.lock().flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[crate::async_rt::test]
+    async fn test_write_message_queue_batches_ready_messages_into_one_flush() {
+        let (mut sender, receiver) = mpsc::channel(8);
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"a"))))
+            .await
+            .expect("send first message");
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"b"))))
+            .await
+            .expect("send second message");
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"c"))))
+            .await
+            .expect("send third message");
+        drop(sender);
+
+        let stats = Arc::new(Mutex::new(WriteStats::default()));
+        let writer = RecordingWrite {
+            stats: Arc::clone(&stats),
+        };
+        let send_queue = ZmqFramedWrite::new(Box::new(writer), ZmqCodec::new());
+
+        write_message_queue(receiver, send_queue).await;
+
+        let stats = stats.lock();
+        assert_eq!(1, stats.flushes);
+        assert_eq!(
+            stats.bytes,
+            vec![0x00, 0x01, b'a', 0x00, 0x01, b'b', 0x00, 0x01, b'c']
+        );
+    }
+}

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -1,4 +1,4 @@
-use crate::codec::{Message, ZmqFramedWrite};
+use crate::codec::{CodecResult, Message, ZmqFramedWrite};
 
 use futures::channel::mpsc;
 use futures::{SinkExt, StreamExt};
@@ -9,33 +9,29 @@ const WRITE_BATCH_LIMIT: usize = 128;
 pub(crate) async fn write_message_queue(
     mut queue_receiver: mpsc::Receiver<Message>,
     mut send_queue: ZmqFramedWrite,
-) {
+) -> CodecResult<()> {
     while let Some(message) = queue_receiver.next().await {
         // When backlog already exists, feed a batch before flushing once to avoid per-message flush cost during bursts.
-        if send_queue.feed(message).await.is_err() {
-            break;
-        }
+        send_queue.feed(message).await?;
 
         for _ in 1..WRITE_BATCH_LIMIT {
             let message = match queue_receiver.try_recv() {
                 Ok(message) => message,
                 Err(_) => break,
             };
-            if send_queue.feed(message).await.is_err() {
-                return;
-            }
+            send_queue.feed(message).await?;
         }
 
-        if send_queue.flush().await.is_err() {
-            break;
-        }
+        send_queue.flush().await?;
     }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::ZmqCodec;
+    use crate::codec::{CodecError, ZmqCodec};
     use crate::ZmqMessage;
 
     use bytes::Bytes;
@@ -77,6 +73,29 @@ mod tests {
         }
     }
 
+    struct FailingWrite;
+
+    impl AsyncWrite for FailingWrite {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &[u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "writer failed",
+            )))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
     #[crate::async_rt::test]
     async fn test_write_message_queue_batches_ready_messages_into_one_flush() {
         let (mut sender, receiver) = mpsc::channel(8);
@@ -100,7 +119,9 @@ mod tests {
         };
         let send_queue = ZmqFramedWrite::new(Box::new(writer), ZmqCodec::new());
 
-        write_message_queue(receiver, send_queue).await;
+        write_message_queue(receiver, send_queue)
+            .await
+            .expect("write queued messages");
 
         let stats = stats.lock();
         assert_eq!(1, stats.flushes);
@@ -108,5 +129,25 @@ mod tests {
             stats.bytes,
             vec![0x00, 0x01, b'a', 0x00, 0x01, b'b', 0x00, 0x01, b'c']
         );
+    }
+
+    #[crate::async_rt::test]
+    async fn test_write_message_queue_returns_writer_errors() {
+        let (mut sender, receiver) = mpsc::channel(1);
+        sender
+            .send(Message::Message(ZmqMessage::from(Bytes::from_static(b"a"))))
+            .await
+            .expect("send message");
+        drop(sender);
+
+        let send_queue = ZmqFramedWrite::new(Box::new(FailingWrite), ZmqCodec::new());
+        let error = write_message_queue(receiver, send_queue)
+            .await
+            .expect_err("write error");
+
+        let CodecError::Io(error) = error else {
+            panic!("unexpected error type");
+        };
+        assert_eq!(io::ErrorKind::BrokenPipe, error.kind());
     }
 }

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)] // TODO: remove when follow-up PRs wire this helper into socket writer tasks.
+
 use crate::codec::{Message, ZmqFramedWrite};
 
 use futures::channel::mpsc;

--- a/src/write_queue.rs
+++ b/src/write_queue.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // TODO: remove when follow-up PRs wire this helper into socket writer tasks.
-
 use crate::codec::{Message, ZmqFramedWrite};
 
 use futures::channel::mpsc;

--- a/tests/compliance/mod.rs
+++ b/tests/compliance/mod.rs
@@ -65,3 +65,21 @@ where
         Err(payload) => panic::resume_unwind(payload),
     }
 }
+
+#[allow(dead_code)]
+pub async fn recv_string_on_thread(
+    socket: zmq2::Socket,
+    timeout: Duration,
+    label: &'static str,
+) -> (zmq2::Socket, String) {
+    let handle = thread::spawn(move || {
+        let received = socket.recv_string(0);
+        (socket, received)
+    });
+    let (socket, received) = join_thread(handle, timeout, label).await;
+    let message = received
+        .unwrap_or_else(|error| panic!("{label}: failed to recv: {error}"))
+        .unwrap_or_else(|bytes| panic!("{label}: invalid UTF-8: {bytes:?}"));
+
+    (socket, message)
+}

--- a/tests/compliance/mod.rs
+++ b/tests/compliance/mod.rs
@@ -1,4 +1,10 @@
 use std::convert::TryInto;
+use std::panic;
+use std::thread;
+use std::time::Duration;
+
+use futures::channel::oneshot;
+use zeromq::__async_rt as async_rt;
 
 /// NOTE: This will block. Careful when using in async code.
 #[allow(dead_code)]
@@ -33,4 +39,29 @@ pub fn setup_monitor(
         .connect(monitor_endpoint)
         .expect("Failed to connect monitor");
     their_monitor
+}
+
+#[allow(dead_code)]
+pub async fn join_thread<T>(
+    handle: thread::JoinHandle<T>,
+    timeout: Duration,
+    label: &'static str,
+) -> T
+where
+    T: Send + 'static,
+{
+    let (sender, receiver) = oneshot::channel();
+    thread::spawn(move || {
+        let _ = sender.send(handle.join());
+    });
+
+    let joined = async_rt::task::timeout(timeout, receiver)
+        .await
+        .unwrap_or_else(|_| panic!("{label}: thread join timed out"))
+        .unwrap_or_else(|_| panic!("{label}: join relay dropped"));
+
+    match joined {
+        Ok(value) => value,
+        Err(payload) => panic::resume_unwind(payload),
+    }
 }

--- a/tests/pub_sub_compliant_reverse.rs
+++ b/tests/pub_sub_compliant_reverse.rs
@@ -3,6 +3,7 @@
 //! Tests that our zmq.rs PUB socket correctly broadcasts to libzmq SUB sockets.
 
 mod compliance;
+use compliance::join_thread;
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -85,12 +86,10 @@ mod test {
                 our_pub.send(msg).await.expect("Failed to send");
             }
 
-            // Wait a bit for messages to propagate, then verify
-            async_rt::task::sleep(Duration::from_millis(500)).await;
-
             // Join all subscriber threads and verify they received messages
             for handle in sub_handles {
-                let (idx, received) = handle.join().expect("Sub thread panicked");
+                let (idx, received) =
+                    join_thread(handle, Duration::from_secs(5), "subscriber receiver").await;
                 // Each sub should receive at least some messages (slow joiner may miss early ones)
                 assert!(!received.is_empty(), "Sub {} received no messages", idx);
                 println!("Sub {} received {} messages", idx, received.len());
@@ -195,9 +194,11 @@ mod test {
         }
 
         // Wait and check results
-        let topic1_msgs = topic1_handle.join().expect("topic1 thread panicked");
-        let topic2_msgs = topic2_handle.join().expect("topic2 thread panicked");
-        let all_msgs = all_handle.join().expect("all thread panicked");
+        let topic1_msgs =
+            join_thread(topic1_handle, Duration::from_secs(3), "topic1 receiver").await;
+        let topic2_msgs =
+            join_thread(topic2_handle, Duration::from_secs(3), "topic2 receiver").await;
+        let all_msgs = join_thread(all_handle, Duration::from_secs(3), "all receiver").await;
 
         assert_eq!(
             topic1_msgs,

--- a/tests/reconnection_compliant.rs
+++ b/tests/reconnection_compliant.rs
@@ -4,7 +4,7 @@
 //! after the peer restarts.
 
 mod compliance;
-use compliance::setup_monitor;
+use compliance::{recv_string_on_thread, setup_monitor};
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -201,10 +201,8 @@ mod test {
             .await
             .expect("Failed to send");
 
-        let msg = their_sub
-            .recv_string(0)
-            .expect("Failed to recv")
-            .expect("Invalid UTF8");
+        let (their_sub, msg) =
+            recv_string_on_thread(their_sub, Duration::from_secs(5), "initial SUB recv").await;
         assert_eq!(msg, "initial-message");
         println!("Phase 2: Initial communication verified");
 
@@ -273,10 +271,12 @@ mod test {
             .await
             .expect("Failed to send");
 
-        let msg = their_sub_fresh
-            .recv_string(0)
-            .expect("Failed to recv with fresh SUB - our PUB may have a bug")
-            .expect("Invalid UTF8");
+        let (_their_sub_fresh, msg) = recv_string_on_thread(
+            their_sub_fresh,
+            Duration::from_secs(5),
+            "fresh SUB recv after PUB restart",
+        )
+        .await;
         assert_eq!(msg, "reconnected-message");
         println!("Phase 6: Fresh SUB received message!");
 


### PR DESCRIPTION
## Summary

This PR extracts the shared bounded writer helper and wires one concrete user into it: PUB subscriber writer tasks.

Changes:

- add `write_message_queue`, which feeds up to `128` immediately ready messages into `ZmqFramedWrite` and flushes once per bounded batch
- replace each PUB subscriber's locked `ZmqFramedWrite` with a bounded `mpsc::Sender<Message>`
- spawn one writer task per PUB subscriber that consumes the queue through `write_message_queue`
- keep the current foreground subscription scan in `PubSocket::send()`
- drop messages for full subscriber queues without backpressuring PUB send
- return writer `feed()` / `flush()` errors from `write_message_queue` to the owning writer task
- disconnect subscribers from the writer task when transport writes fail
- treat closed local queues as PUB drops on the send path, leaving cleanup to the writer/receiver side
- update the reverse PUB/SUB compliance test so blocking libzmq receiver joins do not block the async runtime while queued writer tasks flush
- add focused unit tests for topic matching, full queues, closed queues, writer errors, and batched writes

This PR intentionally does not add the later local PUB fanout queue or subscriber-count fast path. Those remain follow-up PRs.

## Semantics and tradeoffs

`PubSocket::send()` now enqueues messages into matching subscriber writer queues instead of awaiting each subscriber transport write while holding a per-subscriber async mutex. This keeps the publisher path independent from transport flush latency and lets the writer task batch bursts.

The tradeoff is that `Ok(())` no longer means the bytes have already been flushed to each subscriber transport. If a subscriber queue is full, PUB drops that message for that subscriber and still returns `Ok(())`, matching PUB slow-subscriber/drop behavior. If a local subscriber queue is closed, the send path treats it as a local PUB drop and continues fanout; transport error detection and subscriber cleanup are owned by the writer/receiver tasks.

`write_message_queue` now returns the first `feed()` / `flush()` error instead of swallowing it. The PUB writer task handles that error and calls `peer_disconnected()` for the affected subscriber.

## Benchmark context

The bounded writer data below comes from the original combined performance branch. In that experiment, moving writer tasks from per-message `send().await` / flush behavior to bounded `feed()` batches was the main TCP batch-throughput improvement.

| workload | before batching | after queued/batched writer | speedup vs before | libzmq comparison | speedup vs libzmq |
|---|---:|---:|---:|---:|---:|
| `DEALER/ROUTER tcp 256` | `9.2927 ms` / `26.903 MiB/s` | `987.77 us` / `253.10 MiB/s` | `9.41x` | `1.4158 ms` / `176.57 MiB/s` | `1.43x` |
| `DEALER/ROUTER tcp 4096` | not in the same early baseline run | `2.7516 ms` / `1.4196 GiB/s` | n/a | `12.891 ms` / `310.28 MiB/s` | `4.68x` |

The PUB data below is also from the combined performance branch. This PR implements the per-subscriber writer queue piece; the local fanout queue and subscriber-count fast path are intentionally left for follow-up PRs, so these numbers should be read as motivation for the split series rather than as isolated #272-only results.

| workload | native before | combined branch result | speedup vs before | libzmq same/near run | combined branch vs libzmq |
|---|---:|---:|---:|---:|---:|
| `PUB send-only 256B, 1 sub` | `6,428.8 ns` | `181.95 ns` | `35.33x` | `112.30 ns` | `1.62x` slower |
| `PUB send-only 256B, 4 subs` | `26,034.2 ns` | `192.87 ns` | `134.98x` | `110.76 ns` | `1.74x` slower |
| `PUB delivered latency 256B, 1 sub` | n/a | `28.735 us` | n/a | `85.851 us` | `2.99x` faster |
| `PUB delivered latency 256B, 4 subs` | n/a | `50.790 us` | n/a | `93.061 us` | `1.83x` faster |
| `PUB TCP throughput 256B, 1 sub` | n/a | `691.90 us` / `361.32 MiB/s` | n/a | `794.34 us` / `314.73 MiB/s` | `1.15x` faster |
| `PUB TCP throughput 256B, 8 subs` | n/a | `4.6646 ms` / `428.76 MiB/s` | n/a | `7.4259 ms` / `269.33 MiB/s` | `1.59x` faster |
| `PUB TCP throughput 4096B, 64 subs` | n/a | `76.861 ms` / `3.2526 GiB/s` | n/a | `465.15 ms` / `550.36 MiB/s` | `6.05x` faster |

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --test pub_sub_compliant_reverse`
- `cargo test --test reconnection_compliant`
- `cargo clippy --all-targets -- -D warnings`
