### PR TITLE
Queue generic backend writes

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,8 @@
-use crate::codec::{FramedIo, Message, ZmqFramedRead, ZmqFramedWrite};
+use crate::async_rt;
+use crate::codec::{FramedIo, Message, ZmqFramedRead};
 use crate::fair_queue::QueueInner;
 use crate::util::PeerIdentity;
+use crate::write_queue::write_message_queue;
 use crate::{
     MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, ZmqError, ZmqResult,
 };
@@ -16,9 +18,10 @@ use std::sync::Arc;
 
 /// Sender for notifying reconnection tasks when a peer disconnects.
 pub(crate) type DisconnectNotifier = mpsc::Sender<PeerIdentity>;
+const PEER_SEND_QUEUE_CAPACITY: usize = 100_000;
 
 pub(crate) struct Peer {
-    pub(crate) send_queue: ZmqFramedWrite,
+    pub(crate) send_queue: mpsc::Sender<Message>,
 }
 
 pub(crate) struct GenericSocketBackend {
@@ -92,7 +95,7 @@ impl GenericSocketBackend {
                 },
             };
             let send_result = match self.peers.get_async(&next_peer_id).await {
-                Some(mut peer) => peer.send_queue.send(message).await,
+                Some(mut peer) => send_to_peer_queue(&mut peer.send_queue, message).await,
                 None => continue,
             };
             return match send_result {
@@ -106,6 +109,17 @@ impl GenericSocketBackend {
                 }
             };
         }
+    }
+}
+
+async fn send_to_peer_queue(
+    send_queue: &mut mpsc::Sender<Message>,
+    message: Message,
+) -> Result<(), mpsc::SendError> {
+    match send_queue.try_send(message) {
+        Ok(()) => Ok(()),
+        Err(error) if error.is_full() => send_queue.send(error.into_inner()).await,
+        Err(error) => Err(error.into_send_error()),
     }
 }
 
@@ -136,9 +150,27 @@ impl SocketBackend for GenericSocketBackend {
 impl MultiPeerBackend for GenericSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
+        let (queue_sender, queue_receiver) = mpsc::channel(PEER_SEND_QUEUE_CAPACITY);
         self.peers
-            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .upsert_async(
+                peer_id.clone(),
+                Peer {
+                    send_queue: queue_sender,
+                },
+            )
             .await;
+        let writer_backend = self.clone();
+        let writer_peer_id = peer_id.clone();
+        async_rt::task::spawn(async move {
+            if let Err(error) = write_message_queue(queue_receiver, send_queue).await {
+                log::debug!(
+                    "Error sending message to peer {:?}: {:?}",
+                    writer_peer_id,
+                    error
+                );
+                writer_backend.peer_disconnected(&writer_peer_id);
+            }
+        });
         self.round_robin.push(peer_id.clone());
         match &self.fair_queue_inner {
             None => {}
@@ -163,5 +195,109 @@ impl MultiPeerBackend for GenericSocketBackend {
             // will eventually notice the peer is gone
             let _ = notifier.try_send(peer_id.clone());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ZmqMessage;
+
+    use bytes::Bytes;
+    use futures::StreamExt;
+
+    fn message_with_frame(frame: &'static [u8]) -> Message {
+        Message::Message(ZmqMessage::from(Bytes::from_static(frame)))
+    }
+
+    fn first_frame(message: Message) -> Bytes {
+        let Message::Message(message) = message else {
+            panic!("unexpected queued message type");
+        };
+        message.get(0).expect("message frame").clone()
+    }
+
+    async fn insert_peer(
+        backend: &GenericSocketBackend,
+        peer_id: PeerIdentity,
+    ) -> (PeerIdentity, mpsc::Receiver<Message>) {
+        let (send_queue, recv_queue) = mpsc::channel(8);
+        backend
+            .peers
+            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .await;
+        backend.round_robin.push(peer_id.clone());
+        (peer_id, recv_queue)
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_enqueues_into_peer_queue() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let (peer_id, mut recv_queue) =
+            insert_peer(&backend, "peer-a".parse().expect("peer id")).await;
+
+        let queued_peer = backend
+            .send_round_robin(message_with_frame(b"payload"))
+            .await
+            .expect("send to peer queue");
+
+        assert_eq!(peer_id, queued_peer);
+        let queued = recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"payload"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_waits_when_peer_queue_is_full() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let peer_id: PeerIdentity = "full-peer".parse().expect("peer id");
+        let (mut send_queue, mut recv_queue) = mpsc::channel(1);
+        send_queue
+            .try_send(message_with_frame(b"prefilled"))
+            .expect("prefill peer queue");
+        backend
+            .peers
+            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .await;
+        backend.round_robin.push(peer_id.clone());
+
+        let send_future = backend.send_round_robin(message_with_frame(b"after-full"));
+        let recv_future = async {
+            let first = recv_queue.next().await.expect("prefilled message");
+            let second = recv_queue
+                .next()
+                .await
+                .expect("message sent after capacity frees");
+            (first, second)
+        };
+
+        let (send_result, (first, second)) = futures::join!(send_future, recv_future);
+
+        assert_eq!(peer_id, send_result.expect("send waits for capacity"));
+        assert_eq!(Bytes::from_static(b"prefilled"), first_frame(first));
+        assert_eq!(Bytes::from_static(b"after-full"), first_frame(second));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_disconnects_closed_peer_queue() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
+        let peer_id: PeerIdentity = "closed-peer".parse().expect("peer id");
+        let (send_queue, recv_queue) = mpsc::channel(1);
+        drop(recv_queue);
+        backend
+            .peers
+            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .await;
+        backend.round_robin.push(peer_id.clone());
+
+        let error = backend
+            .send_round_robin(message_with_frame(b"lost"))
+            .await
+            .expect_err("closed peer queue should fail");
+
+        assert!(matches!(error, ZmqError::BufferFull(_)));
+        assert!(backend.peers.get_async(&peer_id).await.is_none());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,16 @@ pub trait SocketRecv {
 
 #[async_trait]
 pub trait SocketSend {
+    /// Sends one message according to the socket type's send policy.
+    ///
+    /// For sockets backed by internal writer queues, `Ok(())` means the
+    /// message has entered the local send path. It does not mean the message
+    /// has been flushed to the transport, received by the peer, or processed by
+    /// the peer.
+    ///
+    /// PUB sockets may drop messages according to PUB slow-subscriber policy.
+    /// Non-PUB queued backends still apply backpressure when the selected peer
+    /// queue is full.
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()>;
 }
 

--- a/tests/router_dealer_compliant.rs
+++ b/tests/router_dealer_compliant.rs
@@ -3,7 +3,7 @@
 //! Tests identity-based routing between zmq.rs and libzmq implementations.
 
 mod compliance;
-use compliance::{get_monitor_event, setup_monitor};
+use compliance::{get_monitor_event, join_thread, setup_monitor};
 
 use zeromq::__async_rt as async_rt;
 use zeromq::prelude::*;
@@ -98,7 +98,7 @@ mod test {
             our_router.send(reply).await.expect("Failed to send");
         }
 
-        dealer_handle.join().expect("Dealer thread panicked");
+        join_thread(dealer_handle, Duration::from_secs(5), "dealer thread").await;
     }
 
     // =========================================================================
@@ -179,7 +179,7 @@ mod test {
             assert_eq!(reply_str, format!("Reply: {}", i));
         }
 
-        router_handle.join().expect("Router thread panicked");
+        join_thread(router_handle, Duration::from_secs(5), "router thread").await;
     }
 
     // =========================================================================
@@ -244,7 +244,7 @@ mod test {
         }
 
         for handle in dealer_handles {
-            handle.join().expect("Dealer thread panicked");
+            join_thread(handle, Duration::from_secs(5), "dealer thread").await;
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR wires the generic multi-peer backend into the shared bounded writer queue that was added in #272.

Changes:

- store a bounded `mpsc::Sender<Message>` for each generic backend peer instead of storing `ZmqFramedWrite` directly
- spawn one writer task per peer that drains the queue through `write_message_queue`
- return writer `feed()` / `flush()` errors to the writer task and disconnect the affected peer from the I/O side
- keep non-PUB backpressure semantics by awaiting capacity when the selected peer queue is full
- document queued-send completion semantics on `SocketSend`
- update ROUTER/DEALER compliance tests so blocking libzmq thread joins do not block queued writer tasks from flushing

This PR intentionally does not add the single-peer sender cache or ROUTER send helper. Those remain follow-up work after this backend queueing step lands.

## Semantics and tradeoffs

For generic backend sockets, `send().await` now completes after the message has entered the selected peer's local writer queue. It does not mean the bytes have already been flushed to the transport.

Unlike PUB, generic backend sends still preserve backpressure. If the selected peer queue is full, the send path awaits queue capacity instead of dropping the message. If the queue is closed, the peer is disconnected and the send returns an error.

Transport write failures are handled by the peer writer task. The foreground send path only handles local queue acceptance/backpressure.

## Benchmark context

The data below comes from the original combined performance branch. This PR provides the generic backend queued-writer part of that series; later PRs still split out the single-peer cache and ROUTER helper, so these numbers should be read as motivation for the series rather than as isolated results from only this PR.

| workload | before queued/batched writer | combined branch result | speedup vs before | libzmq comparison | combined branch vs libzmq |
|---|---:|---:|---:|---:|---:|
| `DEALER/ROUTER tcp 256` | `9.2927 ms` / `26.903 MiB/s` | `987.77 us` / `253.10 MiB/s` | `9.41x` | `1.4158 ms` / `176.57 MiB/s` | `1.43x` faster |
| `DEALER/ROUTER tcp 4096` | not in the same early baseline run | `2.7516 ms` / `1.4196 GiB/s` | n/a | `12.891 ms` / `310.28 MiB/s` | `4.68x` faster |

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --lib backend`
- `cargo test --test router_dealer_compliant`
- `cargo test --test dealer_split`
- `cargo test --test router_split`
- `cargo test --test req_router_dealer_rep`
- `cargo test --test push_pull_timeout`
- `cargo clippy --all-targets -- -D warnings`
