### PR TITLE
Queue PUB fanout locally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,7 @@ harness = false
 [[bench]]
 name = "hotpath"
 harness = false
+
+[[bench]]
+name = "fanout_queue"
+harness = false

--- a/benches/fanout_queue.rs
+++ b/benches/fanout_queue.rs
@@ -1,0 +1,355 @@
+//! Fanout queue latency calibration for the PUB local fanout path.
+
+mod bench_runtime;
+
+use bench_runtime::BenchRuntime;
+use bytes::Bytes;
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use crossbeam_queue::ArrayQueue;
+use futures::channel::mpsc;
+use futures::StreamExt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Instant;
+
+use zeromq::{__async_rt::task, ZmqMessage, ZmqResult};
+
+const FANOUT_QUEUE_CAPACITY: usize = 100_000;
+const THROUGHPUT_BATCH_MESSAGES: usize = 8_192;
+const MSG_SIZES: &[usize] = &[64, 256, 1024];
+
+struct ArrayFanoutQueue {
+    queue: Arc<ArrayQueue<ZmqMessage>>,
+    wake_sender: mpsc::UnboundedSender<()>,
+    wake_pending: Arc<AtomicBool>,
+}
+
+impl ArrayFanoutQueue {
+    fn publish(&self, message: ZmqMessage) -> ZmqResult<()> {
+        if self.queue.push(message).is_err() {
+            return Ok(());
+        }
+
+        if !self.wake_pending.load(Ordering::Acquire)
+            && !self.wake_pending.swap(true, Ordering::AcqRel)
+        {
+            let _ = self.wake_sender.unbounded_send(());
+        }
+
+        Ok(())
+    }
+}
+
+fn payload(size: usize, byte: u8) -> Bytes {
+    Bytes::from(vec![byte; size])
+}
+
+fn build_array_queue(capacity: usize) -> (ArrayFanoutQueue, mpsc::UnboundedReceiver<()>) {
+    let (wake_sender, wake_receiver) = mpsc::unbounded();
+    let queue = ArrayFanoutQueue {
+        queue: Arc::new(ArrayQueue::new(capacity)),
+        wake_sender,
+        wake_pending: Arc::new(AtomicBool::new(false)),
+    };
+    (queue, wake_receiver)
+}
+
+fn spawn_array_worker(
+    queue: Arc<ArrayQueue<ZmqMessage>>,
+    wake_pending: Arc<AtomicBool>,
+    mut wake_receiver: mpsc::UnboundedReceiver<()>,
+    ack_sender: mpsc::UnboundedSender<()>,
+) {
+    task::spawn(async move {
+        while wake_receiver.next().await.is_some() {
+            loop {
+                while let Some(message) = queue.pop() {
+                    black_box(message);
+                    let _ = ack_sender.unbounded_send(());
+                }
+
+                wake_pending.store(false, Ordering::Release);
+                if queue.is_empty() {
+                    break;
+                }
+
+                wake_pending.store(true, Ordering::Release);
+            }
+        }
+    });
+}
+
+fn spawn_mpsc_worker(
+    mut receiver: mpsc::Receiver<ZmqMessage>,
+    ack_sender: mpsc::UnboundedSender<()>,
+) {
+    task::spawn(async move {
+        while let Some(message) = receiver.next().await {
+            black_box(message);
+            let _ = ack_sender.unbounded_send(());
+        }
+    });
+}
+
+fn bench_first_message_wake_latency(c: &mut Criterion) {
+    let rt = BenchRuntime::new();
+    let mut group = c.benchmark_group("hotpath/pub_fanout_queue/first_message_wake_latency");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("array_queue_wake_pending", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (queue, wake_receiver) = build_array_queue(FANOUT_QUEUE_CAPACITY);
+                let (ack_sender, mut ack_receiver) = mpsc::unbounded();
+                let payload = payload(size, 0xA1);
+
+                rt.block_on(async {
+                    spawn_array_worker(
+                        queue.queue.clone(),
+                        queue.wake_pending.clone(),
+                        wake_receiver,
+                        ack_sender,
+                    );
+                });
+
+                b.iter(|| {
+                    rt.block_on(async {
+                        queue
+                            .publish(ZmqMessage::from(payload.clone()))
+                            .expect("array publish");
+                        ack_receiver.next().await.expect("array worker ack");
+                    });
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("bounded_futures_mpsc", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (mut sender, receiver) = mpsc::channel(FANOUT_QUEUE_CAPACITY);
+                let (ack_sender, mut ack_receiver) = mpsc::unbounded();
+                let payload = payload(size, 0xA2);
+
+                rt.block_on(async {
+                    spawn_mpsc_worker(receiver, ack_sender);
+                });
+
+                b.iter(|| {
+                    rt.block_on(async {
+                        sender
+                            .try_send(ZmqMessage::from(payload.clone()))
+                            .expect("mpsc publish");
+                        ack_receiver.next().await.expect("mpsc worker ack");
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_enqueue_return_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/pub_fanout_queue/enqueue_return_latency");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("array_queue_pending", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (queue, _wake_receiver) = build_array_queue(FANOUT_QUEUE_CAPACITY);
+                let payload = payload(size, 0xB1);
+                queue.wake_pending.store(true, Ordering::Relaxed);
+
+                b.iter(|| {
+                    queue
+                        .publish(ZmqMessage::from(payload.clone()))
+                        .expect("array publish");
+                    black_box(queue.queue.pop().expect("array queued message"));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("bounded_futures_mpsc", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (mut sender, mut receiver) = mpsc::channel(FANOUT_QUEUE_CAPACITY);
+                let payload = payload(size, 0xB2);
+
+                b.iter(|| {
+                    sender
+                        .try_send(ZmqMessage::from(payload.clone()))
+                        .expect("mpsc publish");
+                    black_box(receiver.try_recv().expect("mpsc queued message"));
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_full_drop_latency(c: &mut Criterion) {
+    let mut group = c.benchmark_group("hotpath/pub_fanout_queue/full_drop_latency");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(msg_size as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("array_queue", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (queue, _wake_receiver) = build_array_queue(1);
+                let payload = payload(size, 0xC1);
+                queue
+                    .publish(ZmqMessage::from(payload.clone()))
+                    .expect("prefill array queue");
+
+                b.iter(|| {
+                    queue
+                        .publish(ZmqMessage::from(payload.clone()))
+                        .expect("array drop publish");
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("bounded_futures_mpsc", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (mut sender, _receiver) = mpsc::channel(1);
+                let payload = payload(size, 0xC2);
+                let mut prefilled = 0;
+                loop {
+                    match sender.try_send(ZmqMessage::from(payload.clone())) {
+                        Ok(()) => prefilled += 1,
+                        Err(error) if error.is_full() => {
+                            black_box(error.into_inner());
+                            break;
+                        }
+                        Err(error) => panic!("unexpected mpsc prefill error: {error:?}"),
+                    }
+                }
+                assert!(prefilled > 0);
+
+                b.iter(
+                    || match sender.try_send(ZmqMessage::from(payload.clone())) {
+                        Ok(()) => panic!("mpsc queue unexpectedly accepted message"),
+                        Err(error) if error.is_full() => {
+                            black_box(error.into_inner());
+                        }
+                        Err(error) => panic!("unexpected mpsc error: {error:?}"),
+                    },
+                );
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_sustained_throughput(c: &mut Criterion) {
+    let rt = BenchRuntime::new();
+    let mut group = c.benchmark_group("hotpath/pub_fanout_queue/sustained_throughput");
+    bench_runtime::configure_group(&mut group);
+
+    for &msg_size in MSG_SIZES {
+        group.throughput(Throughput::Bytes(
+            (msg_size * THROUGHPUT_BATCH_MESSAGES) as u64,
+        ));
+
+        group.bench_with_input(
+            BenchmarkId::new("array_queue_wake_pending", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (queue, wake_receiver) = build_array_queue(FANOUT_QUEUE_CAPACITY);
+                let (ack_sender, mut ack_receiver) = mpsc::unbounded();
+                let payload = payload(size, 0xD1);
+
+                rt.block_on(async {
+                    spawn_array_worker(
+                        queue.queue.clone(),
+                        queue.wake_pending.clone(),
+                        wake_receiver,
+                        ack_sender,
+                    );
+                });
+
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+
+                    rt.block_on(async {
+                        for _ in 0..iters {
+                            for _ in 0..THROUGHPUT_BATCH_MESSAGES {
+                                queue
+                                    .publish(ZmqMessage::from(payload.clone()))
+                                    .expect("array publish");
+                            }
+
+                            for _ in 0..THROUGHPUT_BATCH_MESSAGES {
+                                ack_receiver.next().await.expect("array worker ack");
+                            }
+                        }
+                    });
+
+                    start.elapsed()
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("bounded_futures_mpsc", msg_size),
+            &msg_size,
+            |b, &size| {
+                let (mut sender, receiver) = mpsc::channel(FANOUT_QUEUE_CAPACITY);
+                let (ack_sender, mut ack_receiver) = mpsc::unbounded();
+                let payload = payload(size, 0xD2);
+
+                rt.block_on(async {
+                    spawn_mpsc_worker(receiver, ack_sender);
+                });
+
+                b.iter_custom(|iters| {
+                    let start = Instant::now();
+
+                    rt.block_on(async {
+                        for _ in 0..iters {
+                            for _ in 0..THROUGHPUT_BATCH_MESSAGES {
+                                sender
+                                    .try_send(ZmqMessage::from(payload.clone()))
+                                    .expect("mpsc publish");
+                            }
+
+                            for _ in 0..THROUGHPUT_BATCH_MESSAGES {
+                                ack_receiver.next().await.expect("mpsc worker ack");
+                            }
+                        }
+                    });
+
+                    start.elapsed()
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_first_message_wake_latency,
+    bench_enqueue_return_latency,
+    bench_full_drop_latency,
+    bench_sustained_throughput,
+);
+criterion_main!(benches);

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -10,11 +10,13 @@ use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, So
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use crossbeam_queue::ArrayQueue;
 use futures::channel::{mpsc, oneshot};
 use futures::{select, FutureExt, StreamExt};
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 const PUB_SEND_QUEUE_CAPACITY: usize = 100_000;
@@ -51,11 +53,81 @@ pub(crate) struct Subscriber {
 
 pub(crate) struct PubSocketBackend {
     subscribers: scc::HashMap<PeerIdentity, Subscriber>,
+    subscriber_count: AtomicUsize,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
 }
 
+struct PubFanoutQueue {
+    queue: Arc<ArrayQueue<ZmqMessage>>,
+    wake_sender: mpsc::UnboundedSender<()>,
+    wake_pending: Arc<AtomicBool>,
+}
+
+impl PubFanoutQueue {
+    fn publish(&self, message: ZmqMessage) -> ZmqResult<()> {
+        if self.queue.push(message).is_err() {
+            return Ok(());
+        }
+
+        if !self.wake_pending.load(Ordering::Acquire)
+            && !self.wake_pending.swap(true, Ordering::AcqRel)
+        {
+            let _ = self.wake_sender.unbounded_send(());
+        }
+
+        Ok(())
+    }
+}
+
+fn spawn_pub_fanout_queue(backend: Arc<PubSocketBackend>) -> PubFanoutQueue {
+    let queue = Arc::new(ArrayQueue::new(PUB_SEND_QUEUE_CAPACITY));
+    let wake_pending = Arc::new(AtomicBool::new(false));
+    let (wake_sender, mut wake_receiver) = mpsc::unbounded();
+    let worker_queue = queue.clone();
+    let worker_pending = wake_pending.clone();
+
+    async_rt::task::spawn(async move {
+        while wake_receiver.next().await.is_some() {
+            loop {
+                while let Some(message) = worker_queue.pop() {
+                    backend.fanout_message(message).await;
+                }
+
+                worker_pending.store(false, Ordering::Release);
+                if worker_queue.is_empty() {
+                    break;
+                }
+
+                // New messages arrived between draining and sleeping, so this task keeps ownership of the batch.
+                worker_pending.store(true, Ordering::Release);
+            }
+        }
+    });
+
+    PubFanoutQueue {
+        queue,
+        wake_sender,
+        wake_pending,
+    }
+}
+
 impl PubSocketBackend {
+    async fn fanout_message(&self, message: ZmqMessage) {
+        let first_frame = match message.get(0) {
+            Some(frame) => frame,
+            None => return,
+        };
+
+        let mut iter = self.subscribers.begin_async().await;
+        while let Some(subscriber) = iter {
+            if subscription_matches(&subscriber.subscriptions, first_frame) {
+                send_to_subscriber(subscriber.send_queue.clone(), &message);
+            }
+            iter = subscriber.next_async().await;
+        }
+    }
+
     fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
         let data = match message {
             Message::Message(m) => {
@@ -107,6 +179,7 @@ impl SocketBackend for PubSocketBackend {
 
     fn shutdown(&self) {
         self.subscribers.clear_sync();
+        self.subscriber_count.store(0, Ordering::Relaxed);
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -121,7 +194,8 @@ impl MultiPeerBackend for PubSocketBackend {
         // TODO provide handling for recv_queue
         let (queue_sender, queue_receiver) = mpsc::channel(PUB_SEND_QUEUE_CAPACITY);
         let (sender, stop_receiver) = oneshot::channel();
-        self.subscribers
+        let old_subscriber = self
+            .subscribers
             .upsert_async(
                 peer_id.clone(),
                 Subscriber {
@@ -131,6 +205,9 @@ impl MultiPeerBackend for PubSocketBackend {
                 },
             )
             .await;
+        if old_subscriber.is_none() {
+            self.subscriber_count.fetch_add(1, Ordering::Relaxed);
+        }
         let writer_backend = self.clone();
         let writer_peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -177,12 +254,15 @@ impl MultiPeerBackend for PubSocketBackend {
         if let Some(monitor) = self.monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
         }
-        self.subscribers.remove_sync(peer_id);
+        if self.subscribers.remove_sync(peer_id).is_some() {
+            self.subscriber_count.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 }
 
 pub struct PubSocket {
     pub(crate) backend: Arc<PubSocketBackend>,
+    fanout_queue: PubFanoutQueue,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -195,18 +275,15 @@ impl Drop for PubSocket {
 #[async_trait]
 impl SocketSend for PubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
-        let first_frame = match message.get(0) {
-            Some(frame) => frame,
-            None => return Ok(()), // Empty message, nothing to publish
-        };
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscription_matches(&subscriber.subscriptions, first_frame) {
-                send_to_subscriber(subscriber.send_queue.clone(), &message);
-            }
-            iter = subscriber.next_async().await;
+        if message.get(0).is_none() {
+            return Ok(());
         }
-        Ok(())
+
+        if self.backend.subscriber_count.load(Ordering::Relaxed) == 0 {
+            return Ok(());
+        }
+
+        self.fanout_queue.publish(message)
     }
 }
 
@@ -215,12 +292,17 @@ impl CaptureSocket for PubSocket {}
 #[async_trait]
 impl Socket for PubSocket {
     fn with_options(options: SocketOptions) -> Self {
+        let backend = Arc::new(PubSocketBackend {
+            subscribers: scc::HashMap::new(),
+            subscriber_count: AtomicUsize::new(0),
+            socket_monitor: Mutex::new(None),
+            socket_options: options,
+        });
+        let fanout_queue = spawn_pub_fanout_queue(backend.clone());
+
         Self {
-            backend: Arc::new(PubSocketBackend {
-                subscribers: scc::HashMap::new(),
-                socket_monitor: Mutex::new(None),
-                socket_options: options,
-            }),
+            backend,
+            fanout_queue,
             binds: HashMap::new(),
         }
     }
@@ -252,6 +334,7 @@ mod tests {
     fn test_backend() -> PubSocketBackend {
         PubSocketBackend {
             subscribers: scc::HashMap::new(),
+            subscriber_count: AtomicUsize::new(0),
             socket_monitor: Mutex::new(None),
             socket_options: SocketOptions::default(),
         }
@@ -264,7 +347,7 @@ mod tests {
         queue_sender: PubSendQueue,
     ) {
         let (stop_sender, _stop_receiver) = oneshot::channel();
-        backend
+        let old_subscriber = backend
             .subscribers
             .upsert_async(
                 peer_id,
@@ -275,37 +358,146 @@ mod tests {
                 },
             )
             .await;
+        if old_subscriber.is_none() {
+            backend.subscriber_count.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn test_fanout_queue(capacity: usize) -> (PubFanoutQueue, mpsc::UnboundedReceiver<()>) {
+        let (wake_sender, wake_receiver) = mpsc::unbounded();
+        let fanout_queue = PubFanoutQueue {
+            queue: Arc::new(ArrayQueue::new(capacity)),
+            wake_sender,
+            wake_pending: Arc::new(AtomicBool::new(false)),
+        };
+        (fanout_queue, wake_receiver)
+    }
+
+    fn queued_frame(message: ZmqMessage) -> Bytes {
+        message.get(0).expect("queued frame").clone()
+    }
+
+    #[test]
+    fn test_fanout_queue_drops_new_message_when_full_without_extra_wake() {
+        let (fanout_queue, mut wake_receiver) = test_fanout_queue(1);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"first")))
+            .expect("publish first message");
+
+        assert_eq!(fanout_queue.queue.len(), 1);
+        assert!(fanout_queue.wake_pending.load(Ordering::Relaxed));
+        wake_receiver.try_recv().expect("first wake");
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"dropped")))
+            .expect("publish dropped message");
+
+        assert_eq!(fanout_queue.queue.len(), 1);
+        assert!(wake_receiver.try_recv().is_err());
+        assert_eq!(
+            queued_frame(fanout_queue.queue.pop().expect("queued message")),
+            Bytes::from_static(b"first")
+        );
+    }
+
+    #[test]
+    fn test_fanout_queue_wakes_again_after_pending_is_cleared() {
+        let (fanout_queue, mut wake_receiver) = test_fanout_queue(2);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"first")))
+            .expect("publish first message");
+        wake_receiver.try_recv().expect("first wake");
+        assert!(fanout_queue.queue.pop().is_some());
+
+        // Simulate the worker releasing pending after draining the current batch; the next publish must wake it again.
+        fanout_queue.wake_pending.store(false, Ordering::Release);
+
+        fanout_queue
+            .publish(ZmqMessage::from(Bytes::from_static(b"second")))
+            .expect("publish second message");
+
+        wake_receiver.try_recv().expect("second wake");
+        assert_eq!(
+            queued_frame(fanout_queue.queue.pop().expect("queued message")),
+            Bytes::from_static(b"second")
+        );
     }
 
     #[async_rt::test]
-    async fn test_pub_send_queues_only_matching_subscribers() {
+    async fn test_send_without_subscribers_does_not_enqueue_fanout_message() {
         let mut socket = PubSocket::new();
+
+        socket
+            .send(ZmqMessage::from("dropped without subscribers"))
+            .await
+            .expect("send without subscribers");
+
+        assert!(socket.fanout_queue.queue.is_empty());
+    }
+
+    #[async_rt::test]
+    async fn test_replacing_subscriber_does_not_increment_subscriber_count() {
+        let backend = test_backend();
+        let peer_id = PeerIdentity::new();
+        let (first_sender, _first_receiver) = mpsc::channel(8);
+        let (second_sender, _second_receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(&backend, peer_id.clone(), vec![vec![]], first_sender).await;
+        insert_test_subscriber(
+            &backend,
+            peer_id.clone(),
+            vec![b"topic".to_vec()],
+            second_sender,
+        )
+        .await;
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+        assert_eq!(backend.subscribers.len(), 1);
+    }
+
+    #[async_rt::test]
+    async fn test_shutdown_clears_subscriber_count() {
+        let backend = test_backend();
+        let (sender, _receiver) = mpsc::channel(8);
+
+        insert_test_subscriber(&backend, PeerIdentity::new(), vec![vec![]], sender).await;
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
+
+        backend.shutdown();
+
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 0);
+        assert!(backend.subscribers.is_empty());
+    }
+
+    #[async_rt::test]
+    async fn test_fanout_message_delivers_only_matching_subscribers() {
+        let backend = test_backend();
         let matching_peer = PeerIdentity::new();
         let non_matching_peer = PeerIdentity::new();
         let (matching_sender, mut matching_receiver) = mpsc::channel(8);
         let (non_matching_sender, mut non_matching_receiver) = mpsc::channel(8);
 
         insert_test_subscriber(
-            socket.backend.as_ref(),
+            &backend,
             matching_peer,
             vec![b"topic.a".to_vec()],
             matching_sender,
         )
         .await;
         insert_test_subscriber(
-            socket.backend.as_ref(),
+            &backend,
             non_matching_peer,
             vec![b"topic.b".to_vec()],
             non_matching_sender,
         )
         .await;
 
-        <PubSocket as SocketSend>::send(
-            &mut socket,
-            ZmqMessage::from(Bytes::from_static(b"topic.a payload")),
-        )
-        .await
-        .expect("publish message");
+        backend
+            .fanout_message(ZmqMessage::from(Bytes::from_static(b"topic.a payload")))
+            .await;
 
         let matched = matching_receiver.try_recv().expect("matching subscriber");
         let Message::Message(matched) = matched else {
@@ -320,34 +512,19 @@ mod tests {
 
     #[async_rt::test]
     async fn test_closed_subscriber_queue_does_not_interrupt_fanout_to_matching_peer() {
-        let mut socket = PubSocket::new();
+        let backend = test_backend();
         let stale_peer = PeerIdentity::new();
         let live_peer = PeerIdentity::new();
         let (stale_sender, stale_receiver) = mpsc::channel(1);
         let (live_sender, mut live_receiver) = mpsc::channel(8);
         drop(stale_receiver);
 
-        insert_test_subscriber(
-            socket.backend.as_ref(),
-            stale_peer.clone(),
-            vec![vec![]],
-            stale_sender,
-        )
-        .await;
-        insert_test_subscriber(
-            socket.backend.as_ref(),
-            live_peer.clone(),
-            vec![vec![]],
-            live_sender,
-        )
-        .await;
+        insert_test_subscriber(&backend, stale_peer.clone(), vec![vec![]], stale_sender).await;
+        insert_test_subscriber(&backend, live_peer.clone(), vec![vec![]], live_sender).await;
 
-        <PubSocket as SocketSend>::send(
-            &mut socket,
-            ZmqMessage::from(Bytes::from_static(b"payload")),
-        )
-        .await
-        .expect("publish with stale subscriber");
+        backend
+            .fanout_message(ZmqMessage::from(Bytes::from_static(b"payload")))
+            .await;
 
         let queued = live_receiver.try_recv().expect("live subscriber message");
         let Message::Message(message) = queued else {
@@ -355,8 +532,9 @@ mod tests {
         };
         assert_eq!(message.get(0), Some(&Bytes::from_static(b"payload")));
 
-        assert!(socket.backend.subscribers.get_sync(&stale_peer).is_some());
-        assert!(socket.backend.subscribers.get_sync(&live_peer).is_some());
+        assert!(backend.subscribers.get_sync(&stale_peer).is_some());
+        assert!(backend.subscribers.get_sync(&live_peer).is_some());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 2);
     }
 
     #[async_rt::test]
@@ -392,6 +570,7 @@ mod tests {
         send_to_subscriber(queue_sender, &ZmqMessage::from("dropped payload"));
 
         assert!(backend.subscribers.get_sync(&peer_id).is_some());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
 
         let mut queued_messages = Vec::new();
         while let Ok(queued) = queue_receiver.try_recv() {
@@ -428,6 +607,7 @@ mod tests {
         send_to_subscriber(queue_sender, &ZmqMessage::from("payload"));
 
         assert!(backend.subscribers.get_sync(&peer_id).is_some());
+        assert_eq!(backend.subscriber_count.load(Ordering::Relaxed), 1);
     }
 
     #[async_rt::test]


### PR DESCRIPTION
## Summary

This PR adds the local PUB fanout queue on top of the per-subscriber writer queues merged in #272.

Changes:

- add a bounded local fanout queue for `PubSocket::send()`
- move foreground PUB sends from subscriber-map scanning to local fanout enqueue
- drain the fanout queue in a background task that scans subscriptions and enqueues into matching subscriber writer queues
- coalesce fanout worker wakeups with a `wake_pending` flag
- add an atomic subscriber count so the no-subscriber path returns without touching the fanout queue
- keep PUB drop semantics when the local fanout queue or a subscriber writer queue is full
- preserve #272 writer-side transport error handling; closed local subscriber queues are still treated as PUB drops on the send path
- add focused tests for fanout queue drops, wake coalescing, no-subscriber fast path, subscriber count replacement/shutdown, topic matching, and closed/full subscriber queues

This PR intentionally does not include the generic backend single-peer cache or ROUTER helper.

## Semantics and tradeoffs

`PubSocket::send()` now returns after the message has entered the local fanout path, or after PUB drops it according to normal drop policy. It is not a delivery, subscriber enqueue, or transport flush barrier.

If there are no subscribers, `send()` returns immediately without enqueueing. If the local fanout queue is full, PUB drops the whole published message and returns `Ok(())`. During fanout, each matching subscriber still uses the per-subscriber writer queue from #272; a full subscriber queue drops that subscriber's copy without backpressuring the publisher.

The fanout worker owns subscription scanning. Per-subscriber transport write errors remain owned by each subscriber writer task.

## Benchmark context

The data below comes from the original combined performance branch. #272 already merged the per-subscriber writer queue; this PR adds the remaining local fanout queue and subscriber-count fast path from that PUB series. These numbers should be read as motivation for the PUB split series rather than as isolated results from only this PR.

| workload | native before | combined branch result | speedup vs before | libzmq same/near run | combined branch vs libzmq |
|---|---:|---:|---:|---:|---:|
| `PUB send-only 256B, 1 sub` | `6,428.8 ns` | `181.95 ns` | `35.33x` | `112.30 ns` | `1.62x` slower |
| `PUB send-only 256B, 4 subs` | `26,034.2 ns` | `192.87 ns` | `134.98x` | `110.76 ns` | `1.74x` slower |
| `PUB delivered latency 256B, 1 sub` | n/a | `28.735 us` | n/a | `85.851 us` | `2.99x` faster |
| `PUB delivered latency 256B, 4 subs` | n/a | `50.790 us` | n/a | `93.061 us` | `1.83x` faster |
| `PUB TCP throughput 256B, 1 sub` | n/a | `691.90 us` / `361.32 MiB/s` | n/a | `794.34 us` / `314.73 MiB/s` | `1.15x` faster |
| `PUB TCP throughput 256B, 8 subs` | n/a | `4.6646 ms` / `428.76 MiB/s` | n/a | `7.4259 ms` / `269.33 MiB/s` | `1.59x` faster |
| `PUB TCP throughput 4096B, 64 subs` | n/a | `76.861 ms` / `3.2526 GiB/s` | n/a | `465.15 ms` / `550.36 MiB/s` | `6.05x` faster |

## Validation

- `cargo fmt --check`
- `cargo test --lib`
- `cargo test --lib pub`
- `cargo test --test pub_sub`
- `cargo test --test pub_sub_compliant`
- `cargo test --test pub_sub_compliant_reverse`
- `cargo test --test reconnection_compliant`
- `cargo test --test xpub_sub`
- `cargo clippy --all-targets -- -D warnings`
