### PR TITLE
Cache single-peer backend sends

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,6 +14,7 @@ use futures::SinkExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 /// Sender for notifying reconnection tasks when a peer disconnects.
@@ -24,6 +25,31 @@ pub(crate) struct Peer {
     pub(crate) send_queue: mpsc::Sender<Message>,
 }
 
+#[derive(Clone)]
+struct SinglePeer {
+    peer_id: PeerIdentity,
+    send_queue: mpsc::Sender<Message>,
+}
+
+enum CachedSend {
+    Sent,
+    Full {
+        peer_id: PeerIdentity,
+        send_queue: mpsc::Sender<Message>,
+        message: Message,
+    },
+    Disconnected {
+        peer_id: PeerIdentity,
+        error: mpsc::SendError,
+    },
+    Miss(Message),
+}
+
+enum SendResolution {
+    Sent,
+    Miss(Message),
+}
+
 pub(crate) struct GenericSocketBackend {
     pub(crate) peers: scc::HashMap<PeerIdentity, Peer>,
     fair_queue_inner: Option<Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>>,
@@ -31,6 +57,8 @@ pub(crate) struct GenericSocketBackend {
     socket_type: SocketType,
     socket_options: SocketOptions,
     pub(crate) socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
+    single_peer: Mutex<Option<SinglePeer>>,
+    peer_count: AtomicUsize,
     /// Notifiers for reconnection tasks - keyed by `peer_id`
     disconnect_notifiers: Mutex<HashMap<PeerIdentity, DisconnectNotifier>>,
 }
@@ -48,6 +76,8 @@ impl GenericSocketBackend {
             socket_type,
             socket_options: options,
             socket_monitor: Mutex::new(None),
+            single_peer: Mutex::new(None),
+            peer_count: AtomicUsize::new(0),
             disconnect_notifiers: Mutex::new(HashMap::new()),
         }
     }
@@ -70,7 +100,15 @@ impl GenericSocketBackend {
         self.disconnect_notifiers.lock().remove(peer_id);
     }
 
-    pub(crate) async fn send_round_robin(&self, message: Message) -> ZmqResult<PeerIdentity> {
+    pub(crate) async fn send_round_robin(&self, message: Message) -> ZmqResult<()> {
+        let message = match self
+            .finish_cached_send(self.try_send_cached_single_peer(message, None))
+            .await?
+        {
+            SendResolution::Sent => return Ok(()),
+            SendResolution::Miss(message) => message,
+        };
+
         // In normal scenario this will always be only 1 iteration
         // There can be special case when peer has disconnected and his id is still in
         // RR queue This happens because SegQueue don't have an api to delete
@@ -100,14 +138,111 @@ impl GenericSocketBackend {
             };
             return match send_result {
                 Ok(()) => {
-                    self.round_robin.push(next_peer_id.clone());
-                    Ok(next_peer_id)
+                    self.round_robin.push(next_peer_id);
+                    Ok(())
                 }
                 Err(e) => {
                     self.peer_disconnected(&next_peer_id);
                     Err(e.into())
                 }
             };
+        }
+    }
+
+    pub(crate) async fn send_to_peer(
+        &self,
+        peer_id: &PeerIdentity,
+        message: Message,
+    ) -> ZmqResult<()> {
+        let message = match self
+            .finish_cached_send(self.try_send_cached_single_peer(message, Some(peer_id)))
+            .await?
+        {
+            SendResolution::Sent => return Ok(()),
+            SendResolution::Miss(message) => message,
+        };
+
+        let send_result = match self.peers.get_async(peer_id).await {
+            Some(mut peer) => send_to_peer_queue(&mut peer.send_queue, message).await,
+            None => return Err(ZmqError::Other("Destination client not found by identity")),
+        };
+        match send_result {
+            Ok(()) => Ok(()),
+            Err(e) => {
+                self.peer_disconnected(peer_id);
+                Err(e.into())
+            }
+        }
+    }
+
+    fn try_send_cached_single_peer(
+        &self,
+        message: Message,
+        expected_peer_id: Option<&PeerIdentity>,
+    ) -> CachedSend {
+        if self.peer_count.load(Ordering::Acquire) != 1 {
+            return CachedSend::Miss(message);
+        }
+
+        let mut single_peer = self.single_peer.lock();
+        let Some(single_peer) = single_peer.as_mut() else {
+            return CachedSend::Miss(message);
+        };
+
+        if let Some(expected_peer_id) = expected_peer_id {
+            if single_peer.peer_id != *expected_peer_id {
+                return CachedSend::Miss(message);
+            }
+        }
+
+        match single_peer.send_queue.try_send(message) {
+            Ok(()) => CachedSend::Sent,
+            Err(error) if error.is_full() => CachedSend::Full {
+                peer_id: single_peer.peer_id.clone(),
+                send_queue: single_peer.send_queue.clone(),
+                message: error.into_inner(),
+            },
+            Err(error) => CachedSend::Disconnected {
+                peer_id: single_peer.peer_id.clone(),
+                error: error.into_send_error(),
+            },
+        }
+    }
+
+    async fn finish_cached_send(&self, cached_send: CachedSend) -> ZmqResult<SendResolution> {
+        match cached_send {
+            CachedSend::Sent => Ok(SendResolution::Sent),
+            CachedSend::Full {
+                peer_id,
+                mut send_queue,
+                message,
+            } => match send_queue.send(message).await {
+                Ok(()) => Ok(SendResolution::Sent),
+                Err(e) => {
+                    self.peer_disconnected(&peer_id);
+                    Err(e.into())
+                }
+            },
+            CachedSend::Disconnected { peer_id, error } => {
+                self.peer_disconnected(&peer_id);
+                Err(error.into())
+            }
+            CachedSend::Miss(message) => Ok(SendResolution::Miss(message)),
+        }
+    }
+
+    fn refresh_single_peer_cache(&self) {
+        let peer_count = self.peers.len();
+        self.peer_count.store(peer_count, Ordering::Release);
+
+        let mut single_peer = self.single_peer.lock();
+        if peer_count == 1 {
+            *single_peer = self.peers.begin_sync().map(|peer| SinglePeer {
+                peer_id: peer.key().clone(),
+                send_queue: peer.send_queue.clone(),
+            });
+        } else {
+            *single_peer = None;
         }
     }
 }
@@ -134,6 +269,8 @@ impl SocketBackend for GenericSocketBackend {
 
     fn shutdown(&self) {
         self.peers.clear_sync();
+        self.single_peer.lock().take();
+        self.peer_count.store(0, Ordering::Release);
         // Clear fair_queue streams to ensure TCP connections are closed
         // even when reconnect tasks still hold Arc references to the backend
         if let Some(inner) = &self.fair_queue_inner {
@@ -159,6 +296,7 @@ impl MultiPeerBackend for GenericSocketBackend {
                 },
             )
             .await;
+        self.refresh_single_peer_cache();
         let writer_backend = self.clone();
         let writer_peer_id = peer_id.clone();
         async_rt::task::spawn(async move {
@@ -182,6 +320,7 @@ impl MultiPeerBackend for GenericSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         self.peers.remove_sync(peer_id);
+        self.refresh_single_peer_cache();
         match &self.fair_queue_inner {
             None => {}
             Some(inner) => {
@@ -226,29 +365,79 @@ mod tests {
             .peers
             .upsert_async(peer_id.clone(), Peer { send_queue })
             .await;
+        backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());
         (peer_id, recv_queue)
     }
 
     #[crate::async_rt::test]
-    async fn test_send_round_robin_enqueues_into_peer_queue() {
+    async fn test_send_round_robin_uses_single_peer_cache() {
         let backend =
             GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
-        let (peer_id, mut recv_queue) =
+        let (_peer_id, mut recv_queue) =
             insert_peer(&backend, "peer-a".parse().expect("peer id")).await;
 
-        let queued_peer = backend
+        assert_eq!(1, backend.peer_count.load(Ordering::Acquire));
+        assert!(backend.single_peer.lock().is_some());
+
+        backend
             .send_round_robin(message_with_frame(b"payload"))
             .await
-            .expect("send to peer queue");
+            .expect("send through single peer cache");
 
-        assert_eq!(peer_id, queued_peer);
         let queued = recv_queue.next().await.expect("queued message");
         assert_eq!(Bytes::from_static(b"payload"), first_frame(queued));
     }
 
     #[crate::async_rt::test]
-    async fn test_send_round_robin_waits_when_peer_queue_is_full() {
+    async fn test_send_to_peer_uses_single_peer_cache_for_matching_identity() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::ROUTER, SocketOptions::default());
+        let (peer_id, mut recv_queue) =
+            insert_peer(&backend, "router-peer".parse().expect("peer id")).await;
+
+        assert_eq!(
+            Some(peer_id.clone()),
+            backend
+                .single_peer
+                .lock()
+                .as_ref()
+                .map(|peer| peer.peer_id.clone())
+        );
+
+        backend
+            .send_to_peer(&peer_id, message_with_frame(b"routed"))
+            .await
+            .expect("send to cached peer");
+
+        let queued = recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"routed"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_to_peer_routes_by_identity_with_multiple_peers() {
+        let backend =
+            GenericSocketBackend::with_options(None, SocketType::ROUTER, SocketOptions::default());
+        let (_first_peer_id, mut first_recv_queue) =
+            insert_peer(&backend, "router-peer-a".parse().expect("peer id")).await;
+        let (second_peer_id, mut second_recv_queue) =
+            insert_peer(&backend, "router-peer-b".parse().expect("peer id")).await;
+
+        assert_eq!(2, backend.peer_count.load(Ordering::Acquire));
+        assert!(backend.single_peer.lock().is_none());
+
+        backend
+            .send_to_peer(&second_peer_id, message_with_frame(b"routed-b"))
+            .await
+            .expect("send to selected peer");
+
+        assert!(first_recv_queue.try_recv().is_err());
+        let queued = second_recv_queue.next().await.expect("queued message");
+        assert_eq!(Bytes::from_static(b"routed-b"), first_frame(queued));
+    }
+
+    #[crate::async_rt::test]
+    async fn test_send_round_robin_waits_when_cached_sender_is_full() {
         let backend =
             GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
         let peer_id: PeerIdentity = "full-peer".parse().expect("peer id");
@@ -260,6 +449,7 @@ mod tests {
             .peers
             .upsert_async(peer_id.clone(), Peer { send_queue })
             .await;
+        backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());
 
         let send_future = backend.send_round_robin(message_with_frame(b"after-full"));
@@ -274,13 +464,13 @@ mod tests {
 
         let (send_result, (first, second)) = futures::join!(send_future, recv_future);
 
-        assert_eq!(peer_id, send_result.expect("send waits for capacity"));
+        send_result.expect("send waits for cached sender capacity");
         assert_eq!(Bytes::from_static(b"prefilled"), first_frame(first));
         assert_eq!(Bytes::from_static(b"after-full"), first_frame(second));
     }
 
     #[crate::async_rt::test]
-    async fn test_send_round_robin_disconnects_closed_peer_queue() {
+    async fn test_single_peer_cache_is_cleared_when_cached_sender_is_disconnected() {
         let backend =
             GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
         let peer_id: PeerIdentity = "closed-peer".parse().expect("peer id");
@@ -290,14 +480,17 @@ mod tests {
             .peers
             .upsert_async(peer_id.clone(), Peer { send_queue })
             .await;
+        backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());
 
         let error = backend
             .send_round_robin(message_with_frame(b"lost"))
             .await
-            .expect_err("closed peer queue should fail");
+            .expect_err("closed cached sender should fail");
 
         assert!(matches!(error, ZmqError::BufferFull(_)));
+        assert_eq!(0, backend.peer_count.load(Ordering::Acquire));
+        assert!(backend.single_peer.lock().is_none());
         assert!(backend.peers.get_async(&peer_id).await.is_none());
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -11,7 +11,7 @@ use crate::{Socket, SocketBackend};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 
 use std::collections::HashMap;
 use std::convert::TryInto;
@@ -105,13 +105,9 @@ impl SocketSend for RouterSocket {
             ));
         }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
-        match self.backend.peers.get_async(&peer_id).await {
-            Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
-                Ok(())
-            }
-            None => Err(ZmqError::Other("Destination client not found by identity")),
-        }
+        self.backend
+            .send_to_peer(&peer_id, Message::Message(message))
+            .await
     }
 }
 
@@ -180,13 +176,10 @@ impl SocketSend for RouterSendHalf {
             ));
         }
         let peer_id: PeerIdentity = message.pop_front().unwrap().try_into()?;
-        match self.inner.backend.peers.get_async(&peer_id).await {
-            Some(mut peer) => {
-                peer.send_queue.send(Message::Message(message)).await?;
-                Ok(())
-            }
-            None => Err(ZmqError::Other("Destination client not found by identity")),
-        }
+        self.inner
+            .backend
+            .send_to_peer(&peer_id, Message::Message(message))
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds the final performance-code split from #267: a single-peer fast path in `GenericSocketBackend` plus a shared ROUTER send helper.

The backend now caches the only peer's sender and uses `try_send` before falling back to the existing bounded async send path when the queue is full. ROUTER sends also go through a shared `send_to_peer` backend helper, so the same cached path applies when the destination identity matches the single connected peer.

The existing writer task still owns write errors and disconnect cleanup after queue delivery. This PR only changes how messages enter the per-peer queue.

## Performance Scorecard

I also reran the split-series benchmark scorecard because this is the last performance-code PR from the original optimization branch.

Methodology:

- Series baseline: `cbcb938` (`Add performance roadmap benchmark suite (#253)`).
- This PR: `1b5cc4e`.
- Criterion values below use slope point estimates.
- Socket and throughput benchmarks used:

```sh
ZMQRS_BENCH_SAMPLE_SIZE=10 \
ZMQRS_BENCH_WARMUP_MS=500 \
ZMQRS_BENCH_MEASUREMENT_MS=1000
```

- Codec was rerun on `cbcb938` with matching Criterion CLI settings because the old codec benchmark did not yet use the shared benchmark runtime configuration.
- A few old 64 KiB IPC benchmarks from `cbcb938` did not complete reliably, so they are not used for direct comparison.
- The full `compare_libzmq` target also includes libzmq reference cases; one current libzmq 64 KiB PUB/SUB case panicked in the benchmark harness, so the scorecard focuses on `zmqrs/*` rows and focused internal comparisons.

### This PR: Single-Peer Send Hot Path

`cbcb938` did not have the hotpath benchmark target. For this table, the baseline is the post-#273 upstream `master` at `9ecb520`, measured with the same command on both sides:

```sh
ZMQRS_BENCH_SAMPLE_SIZE=20 \
ZMQRS_BENCH_WARMUP_MS=1000 \
ZMQRS_BENCH_MEASUREMENT_MS=3000 \
cargo bench --bench compare_libzmq -- 'hotpath/native_socket_send/(push_pull|dealer_router)/(64|256)'
```

| Workload | Size | Baseline | This PR | Latency reduction | Speedup |
| --- | ---: | ---: | ---: | ---: | ---: |
| `push_pull` | 64 B | 649.15 ns | 381.37 ns | 41.2% | 1.70x |
| `push_pull` | 256 B | 565.04 ns | 366.84 ns | 35.1% | 1.54x |
| `dealer_router` | 64 B | 578.91 ns | 351.62 ns | 39.3% | 1.65x |
| `dealer_router` | 256 B | 476.11 ns | 369.71 ns | 22.3% | 1.29x |

### Full Split Series: Batch and Send-Pressure Wins

These compare `cbcb938` with this PR. Lower time is better.

| Benchmark | `cbcb938` | This PR | Time reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| PUB fanout send pressure, TCP, 1 sub, 256 B batch | 4.46 ms | 637.08 us | 85.7% | 7.00x |
| PUB fanout send pressure, TCP, 8 subs, 256 B batch | 38.23 ms | 3.79 ms | 90.1% | 10.08x |
| PUB fanout send pressure, TCP, 64 subs, 4 KiB batch | 347.59 ms | 81.22 ms | 76.6% | 4.28x |
| PUB fanout send pressure, IPC, 8 subs, 4 KiB batch | 23.63 ms | 12.54 ms | 46.9% | 1.88x |
| PUB fanout send pressure, IPC, 64 subs, 256 B batch | 92.74 ms | 26.29 ms | 71.6% | 3.53x |
| DEALER/ROUTER throughput, TCP, 256 B batch | 6.37 ms | 938.02 us | 85.3% | 6.80x |
| DEALER/ROUTER throughput, TCP, 4 KiB batch | 7.99 ms | 2.22 ms | 72.3% | 3.61x |
| DEALER/ROUTER throughput, IPC, 256 B batch | 2.19 ms | 878.55 us | 59.8% | 2.49x |
| DEALER/ROUTER throughput, IPC, 4 KiB batch | 9.32 ms | 7.03 ms | 24.6% | 1.33x |

### Focused Internal Comparisons

These targets were added during the split, so they do not exist on `cbcb938`. They compare the old strategy with the new strategy inside the current benchmark target.

| Benchmark | Baseline strategy | New strategy | Time reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Framed read, 1 msg, 256 B | 363.83 ns | 334.53 ns | 8.1% | 1.09x |
| Framed read, 1 msg, 4 KiB | 545.16 ns | 456.77 ns | 16.2% | 1.19x |
| Framed read, 1024 msgs, 4 KiB | 240.46 us | 168.69 us | 29.8% | 1.43x |
| Framed read, 1024 msgs, 64 KiB | 4.42 ms | 2.61 ms | 41.1% | 1.70x |
| PUB fanout first wake, 256 B | 5.99 us | 6.03 us | -0.6% | 0.99x |
| PUB fanout enqueue return, 256 B | 54.32 ns | 31.21 ns | 42.5% | 1.74x |
| PUB fanout full drop, 256 B | 30.05 ns | 27.68 ns | 7.9% | 1.09x |
| PUB fanout sustained batch, 1024 B | 1.89 ms | 1.08 ms | 42.7% | 1.74x |

### Delivered-Latency Spot Checks

There are two different delivered-latency views here:

- The `hotpath/*_delivered_latency` rows compare current native zeromq.rs against libzmq with the same benchmark shape. They are the low-latency sanity check for the current implementation.

As a tradeoff check, I also compared the legacy `zmqrs/*` lockstep `send().await` then `recv().await` rows from `cbcb938` against this PR. Small-message lockstep latency is mixed and can be slower after queued writes, because successful sends now mean local queue acceptance and the receiver delivery path includes the writer-task handoff. Larger fanout or payload cases improved. I am not using those legacy rows as the primary scorecard because they mix several split PRs and do not isolate this PR's hot path.

Current delivered-latency sanity check, measured with:

```sh
ZMQRS_BENCH_SAMPLE_SIZE=10 \
ZMQRS_BENCH_WARMUP_MS=500 \
ZMQRS_BENCH_MEASUREMENT_MS=1000 \
cargo bench --bench compare_libzmq -- 'hotpath/(native_delivered_latency|libzmq_delivered_latency)/(pub_fanout/subs=(1|4)|push_pull|dealer_router)/256'
```

| Benchmark | Native zeromq.rs | libzmq | Native latency reduction | Native speedup |
| --- | ---: | ---: | ---: | ---: |
| PUB fanout, 1 sub, 256 B | 24.964 us | 44.096 us | 43.4% | 1.77x |
| PUB fanout, 4 subs, 256 B | 48.052 us | 64.250 us | 25.2% | 1.34x |
| PUSH/PULL, 256 B | 23.581 us | 43.444 us | 45.7% | 1.84x |
| DEALER/ROUTER, 256 B | 48.581 us | 88.613 us | 45.2% | 1.82x |

### Codec Sanity Check

#269 was closed without merge, so the final split series does not intentionally carry the codec/message micro-optimizations. The codec benchmark is therefore effectively a sanity check rather than the main result.

| Benchmark | `cbcb938` | This PR | Time reduction | Speedup |
| --- | ---: | ---: | ---: | ---: |
| Encode 1 frame, 64 KiB | 1.32 us | 1.27 us | 3.8% | 1.04x |
| Decode 1 frame, 256 B | 168.27 ns | 165.57 ns | 1.6% | 1.02x |
| Decode 8 frames, 64 KiB | 9.34 us | 9.22 us | 1.4% | 1.01x |

## Validation

```sh
cargo fmt --check
cargo test --lib
cargo test --test router_dealer_compliant
cargo test --test router_split
cargo test --test dealer_split
cargo test --test req_router_dealer_rep
cargo test --test push_pull_timeout
cargo clippy --all-targets -- -D warnings
```

Benchmark targets run during the scorecard pass. Some `compare_libzmq` rows were rerun with filters after the unstable legacy IPC/libzmq cases above were identified.

```sh
cargo bench --bench codec
cargo bench --bench compare_libzmq
cargo bench --bench throughput
cargo bench --bench hotpath
cargo bench --bench framed_read
cargo bench --bench fanout_queue
```

GitHub Actions are green for this PR: Formatting, Check and Lint, MSRV Check, Nightly Check, Performance Smoke, Test, and Windows IPC.

`cargo clippy --all-targets -- -D warnings` passes locally. The command still prints the repository's existing command-line lint-name warnings for renamed or removed Clippy lints.
