### PR TITLE
Add peers-aware PUSH/PULL throughput rows

### DIFF
--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -17,7 +17,10 @@ use zeromq::{
 };
 
 const BATCH_SIZE: usize = 1024;
+const PUSH_PULL_BATCH_SIZE: usize = 8192;
 const PIPELINE_SIZES: &[usize] = &[256, 4096];
+const PUSH_PULL_SIZES: &[usize] = &[128, 2048, 8192];
+const PEER_COUNTS: &[usize] = &[1, 8];
 const SUB_COUNTS: &[usize] = &[1, 8, 64];
 
 static IPC_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -296,6 +299,92 @@ fn bench_libzmq_pub_pipelined_one(
         for sub in &subs {
             black_box(sub.rx_done.recv().expect("sub done"));
         }
+    });
+}
+
+fn bench_zmqrs_push_pull_pipelined(c: &mut Criterion) {
+    let rt = build_rt();
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        for &peers in PEER_COUNTS {
+            let mut group = c.benchmark_group(format!(
+                "zmqrs/throughput/push_pull/{transport}/peers={peers}"
+            ));
+            bench_runtime::configure_group(&mut group);
+            for &msg_size in PUSH_PULL_SIZES {
+                group.throughput(Throughput::Bytes((PUSH_PULL_BATCH_SIZE * msg_size) as u64));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(msg_size),
+                    &msg_size,
+                    |b, &s| {
+                        bench_zmqrs_push_pull_pipelined_one(b, &rt, peers, s, transport);
+                    },
+                );
+            }
+            group.finish();
+        }
+    }
+}
+
+fn bench_zmqrs_push_pull_pipelined_one(
+    b: &mut criterion::Bencher<'_>,
+    rt: &BenchRuntime,
+    peers: usize,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("zmqrs-pushpull-{peers}-{msg_size}"), transport);
+    let (mut pull, pushes) = rt.block_on(async {
+        let mut pull = PullSocket::new();
+        let bound = pull.bind(&endpoint).await.expect("pull bind").to_string();
+        let mut pushes = Vec::with_capacity(peers);
+        for _ in 0..peers {
+            let mut push = PushSocket::new();
+            push.connect(bound.as_str()).await.expect("push connect");
+            pushes.push(push);
+        }
+
+        let sync = ZmqMessage::from(Bytes::from_static(b"sync"));
+        for push in &mut pushes {
+            push.send(sync.clone()).await.expect("push sync");
+        }
+        for _ in 0..peers {
+            black_box(pull.recv().await.expect("pull sync"));
+        }
+        (pull, pushes)
+    });
+
+    let mut pushes = Some(pushes);
+    let payload = Bytes::from(vec![0xCD; msg_size]);
+    b.iter(|| {
+        let mut active_pushes = pushes.take().expect("push sockets");
+        rt.block_on(async {
+            let per_peer = PUSH_PULL_BATCH_SIZE / active_pushes.len();
+            let recv_count = per_peer * active_pushes.len();
+            let send_handles: Vec<_> = active_pushes
+                .drain(..)
+                .map(|mut push| {
+                    let payload = payload.clone();
+                    task::spawn(async move {
+                        for _ in 0..per_peer {
+                            push.send(ZmqMessage::from(payload.clone()))
+                                .await
+                                .expect("push send");
+                        }
+                        push
+                    })
+                })
+                .collect();
+
+            for _ in 0..recv_count {
+                black_box(pull.recv().await.expect("pull recv"));
+            }
+
+            let mut returned_pushes = Vec::with_capacity(send_handles.len());
+            for handle in send_handles {
+                returned_pushes.push(handle.await.expect("push task"));
+            }
+            pushes.replace(returned_pushes);
+        });
     });
 }
 
@@ -632,13 +721,116 @@ fn bench_libzmq_push_pull_one_way_one(
     });
 }
 
+fn bench_libzmq_push_pull_pipelined(c: &mut Criterion) {
+    for transport in bench_runtime::selected_transports(bench_runtime::DEFAULT_TRANSPORTS) {
+        for &peers in PEER_COUNTS {
+            let mut group = c.benchmark_group(format!(
+                "libzmq/throughput/push_pull/{transport}/peers={peers}"
+            ));
+            bench_runtime::configure_group(&mut group);
+            for &msg_size in PUSH_PULL_SIZES {
+                group.throughput(Throughput::Bytes((PUSH_PULL_BATCH_SIZE * msg_size) as u64));
+                group.bench_with_input(
+                    BenchmarkId::from_parameter(msg_size),
+                    &msg_size,
+                    |b, &s| {
+                        bench_libzmq_push_pull_pipelined_one(b, peers, s, transport);
+                    },
+                );
+            }
+            group.finish();
+        }
+    }
+}
+
+fn bench_libzmq_push_pull_pipelined_one(
+    b: &mut criterion::Bencher<'_>,
+    peers: usize,
+    msg_size: usize,
+    transport: &str,
+) {
+    let endpoint = endpoint(&format!("libzmq-pushpull-{peers}-{msg_size}"), transport);
+    let ctx = zmq2::Context::new();
+    let pull = ctx.socket(zmq2::PULL).expect("pull socket");
+    let hwm = (PUSH_PULL_BATCH_SIZE * 4) as i32;
+    pull.set_rcvhwm(hwm).expect("pull rcvhwm");
+    pull.set_rcvtimeo(100).expect("pull timeout");
+    pull.bind(&endpoint).expect("pull bind");
+    let bound = pull.get_last_endpoint().expect("last_endpoint").unwrap();
+
+    struct PushHandle {
+        tx_drive: mpsc::Sender<usize>,
+        rx_done: mpsc::Receiver<()>,
+        thread: thread::JoinHandle<()>,
+    }
+
+    impl PushHandle {
+        fn stop(self) {
+            let Self {
+                tx_drive,
+                rx_done: _rx_done,
+                thread,
+            } = self;
+            drop(tx_drive);
+            thread.join().expect("push thread");
+        }
+    }
+
+    let mut pushes = Vec::with_capacity(peers);
+    for _ in 0..peers {
+        let ctx = ctx.clone();
+        let bound = bound.clone();
+        let payload = vec![0xCD; msg_size];
+        let (tx_drive, rx_drive) = mpsc::channel();
+        let (tx_done, rx_done) = mpsc::channel();
+        let thread = thread::spawn(move || {
+            let push = ctx.socket(zmq2::PUSH).expect("push socket");
+            push.set_sndhwm(hwm).expect("push sndhwm");
+            push.connect(&bound).expect("push connect");
+            while let Ok(n) = rx_drive.recv() {
+                for _ in 0..n {
+                    push.send(&payload, 0).expect("push send");
+                }
+                if tx_done.send(()).is_err() {
+                    break;
+                }
+            }
+        });
+        pushes.push(PushHandle {
+            tx_drive,
+            rx_done,
+            thread,
+        });
+    }
+
+    thread::sleep(Duration::from_millis(200));
+    let per_peer = PUSH_PULL_BATCH_SIZE / peers;
+    b.iter(|| {
+        for push in &pushes {
+            push.tx_drive.send(per_peer).expect("drive push");
+        }
+        for _ in 0..(per_peer * peers) {
+            black_box(pull.recv_bytes(0).expect("pull recv"));
+        }
+        for push in &pushes {
+            push.rx_done.recv().expect("push done");
+        }
+    });
+
+    for push in pushes {
+        push.stop();
+    }
+}
+
 criterion_group!(
     benches,
     bench_zmqrs_pub_pipelined,
+    bench_zmqrs_push_pull_pipelined,
     bench_zmqrs_dealer_router_pipelined,
     bench_zmqrs_dealer_router_one_way,
     bench_zmqrs_push_pull_one_way,
     bench_libzmq_pub_pipelined,
+    bench_libzmq_push_pull_pipelined,
     bench_libzmq_dealer_router_pipelined,
     bench_libzmq_dealer_router_one_way,
     bench_libzmq_push_pull_one_way,

--- a/perf-suite.json
+++ b/perf-suite.json
@@ -25,6 +25,30 @@
         "rounds": 1
       }
     },
+    "pushpull-omq": {
+      "description": "Focused PUSH/PULL throughput profile matching the standard OMQ peer and message-size grid.",
+      "criterion_args": ["--sample-size", "10", "--measurement-time", "1", "--warm-up-time", "1"],
+      "zmqrs_runtimes": ["tokio-runtime"],
+      "benches": [
+        {
+          "name": "throughput",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/throughput/push_pull/{transport}/peers={peers}/{size}"
+          ],
+          "sizes": [128, 2048, 8192],
+          "peers": [1, 8]
+        }
+      ],
+      "omq": {
+        "packages": ["omq-tokio", "omq-compio"],
+        "benches": ["push_pull"],
+        "sizes": [128, 2048, 8192],
+        "peers": [1, 8],
+        "round_ms": 100,
+        "rounds": 1
+      }
+    },
     "standard": {
       "description": "Day-to-day comparison profile for decision making before and after hot-path changes.",
       "criterion_args": ["--sample-size", "10", "--measurement-time", "3", "--warm-up-time", "1"],
@@ -51,6 +75,16 @@
           ],
           "sizes": [256, 4096],
           "subs": [1, 8]
+        },
+        {
+          "id": "throughput_push_pull_omq_key",
+          "name": "throughput",
+          "implementations": ["zmqrs", "libzmq"],
+          "templates": [
+            "{impl}/throughput/push_pull/{transport}/peers={peers}/{size}"
+          ],
+          "sizes": [8192],
+          "peers": [8]
         },
         {
           "name": "codec",

--- a/scripts/run_perf_suite.py
+++ b/scripts/run_perf_suite.py
@@ -101,7 +101,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--repo-root", default=".")
     parser.add_argument("--candidate-path", help="zmq.rs checkout to benchmark")
     parser.add_argument("--config", default=DEFAULT_CONFIG)
-    parser.add_argument("--profile", choices=["smoke", "standard", "full"], default="standard")
+    parser.add_argument(
+        "--profile",
+        choices=["smoke", "pushpull-omq", "standard", "full"],
+        default="standard",
+    )
     parser.add_argument("--impl", default="zmqrs,libzmq")
     parser.add_argument("--transport", default="tcp,ipc")
     parser.add_argument("--runtime", help="Comma-separated zmq.rs runtime features")
@@ -294,7 +298,7 @@ def run_criterion_entry(
     env = os.environ.copy()
     env.update(criterion_env(criterion_args))
     run_command(cmd, cwd=candidate_root, env=env, manifest=manifest, dry_run=args.dry_run)
-    artifact_dir = run_dir / "artifacts" / safe_name(f"{implementation}-{runtime}") / bench["name"]
+    artifact_dir = run_dir / "artifacts" / safe_name(f"{implementation}-{runtime}") / artifact_name(bench)
     if not args.dry_run and target_criterion.exists():
         shutil.copytree(target_criterion, artifact_dir / "criterion")
         rows = criterion_rows(
@@ -332,6 +336,7 @@ def expand_filters(bench: dict[str, Any], implementation: str, transports: list[
         "transport": transports,
         "size": bench.get("sizes", [None]),
         "subs": bench.get("subs", [None]),
+        "peers": bench.get("peers", [None]),
         "frames": bench.get("frames", [None]),
     }
     filters: list[str] = []
@@ -558,6 +563,10 @@ def write_json(path: Path, data: dict[str, Any]) -> None:
 
 def safe_name(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+
+
+def artifact_name(bench: dict[str, Any]) -> str:
+    return safe_name(str(bench.get("id", bench["name"])))
 
 
 if __name__ == "__main__":

--- a/scripts/test_run_perf_suite.py
+++ b/scripts/test_run_perf_suite.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Unit tests for run_perf_suite.py configuration expansion."""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT / "scripts" / "run_perf_suite.py"
+
+spec = importlib.util.spec_from_file_location("run_perf_suite", MODULE_PATH)
+assert spec is not None
+run_perf_suite = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(run_perf_suite)
+
+
+class RunPerfSuiteTests(unittest.TestCase):
+    def test_expand_filters_supports_peers_dimension(self) -> None:
+        bench = {
+            "templates": ["{impl}/throughput/push_pull/{transport}/peers={peers}/{size}"],
+            "sizes": [8192],
+            "peers": [8],
+        }
+
+        self.assertEqual(
+            run_perf_suite.expand_filters(bench, "zmqrs", ["tcp", "ipc"]),
+            [
+                "zmqrs/throughput/push_pull/ipc/peers=8/8192",
+                "zmqrs/throughput/push_pull/tcp/peers=8/8192",
+            ],
+        )
+
+    def test_standard_profile_selects_omq_key_push_pull_rows(self) -> None:
+        config = run_perf_suite.load_config(REPO_ROOT / "perf-suite.json")
+        filters = [
+            item
+            for bench in config["profiles"]["standard"]["benches"]
+            for item in run_perf_suite.expand_filters(bench, "zmqrs", ["tcp", "ipc"])
+        ]
+
+        self.assertIn("zmqrs/throughput/push_pull/tcp/peers=8/8192", filters)
+        self.assertIn("zmqrs/throughput/push_pull/ipc/peers=8/8192", filters)
+
+    def test_duplicate_bench_entries_can_use_distinct_artifact_names(self) -> None:
+        self.assertEqual(run_perf_suite.artifact_name({"name": "throughput"}), "throughput")
+        self.assertEqual(
+            run_perf_suite.artifact_name(
+                {"id": "throughput_push_pull_omq_key", "name": "throughput"}
+            ),
+            "throughput_push_pull_omq_key",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This creates a fresh benchmark-only PR inspired by the old #263 cloud-agent branch.

Changes:

- add peers-aware `throughput/push_pull/{transport}/peers={peers}/{size}` rows for zmq.rs and libzmq
- add a focused `pushpull-omq` perf-suite profile that matches the OMQ PUSH/PULL peer and message-size grid
- include the key `peers=8,size=8192` PUSH/PULL rows in the standard profile
- teach `scripts/run_perf_suite.py` to expand `{peers}` filters and avoid artifact collisions when a profile has multiple entries for the same bench target
- add copied/refreshed unit coverage for perf-suite filter expansion and artifact naming
- keep the new libzmq PUSH/PULL benchmark workers bounded: receive timeouts prevent hangs and worker threads are joined at teardown

## Notes

This is measurement coverage only. It does not change socket behavior or claim a new performance result.

## Validation

```text
rustfmt --edition 2021 --check benches/throughput.rs
python3 -m json.tool perf-suite.json >/dev/null
python3 -m unittest scripts.test_run_perf_suite
git diff --check
cargo bench --bench throughput --no-run
cargo bench --bench throughput --no-run --no-default-features --features async-std-runtime,all-transport
cargo bench --bench throughput --no-run --no-default-features --features async-dispatcher-runtime,all-transport,async-dispatcher-macros
python3 scripts/run_perf_suite.py --dry-run --profile pushpull-omq --impl zmqrs,libzmq --transport tcp --run-id dry-run-pushpull-omq --repo-root .
```
