### PR TITLE
Tune Tokio TCP socket buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85.0"
 
 [features]
 default = ["tokio-runtime", "all-transport"]
-tokio-runtime = ["tokio", "tokio-util"]
+tokio-runtime = ["tokio", "tokio-util", "dep:socket2"]
 async-std-runtime = ["async-std"]
 async-dispatcher-runtime = ["async-std", "async-dispatcher"]
 async-dispatcher-macros = ["async-dispatcher/macros"]
@@ -45,6 +45,7 @@ once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
 async-std = { version = "1", features = ["attributes"], optional = true }
+socket2 = { version = "0.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 win_uds = { version = "=0.2.2", features = ["async"], optional = true }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -14,12 +14,16 @@ use crate::ZmqResult;
 
 use futures::{select, FutureExt};
 
+#[cfg(feature = "tokio-runtime")]
+const TCP_SOCKET_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
 pub(crate) async fn connect(host: &Host, port: Port) -> ZmqResult<(FramedIo, Endpoint)> {
     let raw_socket = TcpStream::connect((host.to_string().as_str(), port)).await?;
     // For some reason set_nodelay doesn't work on windows. See
     // https://github.com/zeromq/zmq.rs/issues/148 for details
     #[cfg(not(windows))]
     raw_socket.set_nodelay(true)?;
+    tune_socket_buffers(&raw_socket);
     let peer_addr = raw_socket.peer_addr()?;
 
     Ok((make_framed(raw_socket), Endpoint::from_tcp_addr(peer_addr)))
@@ -45,7 +49,10 @@ where
                         .and_then(|(raw_socket, remote_addr)| {
                             raw_socket
                                 .set_nodelay(true)
-                                .map(|_| (raw_socket, remote_addr))
+                                .map(|_| {
+                                    tune_socket_buffers(&raw_socket);
+                                    (raw_socket, remote_addr)
+                                })
                         })
                         .map(|(raw_socket, remote_addr)| {
                             (
@@ -78,3 +85,17 @@ where
         AcceptStopHandle(TaskHandle::new(stop_channel, task_handle)),
     ))
 }
+
+#[cfg(feature = "tokio-runtime")]
+fn tune_socket_buffers(raw_socket: &TcpStream) {
+    let socket = socket2::SockRef::from(raw_socket);
+    if let Err(error) = socket.set_recv_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP receive buffer size: {error}");
+    }
+    if let Err(error) = socket.set_send_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP send buffer size: {error}");
+    }
+}
+
+#[cfg(not(feature = "tokio-runtime"))]
+fn tune_socket_buffers(_raw_socket: &TcpStream) {}


### PR DESCRIPTION
## Summary

This creates a fresh, narrow PR inspired by the old #265 cloud-agent branch.

Changes:

- request 4 MiB TCP receive and send socket buffers for Tokio TCP connections
- apply the tuning on both outgoing `connect()` sockets and accepted listener sockets
- keep the tuning best-effort by logging failures at debug level and continuing connection setup
- leave non-Tokio runtime builds on the existing behavior through a no-op helper

## Notes

This intentionally preserves socket semantics and public API shape. The only behavior change is the best-effort OS socket-buffer request on the Tokio TCP transport path.

## Validation

```text
rustfmt --edition 2021 --check src/transport/tcp.rs
cargo check --features tokio-runtime,tcp-transport
cargo check --no-default-features --features async-std-runtime,tcp-transport
cargo check --no-default-features --features async-dispatcher-runtime,tcp-transport,async-dispatcher-macros
git diff --check
cargo test --test connect --test large_message
```
