### PR TITLE
Trim dependency features and upgrade deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,25 +25,29 @@ bench-internals = []
 
 [dependencies]
 async-dispatcher = { version = "0.1", optional = true }
-thiserror = "1"
-futures = "0.3"
+thiserror = "2"
+futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 # write_queue.rs uses mpsc::Receiver::try_recv, added in futures-channel 0.3.32.
 # The futures meta-crate's "0.3" range would otherwise allow 0.3.31, which lacks it.
-futures-channel = "0.3.32"
+futures-channel = { version = "0.3.32", default-features = false, features = ["std"] }
 async-trait = "0.1"
 parking_lot = "0.12"
-rand = "0.9"
+rand = { version = "0.10", default-features = false, features = ["thread_rng"] }
 bytes = "1"
-tokio = { version = "1", features = ["full"], optional = true }
-tokio-util = { version = "0.7", features = ["compat"], optional = true }
-num-traits = "0.2"
-scc = "3.4.4"
+tokio = { version = "1", default-features = false, features = [
+    "fs",
+    "io-util",
+    "macros",
+    "net",
+    "rt",
+    "rt-multi-thread",
+    "time",
+], optional = true }
+tokio-util = { version = "0.7", default-features = false, features = ["compat"], optional = true }
+scc = "3.7"
 crossbeam-queue = "0.3"
-uuid = { version = "1", features = ["v4"] }
-regex = { version = "1", default-features = false, features = [
-    "std",
-    "unicode-perl",
-] }
+uuid = { version = "1", default-features = false, features = ["v4"] }
+regex = { version = "1", default-features = false, features = ["std"] }
 once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
@@ -56,8 +60,10 @@ win_uds = { version = "=0.2.2", features = ["async"], optional = true }
 [dev-dependencies]
 async-dispatcher = { version = "0.1", features = ["macros"] }
 chrono = "0.4"
-criterion = "0.5"
+criterion = "0.7"
+futures = "0.3"
 pretty_env_logger = "0.5"
+tokio = { version = "1", features = ["full"] }
 zmq2 = "0.5"
 hex = "0.4"
 

--- a/benches/codec.rs
+++ b/benches/codec.rs
@@ -4,7 +4,8 @@ mod bench_runtime;
 
 use asynchronous_codec::{Decoder, Encoder};
 use bytes::{Bytes, BytesMut};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 
 use zeromq::{
     __bench::{Message, ZmqCodec},

--- a/benches/compare_libzmq.rs
+++ b/benches/compare_libzmq.rs
@@ -9,8 +9,9 @@ mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::future;
+use std::hint::black_box;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;

--- a/benches/fanout_queue.rs
+++ b/benches/fanout_queue.rs
@@ -4,10 +4,11 @@ mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use crossbeam_queue::ArrayQueue;
 use futures::channel::mpsc;
 use futures::StreamExt;
+use std::hint::black_box;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Instant;

--- a/benches/framed_read.rs
+++ b/benches/framed_read.rs
@@ -5,8 +5,9 @@ mod bench_runtime;
 
 use asynchronous_codec::{Encoder, FramedRead};
 use bytes::{Bytes, BytesMut};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use futures::{executor::block_on, io::Cursor, Stream, StreamExt};
+use std::hint::black_box;
 
 use zeromq::{
     __bench::{zmq_framed_read, Message, ZmqCodec, ZmqFramedRead},

--- a/benches/hotpath.rs
+++ b/benches/hotpath.rs
@@ -5,14 +5,13 @@ mod bench_runtime;
 use async_trait::async_trait;
 use bench_runtime::BenchRuntime;
 use bytes::Bytes;
-use criterion::{
-    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
-};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
 use futures::channel::mpsc;
 use futures::{AsyncWrite, Stream, StreamExt};
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 use std::convert::TryFrom;
+use std::hint::black_box;
 use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/benches/throughput.rs
+++ b/benches/throughput.rs
@@ -4,8 +4,9 @@ mod bench_runtime;
 
 use bench_runtime::BenchRuntime;
 use bytes::Bytes;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::{channel::oneshot, select, FutureExt};
+use std::hint::black_box;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc};
 use std::thread;

--- a/examples/stock_server.rs
+++ b/examples/stock_server.rs
@@ -1,6 +1,6 @@
 mod async_helpers;
 
-use rand::Rng;
+use rand::RngExt;
 use std::time::Duration;
 use zeromq::*;
 

--- a/examples/task_ventilator.rs
+++ b/examples/task_ventilator.rs
@@ -1,6 +1,6 @@
 mod async_helpers;
 
-use rand::Rng;
+use rand::RngExt;
 use std::error::Error;
 use std::io::{BufRead, BufReader};
 

--- a/examples/weather_server.rs
+++ b/examples/weather_server.rs
@@ -1,6 +1,6 @@
 mod async_helpers;
 
-use rand::Rng;
+use rand::RngExt;
 use std::time::Duration;
 
 use zeromq::*;

--- a/examples/xpub_weather_server.rs
+++ b/examples/xpub_weather_server.rs
@@ -1,6 +1,6 @@
 mod async_helpers;
 
-use rand::Rng;
+use rand::RngExt;
 use std::sync::Arc;
 use std::time::Duration;
 

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -17,7 +17,7 @@ pub use transport::Transport;
 pub type Port = u16;
 
 static TRANSPORT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([[:lower:]]+)://(.+)$").unwrap());
-static HOST_PORT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.+):(\d+)$").unwrap());
+static HOST_PORT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.+):([0-9]+)$").unwrap());
 
 /// Represents a ZMQ Endpoint.
 ///

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -13,7 +13,7 @@ use crate::MultiPeerBackend;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{FutureExt, StreamExt};
-use rand::Rng;
+use rand::RngExt;
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@ use crate::*;
 
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
-use rand::Rng;
+use rand::RngExt;
 
 use std::convert::{TryFrom, TryInto};
 use std::future::Future;


### PR DESCRIPTION
## Summary

- Disable unnecessary production default features and keep dev dependencies broad for tests and benchmarks.
- Upgrade thiserror, rand, scc, and criterion.
- Adapt rand 0.10 and Criterion 0.7 API usage.
- Restrict endpoint port matching to ASCII digits after removing the regex unicode-perl feature.

## Validation

- cargo check
- cargo check --offline --no-default-features --features tokio-runtime,tcp-transport
- cargo check --no-default-features --features async-std-runtime,all-transport
- cargo check --no-default-features --features async-dispatcher-runtime,async-dispatcher-macros,all-transport
- cargo check --examples
- cargo test --no-run
- cargo test endpoint
- cargo bench --no-run
- cargo fmt --check