### PR TITLE
Tune Tokio TCP socket buffers for PUSH/PULL throughput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.85.0"
 
 [features]
 default = ["tokio-runtime", "all-transport"]
-tokio-runtime = ["tokio", "tokio-util"]
+tokio-runtime = ["tokio", "tokio-util", "dep:socket2"]
 async-std-runtime = ["async-std"]
 async-dispatcher-runtime = ["async-std", "async-dispatcher"]
 async-dispatcher-macros = ["async-dispatcher/macros"]
@@ -45,6 +45,7 @@ once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
 async-std = { version = "1", features = ["attributes"], optional = true }
+socket2 = { version = "0.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 win_uds = { version = "=0.2.2", features = ["async"], optional = true }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -14,12 +14,16 @@ use crate::ZmqResult;
 
 use futures::{select, FutureExt};
 
+#[cfg(feature = "tokio-runtime")]
+const TCP_SOCKET_BUFFER_SIZE: usize = 4 * 1024 * 1024;
+
 pub(crate) async fn connect(host: &Host, port: Port) -> ZmqResult<(FramedIo, Endpoint)> {
     let raw_socket = TcpStream::connect((host.to_string().as_str(), port)).await?;
     // For some reason set_nodelay doesn't work on windows. See
     // https://github.com/zeromq/zmq.rs/issues/148 for details
     #[cfg(not(windows))]
     raw_socket.set_nodelay(true)?;
+    tune_socket_buffers(&raw_socket);
     let peer_addr = raw_socket.peer_addr()?;
 
     Ok((make_framed(raw_socket), Endpoint::from_tcp_addr(peer_addr)))
@@ -45,7 +49,10 @@ where
                         .and_then(|(raw_socket, remote_addr)| {
                             raw_socket
                                 .set_nodelay(true)
-                                .map(|_| (raw_socket, remote_addr))
+                                .map(|_| {
+                                    tune_socket_buffers(&raw_socket);
+                                    (raw_socket, remote_addr)
+                                })
                         })
                         .map(|(raw_socket, remote_addr)| {
                             (
@@ -78,3 +85,17 @@ where
         AcceptStopHandle(TaskHandle::new(stop_channel, task_handle)),
     ))
 }
+
+#[cfg(feature = "tokio-runtime")]
+fn tune_socket_buffers(raw_socket: &TcpStream) {
+    let socket = socket2::SockRef::from(raw_socket);
+    if let Err(error) = socket.set_recv_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP receive buffer size: {error}");
+    }
+    if let Err(error) = socket.set_send_buffer_size(TCP_SOCKET_BUFFER_SIZE) {
+        log::debug!("failed to set TCP send buffer size: {error}");
+    }
+}
+
+#[cfg(not(feature = "tokio-runtime"))]
+fn tune_socket_buffers(_raw_socket: &TcpStream) {}


### PR DESCRIPTION
The Tokio TCP transport left send and receive socket buffers at the OS default, which capped in-flight bytes well below what the PUSH/PULL fanout path can drive. This requests 4 MiB send and receive buffers on every TCP connection, both on the connect path and the accept path, right after the existing `set_nodelay`.

## Design decision

Buffer tuning is best-effort. If the platform refuses the requested size, connection setup still proceeds and the failure is logged at debug. Connection success behavior does not change. The whole point is to ask for more buffer headroom where the OS allows it, never to make a larger buffer a precondition for a working socket.

The change is Tokio-only. `socket2` is added as an optional dependency wired into the `tokio-runtime` feature via `dep:socket2`. The async-std and async-dispatcher runtimes keep a no-op `tune_socket_buffers` and pull in no new dependency. `socket2::SockRef::from` borrows the live Tokio `TcpStream`, so there is no extra fd dup or ownership transfer.

## Behavioral coverage

| Build | tune_socket_buffers | socket2 dependency |
| --- | --- | --- |
| tokio-runtime | requests 4 MiB recv + send, best-effort | linked |
| async-std-runtime | no-op | not linked |
| async-dispatcher-runtime | no-op | not linked |

## Benchmark evidence

Re-measured against pre-#277 master (`90944d2`), Apple M3 Max, macOS arm64. The current `master` also includes #277 (`c7a318a`), which only changes REQ recv cancel-safety production code and test coverage, not the TCP transport or these throughput benchmark paths. Criterion baseline comparison, candidate branch vs master, TCP only, sample size 20, 3s measurement, 1s warmup. Each iteration moves a fixed batch, so higher throughput is lower elapsed time.

| workload | master | branch | change |
|---|---:|---:|---:|
| `push_pull_one_way/tcp/256` | 382.8 MiB/s | 527.6 MiB/s | +19.2% (p < 0.05) |
| `push_pull_one_way/tcp/4096` | 4.71 GiB/s | 5.19 GiB/s | +9.2% (p < 0.05) |
| `dealer_router_one_way/tcp/256` | 357.2 MiB/s | 454.8 MiB/s | +34.4% (p < 0.05) |
| `dealer_router_one_way/tcp/4096` | 4.51 GiB/s | 4.60 GiB/s | within noise (p = 0.21) |

This is a single back-to-back comparison run. The small-message rows carry wide Criterion confidence intervals (the 256B intervals span roughly +9% to +62%), so read the point estimates as directional; the sign and significance held across the run. The 4096B dealer/router row sits within noise.

On-master TCP throughput workloads are single-peer one-way. The original PR reported a larger gain on a `push_pull/tcp/peers=8/8192` row (1.43 -> 3.80 GiB/s) on different hardware, but that peers-aware grid is not on master yet (it arrives with #278), so it is not reproduced here. libzmq remains ahead on raw TCP throughput.

Recreates #265. Supersedes #279, which carries the identical change.

