### PR TITLE
Add FairQueue single-peer fast path

### DIFF
--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -14,6 +14,11 @@ pub(crate) struct QueueInner<S, K: Clone> {
     counter: atomic::AtomicUsize,
     ready_queue: BinaryHeap<ReadyEvent<K>>,
     queued: HashSet<K>,
+    /// Holds the sole connected stream so it can be polled directly, skipping
+    /// the multi-peer ready-queue bookkeeping. Promotion to `streams` is
+    /// one-way: once a second peer connects the queue stays on the multi-peer
+    /// path for the rest of its life, even if peers later drop back to one.
+    /// Re-demoting would add churn-sensitive state transitions for no real gain.
     single_stream: Option<(K, Pin<Box<S>>)>,
     streams: HashMap<K, Pin<Box<S>>>,
     waker: Option<Waker>,
@@ -516,6 +521,72 @@ mod test {
         assert_eq!(fair_queue.next().await, Some((1, "a1")));
         assert_eq!(fair_queue.next().await, None);
         assert_eq!(disconnect_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_fair_queue_promotes_single_stream_pending_across_second_insert() {
+        use futures::task::{waker_ref, ArcWake};
+
+        struct CountingWaker {
+            wakes: AtomicUsize,
+        }
+        impl ArcWake for CountingWaker {
+            fn wake_by_ref(arc_self: &Arc<Self>) {
+                arc_self.wakes.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let counting = Arc::new(CountingWaker {
+            wakes: AtomicUsize::new(0),
+        });
+        let waker = waker_ref(&counting);
+        let mut cx = Context::from_waker(&waker);
+
+        let mut fair_queue: FairQueue<UnifiedStream, &'static str> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(
+                "single",
+                UnifiedStream::Test(TestStream::pending_once(&["a1"])),
+            );
+            assert!(lock.single_stream.is_some());
+        }
+
+        // The single stream is Pending on its first poll, so the queue parks on
+        // the fast path rather than reporting end-of-stream.
+        assert!(matches!(
+            Pin::new(&mut fair_queue).poll_next(&mut cx),
+            Poll::Pending
+        ));
+
+        // A second peer connects while the single stream is still pending. This
+        // must move both streams onto the multi-peer path and wake the task that
+        // parked on the fast path, or a real executor would never re-poll.
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert("second", UnifiedStream::Test(TestStream::ready(&["b1"])));
+            assert!(lock.single_stream.is_none());
+            assert_eq!(lock.streams.len(), 2);
+            assert_eq!(lock.ready_queue.len(), 2);
+        }
+        assert!(
+            counting.wakes.load(Ordering::SeqCst) >= 1,
+            "second insert must wake the task parked on the single-stream fast path"
+        );
+
+        // After promotion both streams deliver via the multi-peer path.
+        let mut results = Vec::new();
+        for _ in 0..10 {
+            match Pin::new(&mut fair_queue).poll_next(&mut cx) {
+                Poll::Ready(Some(item)) => results.push(item),
+                Poll::Ready(None) => break,
+                Poll::Pending => {}
+            }
+        }
+        results.sort_unstable();
+        assert_eq!(results, vec![("second", "b1"), ("single", "a1")]);
     }
 
     #[test]

--- a/src/fair_queue.rs
+++ b/src/fair_queue.rs
@@ -14,6 +14,7 @@ pub(crate) struct QueueInner<S, K: Clone> {
     counter: atomic::AtomicUsize,
     ready_queue: BinaryHeap<ReadyEvent<K>>,
     queued: HashSet<K>,
+    single_stream: Option<(K, Pin<Box<S>>)>,
     streams: HashMap<K, Pin<Box<S>>>,
     waker: Option<Waker>,
     /// Callback invoked when a stream ends (peer disconnected).
@@ -23,14 +24,41 @@ pub(crate) struct QueueInner<S, K: Clone> {
 
 impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     pub fn insert(&mut self, k: K, s: S) {
-        self.streams.insert(k.clone(), Box::pin(s));
-        self.push_ready(k);
+        let stream = Box::pin(s);
+        match self.single_stream.take() {
+            Some((single_key, _single_stream)) if single_key == k => {
+                self.single_stream = Some((k, stream));
+            }
+            Some((single_key, single_stream)) => {
+                // Restore the fair-queue path once a second peer connects so the
+                // single-peer fast path does not affect multi-peer polling semantics.
+                self.streams.insert(single_key.clone(), single_stream);
+                self.push_ready(single_key);
+                self.streams.insert(k.clone(), stream);
+                self.push_ready(k);
+            }
+            None if self.streams.is_empty() => {
+                self.single_stream = Some((k, stream));
+            }
+            None => {
+                self.streams.insert(k.clone(), stream);
+                self.push_ready(k);
+            }
+        }
         if let Some(w) = &self.waker {
             w.wake_by_ref();
         }
     }
 
     pub fn remove(&mut self, k: &K) {
+        if self
+            .single_stream
+            .as_ref()
+            .is_some_and(|(single_key, _)| single_key == k)
+        {
+            self.single_stream = None;
+            return;
+        }
         self.streams.remove(k);
         self.queued.remove(k);
     }
@@ -40,6 +68,7 @@ impl<S, K: Clone + Eq + Hash> QueueInner<S, K> {
     /// Used during shutdown to ensure TCP connections are closed even when
     /// other components (like reconnect tasks) hold Arc references to the inner.
     pub fn clear(&mut self) {
+        self.single_stream = None;
         self.streams.clear();
         self.ready_queue.clear();
         self.queued.clear();
@@ -118,6 +147,31 @@ where
     #[allow(clippy::needless_continue)]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let fair_queue = self.get_mut();
+        let disconnected_single = {
+            let mut inner = fair_queue.inner.lock();
+            inner.waker = Some(cx.waker().clone());
+            if let Some((key, stream)) = inner.single_stream.as_mut() {
+                match stream.as_mut().poll_next(cx) {
+                    Poll::Ready(Some(item)) => {
+                        return Poll::Ready(Some((key.clone(), item)));
+                    }
+                    Poll::Ready(None) => {
+                        let key = key.clone();
+                        inner.single_stream = None;
+                        Some((key, inner.on_disconnect.clone()))
+                    }
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                }
+            } else {
+                None
+            }
+        };
+        if let Some((key, Some(callback))) = disconnected_single {
+            callback(key);
+        }
+
         let mut remaining_ready = {
             let mut inner = fair_queue.inner.lock();
             inner.waker = Some(cx.waker().clone());
@@ -131,13 +185,7 @@ where
                 inner.waker = Some(cx.waker().clone());
                 let event = match inner.ready_queue.pop() {
                     Some(s) => s,
-                    None => {
-                        return if !inner.streams.is_empty() || fair_queue.block_on_no_clients {
-                            Poll::Pending
-                        } else {
-                            Poll::Ready(None)
-                        }
-                    }
+                    None => return queue_empty_poll(&inner, fair_queue.block_on_no_clients),
                 };
                 inner.queued.remove(&event.key);
                 match inner.streams.remove(&event.key) {
@@ -187,17 +235,27 @@ where
         let mut inner = fair_queue.inner.lock();
         inner.waker = Some(cx.waker().clone());
         let should_wake = !inner.ready_queue.is_empty();
-        let result = if !inner.streams.is_empty() || fair_queue.block_on_no_clients {
-            Poll::Pending
-        } else {
-            Poll::Ready(None)
-        };
+        let result = queue_empty_poll(&inner, fair_queue.block_on_no_clients);
         drop(inner);
 
         if should_wake {
             cx.waker().wake_by_ref();
         }
         result
+    }
+}
+
+fn queue_empty_poll<S, K: Clone>(
+    inner: &QueueInner<S, K>,
+    block_on_no_clients: bool,
+) -> Poll<Option<(K, S::Item)>>
+where
+    S: Stream,
+{
+    if inner.single_stream.is_some() || !inner.streams.is_empty() || block_on_no_clients {
+        Poll::Pending
+    } else {
+        Poll::Ready(None)
     }
 }
 
@@ -209,6 +267,7 @@ impl<S, K: Clone> FairQueue<S, K> {
                 counter: atomic::AtomicUsize::new(0),
                 ready_queue: BinaryHeap::new(),
                 queued: HashSet::new(),
+                single_stream: None,
                 streams: HashMap::new(),
                 waker: None,
                 on_disconnect: None,
@@ -239,6 +298,8 @@ mod test {
     use futures::{stream, Stream, StreamExt};
     use std::collections::VecDeque;
     use std::pin::Pin;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
     use std::task::{Context, Poll};
 
     /// Test stream that yields Pending for the first N polls, then emits messages FIFO
@@ -390,6 +451,71 @@ mod test {
                 (1, "a3")
             ]
         );
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_single_stream_fast_path_yields_all_items() {
+        let stream = stream::iter(vec!["a1", "a2", "a3"]);
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            inner.lock().insert(1, stream);
+        }
+
+        let mut results = Vec::new();
+        while let Some(item) = fair_queue.next().await {
+            results.push(item);
+        }
+
+        assert_eq!(results, vec![(1, "a1"), (1, "a2"), (1, "a3")]);
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_promotes_single_stream_when_second_stream_is_inserted() {
+        let first = stream::iter(vec!["a1", "a2"]);
+        let second = stream::iter(vec!["b1", "b2"]);
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        {
+            let inner = fair_queue.inner();
+            let mut lock = inner.lock();
+            lock.insert(1, first);
+            assert!(lock.single_stream.is_some());
+            assert!(lock.streams.is_empty());
+            assert!(lock.ready_queue.is_empty());
+
+            lock.insert(2, second);
+            assert!(lock.single_stream.is_none());
+            assert_eq!(lock.streams.len(), 2);
+            assert_eq!(lock.ready_queue.len(), 2);
+            assert_eq!(lock.queued.len(), 2);
+        }
+
+        let mut results = Vec::new();
+        while let Some(item) = fair_queue.next().await {
+            results.push(item);
+        }
+
+        assert_eq!(results, vec![(1, "a1"), (2, "b1"), (1, "a2"), (2, "b2")]);
+    }
+
+    #[async_rt::test]
+    async fn test_fair_queue_single_stream_disconnect_invokes_callback() {
+        let stream = stream::iter(vec!["a1"]);
+        let disconnect_count = Arc::new(AtomicUsize::new(0));
+        let disconnect_count_for_callback = disconnect_count.clone();
+        let mut fair_queue: FairQueue<_, u64> = FairQueue::new(false);
+        fair_queue.set_on_disconnect(move |peer_id| {
+            assert_eq!(peer_id, 1);
+            disconnect_count_for_callback.fetch_add(1, Ordering::Relaxed);
+        });
+        {
+            let inner = fair_queue.inner();
+            inner.lock().insert(1, stream);
+        }
+
+        assert_eq!(fair_queue.next().await, Some((1, "a1")));
+        assert_eq!(fair_queue.next().await, None);
+        assert_eq!(disconnect_count.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -548,6 +674,10 @@ mod test {
             lock.insert(
                 "pending",
                 UnifiedStream::WakePending(WakePendingStream { poll_count: 0 }),
+            );
+            lock.insert(
+                "other",
+                UnifiedStream::CountPending(CountPendingStream { poll_count: 0 }),
             );
         }
 


### PR DESCRIPTION
## Summary

With a single connected peer, `FairQueue` still pays the full multi-peer bookkeeping cost on every message: ready-queue push/pop, queued-set updates, map remove/insert, and requeueing. The one-way large-payload IPC receive benchmarks pointed straight at this common receive-side cost rather than ROUTER identity or echo-send work. This stores the lone connected stream outside the ready-queue machinery and polls it directly while it remains the only stream, then promotes both streams back into the existing fair-queue path the moment a second peer connects.

## Design decision

The fast path is a `single_stream: Option<(K, Pin<Box<S>>)>` slot on `QueueInner`. The safety boundary is the stream count:

| state | where the stream lives | how it's polled |
|---|---|---|
| zero streams, then first insert | `single_stream` slot | polled directly with the task waker at the top of `poll_next` |
| second insert arrives | both moved into `streams` + `ready_queue` | existing multi-peer fair-queue loop, semantics unchanged |
| single stream disconnects (`Ready(None)`) | slot cleared | `on_disconnect` fired outside the lock, same as the multi-peer path |
| single stream removed via `remove` | slot cleared | n/a |

`insert` is the only promotion site. If a stream already sits in `streams`, a new insert never takes the fast path, so the fast path can only ever hold the sole stream. The direct poll happens before the bounded multi-peer loop and never touches `ready_queue`, so it composes with the existing spin fix (ready events are still bounded to those present at poll entry). `queue_empty_poll` folds `single_stream.is_some()` into the "stay Pending" check so an idle single stream does not get reported as end-of-stream.

This does add complexity to a core scheduling type. The benchmark numbers below are why it carries its weight. The promotion boundary keeps that complexity contained: anything past one peer runs the exact code that ran before.

## Benchmark evidence

From the original measurement run (not re-measured here). Benchmark shape: one-way workloads that isolate receive cost from echo/reply.

- `DEALER/ROUTER one-way`: DEALER sends `BATCH_SIZE` messages, ROUTER receives `BATCH_SIZE`, no echo
- `PUSH/PULL one-way`: PUSH sends `BATCH_SIZE`, PULL receives `BATCH_SIZE`
- transport `ipc`, payload `4096B`
- `ZMQRS_BENCH_SAMPLE_SIZE=20`, `ZMQRS_BENCH_MEASUREMENT_MS=2000`, `ZMQRS_BENCH_WARMUP_MS=500`

| workload | before | after | elapsed reduction | throughput |
|---|---:|---:|---:|---:|
| `zmqrs D/R one-way ipc 4096` | `4.8989 ms` | `4.1979 ms` | ~14.3% | ~16.7% more |
| `zmqrs P/P one-way ipc 4096` | `5.2582 ms` | `4.1240 ms` | ~21.6% | ~27.5% more |

Since each workload moves a fixed number of messages, the lower elapsed time corresponds directly to higher receive-side throughput.

## Validation

- `cargo test --lib fair_queue` and `cargo test --lib test_fair_queue`: 9 passed, 0 failed
- `cargo clippy --all-targets -- --deny warnings`: exit 0 (only the repo's pre-existing renamed-lint notes)

Recreates #271.
