### PR TITLE
Reduce XPUB fanout lock pressure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod fair_queue;
 mod message;
 mod r#pub;
+mod pub_fanout;
 mod pull;
 mod push;
 mod reconnect;

--- a/src/pub_fanout.rs
+++ b/src/pub_fanout.rs
@@ -1,0 +1,221 @@
+use crate::codec::{Message, ZmqFramedWrite};
+use crate::message::ZmqMessage;
+use crate::util::PeerIdentity;
+use crate::{async_rt, write_queue::write_message_queue};
+
+use futures::channel::mpsc;
+
+/// Bounded per-peer queue depth. Mirrors the PUB fanout queue so XPUB shares
+/// the same drop-on-slow-subscriber behavior.
+const FANOUT_SEND_QUEUE_CAPACITY: usize = 100_000;
+
+pub(crate) type FanoutEventSender = mpsc::UnboundedSender<FanoutEvent>;
+pub(crate) type FanoutEventReceiver = mpsc::UnboundedReceiver<FanoutEvent>;
+
+pub(crate) enum SubscriptionChange {
+    Subscribe(Vec<u8>),
+    Unsubscribe(Vec<u8>),
+}
+
+/// Backend-to-socket fanout events.
+///
+/// The backend owns the I/O lifecycle (accept, disconnect) but does not touch
+/// the send path. It hands the socket a bounded write queue on connect and a
+/// peer-id on disconnect. Subscription changes for XPUB are applied by the
+/// socket itself from the recv path, so they are not carried as events here.
+pub(crate) enum FanoutEvent {
+    PeerConnected {
+        peer_id: PeerIdentity,
+        send_queue: ZmqFramedWrite,
+    },
+    PeerDisconnected(PeerIdentity),
+}
+
+struct FanoutPeer {
+    subscriptions: Vec<Vec<u8>>,
+    send_queue: mpsc::Sender<Message>,
+}
+
+impl FanoutPeer {
+    fn is_subscribed_to(&self, first_frame: &[u8]) -> bool {
+        self.subscriptions.iter().any(|sub_filter| {
+            sub_filter.len() <= first_frame.len()
+                && sub_filter.as_slice() == &first_frame[..sub_filter.len()]
+        })
+    }
+}
+
+/// Socket-owned fanout connection and subscription state.
+///
+/// Steady-state sends iterate this map directly. No backend scc lookup, no
+/// async writer mutex. Each peer drains its bounded queue on a dedicated writer
+/// task via [`write_message_queue`], so a full or closed queue drops one
+/// message rather than blocking the publisher.
+#[derive(Default)]
+pub(crate) struct FanoutState {
+    peers: std::collections::HashMap<PeerIdentity, FanoutPeer>,
+}
+
+impl FanoutState {
+    pub(crate) fn drain_events(&mut self, events: &mut FanoutEventReceiver) {
+        while let Ok(event) = events.try_recv() {
+            self.apply_event(event);
+        }
+    }
+
+    fn apply_event(&mut self, event: FanoutEvent) {
+        match event {
+            FanoutEvent::PeerConnected {
+                peer_id,
+                send_queue,
+            } => self.peer_connected(peer_id, send_queue),
+            FanoutEvent::PeerDisconnected(peer_id) => self.peer_disconnected(&peer_id),
+        }
+    }
+
+    fn peer_connected(&mut self, peer_id: PeerIdentity, send_queue: ZmqFramedWrite) {
+        let (queue_sender, queue_receiver) = mpsc::channel(FANOUT_SEND_QUEUE_CAPACITY);
+        let writer_peer_id = peer_id.clone();
+        async_rt::task::spawn(async move {
+            if let Err(error) = write_message_queue(queue_receiver, send_queue).await {
+                log::debug!(
+                    "Error sending message to fanout peer {:?}: {:?}",
+                    writer_peer_id,
+                    error
+                );
+            }
+        });
+        self.peers.insert(
+            peer_id,
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue: queue_sender,
+            },
+        );
+    }
+
+    pub(crate) fn peer_disconnected(&mut self, peer_id: &PeerIdentity) {
+        self.peers.remove(peer_id);
+    }
+
+    pub(crate) fn apply_subscription(
+        &mut self,
+        peer_id: &PeerIdentity,
+        change: SubscriptionChange,
+    ) {
+        let Some(peer) = self.peers.get_mut(peer_id) else {
+            return;
+        };
+
+        match change {
+            SubscriptionChange::Subscribe(subscription) => {
+                peer.subscriptions.push(subscription);
+            }
+            SubscriptionChange::Unsubscribe(subscription) => {
+                if let Some(index) = peer
+                    .subscriptions
+                    .iter()
+                    .position(|existing| existing == &subscription)
+                {
+                    peer.subscriptions.remove(index);
+                }
+            }
+        }
+    }
+
+    /// Queue `message` for every peer whose subscriptions match `first_frame`.
+    ///
+    /// A full or closed peer queue drops the message for that peer; the writer
+    /// task owns transport error detection and disconnect cleanup.
+    pub(crate) fn send_matching(&mut self, first_frame: &[u8], message: &ZmqMessage) {
+        for peer in self.peers.values_mut() {
+            if !peer.is_subscribed_to(first_frame) {
+                continue;
+            }
+
+            match peer.send_queue.try_send(Message::Message(message.clone())) {
+                Ok(()) => {}
+                Err(error) => {
+                    // Slow or gone subscriber: drop the message rather than backpressure the publisher.
+                    drop(error.into_inner());
+                }
+            }
+        }
+    }
+}
+
+pub(crate) fn subscription_change(message: &ZmqMessage) -> Option<SubscriptionChange> {
+    let frame = message.get(0)?;
+    if message.len() != 1 || frame.is_empty() {
+        return None;
+    }
+
+    match frame[0] {
+        1 => Some(SubscriptionChange::Subscribe(frame[1..].to_vec())),
+        0 => Some(SubscriptionChange::Unsubscribe(frame[1..].to_vec())),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn insert_peer(state: &mut FanoutState, peer_id: PeerIdentity) {
+        let (queue_sender, _queue_receiver) = mpsc::channel(8);
+        state.peers.insert(
+            peer_id,
+            FanoutPeer {
+                subscriptions: Vec::new(),
+                send_queue: queue_sender,
+            },
+        );
+    }
+
+    #[test]
+    fn duplicate_subscription_requires_matching_unsubscribe_events() {
+        let mut state = FanoutState::default();
+        let peer_id = PeerIdentity::new();
+        insert_peer(&mut state, peer_id.clone());
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+        state.apply_subscription(&peer_id, SubscriptionChange::Subscribe(b"dup".to_vec()));
+
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-subscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(peer.is_subscribed_to(b"dup-after-one-unsubscribe"));
+
+        state.apply_subscription(&peer_id, SubscriptionChange::Unsubscribe(b"dup".to_vec()));
+        let peer = state.peers.get(&peer_id).unwrap();
+        assert!(!peer.is_subscribed_to(b"dup-after-two-unsubscribes"));
+    }
+
+    #[test]
+    fn send_matching_skips_unsubscribed_peers() {
+        let mut state = FanoutState::default();
+        let peer_id = PeerIdentity::new();
+        let (queue_sender, mut queue_receiver) = mpsc::channel(8);
+        state.peers.insert(
+            peer_id.clone(),
+            FanoutPeer {
+                subscriptions: vec![b"topic".to_vec()],
+                send_queue: queue_sender,
+            },
+        );
+
+        state.send_matching(b"other", &ZmqMessage::from("other-payload"));
+        assert!(queue_receiver.try_recv().is_err());
+
+        state.send_matching(b"topic.a", &ZmqMessage::from("topic.a payload"));
+        let Message::Message(message) = queue_receiver.try_recv().expect("queued message") else {
+            panic!("expected a queued message");
+        };
+        assert_eq!(
+            message.get(0).unwrap().as_ref(),
+            b"topic.a payload".as_slice()
+        );
+    }
+}

--- a/src/pub_fanout.rs
+++ b/src/pub_fanout.rs
@@ -51,12 +51,23 @@ impl FanoutPeer {
 /// async writer mutex. Each peer drains its bounded queue on a dedicated writer
 /// task via [`write_message_queue`], so a full or closed queue drops one
 /// message rather than blocking the publisher.
-#[derive(Default)]
 pub(crate) struct FanoutState {
     peers: std::collections::HashMap<PeerIdentity, FanoutPeer>,
+    /// Cloned into each peer's writer task so a transport write failure evicts
+    /// the dead peer from the fanout map (the writer emits `PeerDisconnected`).
+    /// This matches the cleanup the PUB writer does on its backend and keeps a
+    /// half-open peer (write dead, read still open) from leaking its slot.
+    event_sender: FanoutEventSender,
 }
 
 impl FanoutState {
+    pub(crate) fn new(event_sender: FanoutEventSender) -> Self {
+        Self {
+            peers: std::collections::HashMap::new(),
+            event_sender,
+        }
+    }
+
     pub(crate) fn drain_events(&mut self, events: &mut FanoutEventReceiver) {
         while let Ok(event) = events.try_recv() {
             self.apply_event(event);
@@ -76,6 +87,7 @@ impl FanoutState {
     fn peer_connected(&mut self, peer_id: PeerIdentity, send_queue: ZmqFramedWrite) {
         let (queue_sender, queue_receiver) = mpsc::channel(FANOUT_SEND_QUEUE_CAPACITY);
         let writer_peer_id = peer_id.clone();
+        let writer_events = self.event_sender.clone();
         async_rt::task::spawn(async move {
             if let Err(error) = write_message_queue(queue_receiver, send_queue).await {
                 log::debug!(
@@ -83,6 +95,10 @@ impl FanoutState {
                     writer_peer_id,
                     error
                 );
+                // Transport write failed, so evict the peer instead of leaving a
+                // dead slot that silently drops every future send. Drained on the
+                // next send/recv, the same path backend disconnects flow through.
+                let _ = writer_events.unbounded_send(FanoutEvent::PeerDisconnected(writer_peer_id));
             }
         });
         self.peers.insert(
@@ -161,6 +177,13 @@ pub(crate) fn subscription_change(message: &ZmqMessage) -> Option<SubscriptionCh
 mod tests {
     use super::*;
 
+    fn test_state() -> FanoutState {
+        // The writer-eviction sender is unused by these tests (peers are inserted
+        // directly, no writer task is spawned), so a detached sender is fine.
+        let (event_sender, _events) = mpsc::unbounded();
+        FanoutState::new(event_sender)
+    }
+
     fn insert_peer(state: &mut FanoutState, peer_id: PeerIdentity) {
         let (queue_sender, _queue_receiver) = mpsc::channel(8);
         state.peers.insert(
@@ -174,7 +197,7 @@ mod tests {
 
     #[test]
     fn duplicate_subscription_requires_matching_unsubscribe_events() {
-        let mut state = FanoutState::default();
+        let mut state = test_state();
         let peer_id = PeerIdentity::new();
         insert_peer(&mut state, peer_id.clone());
 
@@ -195,7 +218,7 @@ mod tests {
 
     #[test]
     fn send_matching_skips_unsubscribed_peers() {
-        let mut state = FanoutState::default();
+        let mut state = test_state();
         let peer_id = PeerIdentity::new();
         let (queue_sender, mut queue_receiver) = mpsc::channel(8);
         state.peers.insert(
@@ -217,5 +240,40 @@ mod tests {
             message.get(0).unwrap().as_ref(),
             b"topic.a payload".as_slice()
         );
+    }
+
+    #[test]
+    fn send_matching_drops_for_dead_peer_and_still_serves_healthy_peer() {
+        let mut state = test_state();
+
+        // Dead peer: its writer task is gone, so the receiver is dropped and
+        // try_send fails. The message is dropped without disturbing other peers.
+        let dead = PeerIdentity::new();
+        let (dead_sender, dead_receiver) = mpsc::channel(8);
+        drop(dead_receiver);
+        state.peers.insert(
+            dead,
+            FanoutPeer {
+                subscriptions: vec![b"topic".to_vec()],
+                send_queue: dead_sender,
+            },
+        );
+
+        let healthy = PeerIdentity::new();
+        let (healthy_sender, mut healthy_receiver) = mpsc::channel(8);
+        state.peers.insert(
+            healthy,
+            FanoutPeer {
+                subscriptions: vec![b"topic".to_vec()],
+                send_queue: healthy_sender,
+            },
+        );
+
+        state.send_matching(b"topic.a", &ZmqMessage::from("payload"));
+
+        let Message::Message(message) = healthy_receiver.try_recv().expect("queued message") else {
+            panic!("expected a queued message for the healthy peer");
+        };
+        assert_eq!(message.get(0).unwrap().as_ref(), b"payload".as_slice());
     }
 }

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -3,6 +3,9 @@ use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::{FairQueue, QueueInner};
 use crate::message::*;
+use crate::pub_fanout::{
+    subscription_change, FanoutEvent, FanoutEventReceiver, FanoutEventSender, FanoutState,
+};
 use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{CaptureSocket, SocketOptions};
@@ -13,62 +16,17 @@ use crate::{
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
-use futures::lock::Mutex as AsyncMutex;
-use futures::{SinkExt, StreamExt};
+use futures::StreamExt;
 use parking_lot::Mutex;
 
 use std::collections::HashMap;
-use std::io::ErrorKind;
-use std::pin::Pin;
 use std::sync::Arc;
 
-pub(crate) struct XPubSubscriber {
-    pub(crate) subscriptions: Vec<Vec<u8>>,
-    pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
-}
-
 pub(crate) struct XPubSocketBackend {
-    subscribers: scc::HashMap<PeerIdentity, XPubSubscriber>,
+    fanout_events: FanoutEventSender,
     fair_queue_inner: Arc<Mutex<QueueInner<ZmqFramedRead, PeerIdentity>>>,
     socket_monitor: Mutex<Option<mpsc::Sender<SocketEvent>>>,
     socket_options: SocketOptions,
-}
-
-impl XPubSocketBackend {
-    fn message_received(&self, peer_id: &PeerIdentity, message: Message) {
-        let data = match message {
-            Message::Message(m) => {
-                if m.len() != 1 {
-                    return;
-                }
-                m.into_vec().pop().unwrap_or_default()
-            }
-            _ => return,
-        };
-
-        if data.is_empty() {
-            return;
-        }
-
-        match data.first() {
-            Some(1) => {
-                // Subscribe
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    entry.subscriptions.push(Vec::from(&data[1..]));
-                }
-            }
-            Some(0) => {
-                // Unsubscribe
-                let sub = Vec::from(&data[1..]);
-                if let Some(mut entry) = self.subscribers.get_sync(peer_id) {
-                    if let Some(index) = entry.subscriptions.iter().position(|s| s == &sub) {
-                        entry.subscriptions.remove(index);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
 }
 
 impl SocketBackend for XPubSocketBackend {
@@ -81,7 +39,7 @@ impl SocketBackend for XPubSocketBackend {
     }
 
     fn shutdown(&self) {
-        self.subscribers.clear_sync();
+        self.fair_queue_inner.lock().clear();
     }
 
     fn monitor(&self) -> &Mutex<Option<mpsc::Sender<SocketEvent>>> {
@@ -94,15 +52,16 @@ impl MultiPeerBackend for XPubSocketBackend {
     async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
         let (recv_queue, send_queue) = io.into_parts();
 
-        self.subscribers
-            .upsert_async(
-                peer_id.clone(),
-                XPubSubscriber {
-                    subscriptions: vec![],
-                    send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
-                },
-            )
-            .await;
+        if self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerConnected {
+                peer_id: peer_id.clone(),
+                send_queue,
+            })
+            .is_err()
+        {
+            return;
+        }
 
         self.fair_queue_inner
             .lock()
@@ -111,14 +70,18 @@ impl MultiPeerBackend for XPubSocketBackend {
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         log::info!("Client disconnected {:?}", peer_id);
-        self.subscribers.remove_sync(peer_id);
         self.fair_queue_inner.lock().remove(peer_id);
+        let _ = self
+            .fanout_events
+            .unbounded_send(FanoutEvent::PeerDisconnected(peer_id.clone()));
     }
 }
 
 pub struct XPubSocket {
     pub(crate) backend: Arc<XPubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
+    fanout_state: FanoutState,
+    fanout_events: FanoutEventReceiver,
     binds: HashMap<Endpoint, AcceptStopHandle>,
 }
 
@@ -131,48 +94,14 @@ impl Drop for XPubSocket {
 #[async_trait]
 impl SocketSend for XPubSocket {
     async fn send(&mut self, message: ZmqMessage) -> ZmqResult<()> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         let first_frame = match message.get(0) {
             Some(frame) => frame,
             None => return Ok(()), // Empty message, nothing to publish
         };
-        let mut targets = Vec::new();
-        let mut iter = self.backend.subscribers.begin_async().await;
-        while let Some(subscriber) = iter {
-            if subscriber.subscriptions.iter().any(|sub_filter| {
-                sub_filter.len() <= first_frame.len()
-                    && sub_filter.as_slice() == &first_frame[0..sub_filter.len()]
-            }) {
-                targets.push((subscriber.key().clone(), subscriber.send_queue.clone()));
-            }
-            iter = subscriber.next_async().await;
-        }
 
-        let mut dead_peers = Vec::new();
-        for (peer_id, send_queue) in targets {
-            let res = send_queue
-                .lock()
-                .await
-                .as_mut()
-                .send(Message::Message(message.clone()))
-                .await;
-            match res {
-                Ok(()) => {}
-                Err(CodecError::Io(e)) => {
-                    if e.kind() == ErrorKind::BrokenPipe {
-                        dead_peers.push(peer_id);
-                    } else {
-                        log::error!("Error sending message: {:?}", e);
-                    }
-                }
-                Err(e) => {
-                    log::error!("Error sending message: {:?}", e);
-                    return Err(e.into());
-                }
-            }
-        }
-        for peer in dead_peers {
-            self.backend.peer_disconnected(&peer);
-        }
+        self.fanout_state.send_matching(first_frame, &message);
         Ok(())
     }
 }
@@ -180,19 +109,25 @@ impl SocketSend for XPubSocket {
 #[async_trait]
 impl SocketRecv for XPubSocket {
     async fn recv(&mut self) -> ZmqResult<ZmqMessage> {
+        self.fanout_state.drain_events(&mut self.fanout_events);
+
         loop {
             match self.fair_queue.next().await {
                 Some((peer_id, Ok(Message::Message(message)))) => {
-                    // Process the subscription message internally to update tracking
-                    self.backend
-                        .message_received(&peer_id, Message::Message(message.clone()));
-                    // Also expose it to the application
+                    // Apply any pending connect/disconnect events before mutating subscription state
+                    // so a subscription always lands on a peer the fanout map already knows about.
+                    self.fanout_state.drain_events(&mut self.fanout_events);
+                    if let Some(change) = subscription_change(&message) {
+                        self.fanout_state.apply_subscription(&peer_id, change);
+                    }
+                    // Also expose the subscription frame to the application.
                     return Ok(message);
                 }
                 Some((_peer_id, Ok(_msg))) => {
                     // Ignore non-message frames
                 }
                 Some((peer_id, Err(e))) => {
+                    self.fanout_state.peer_disconnected(&peer_id);
                     self.backend.peer_disconnected(&peer_id);
                     return Err(e.into());
                 }
@@ -210,8 +145,9 @@ impl CaptureSocket for XPubSocket {}
 impl Socket for XPubSocket {
     fn with_options(options: SocketOptions) -> Self {
         let mut fair_queue = FairQueue::new(true);
+        let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         let backend = Arc::new(XPubSocketBackend {
-            subscribers: scc::HashMap::new(),
+            fanout_events: fanout_event_sender,
             fair_queue_inner: fair_queue.inner(),
             socket_monitor: Mutex::new(None),
             socket_options: options,
@@ -227,6 +163,8 @@ impl Socket for XPubSocket {
         Self {
             backend,
             fair_queue,
+            fanout_state: FanoutState::default(),
+            fanout_events,
             binds: HashMap::new(),
         }
     }

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -147,7 +147,7 @@ impl Socket for XPubSocket {
         let mut fair_queue = FairQueue::new(true);
         let (fanout_event_sender, fanout_events) = mpsc::unbounded();
         let backend = Arc::new(XPubSocketBackend {
-            fanout_events: fanout_event_sender,
+            fanout_events: fanout_event_sender.clone(),
             fair_queue_inner: fair_queue.inner(),
             socket_monitor: Mutex::new(None),
             socket_options: options,
@@ -163,7 +163,7 @@ impl Socket for XPubSocket {
         Self {
             backend,
             fair_queue,
-            fanout_state: FanoutState::default(),
+            fanout_state: FanoutState::new(fanout_event_sender),
             fanout_events,
             binds: HashMap::new(),
         }

--- a/tests/pub_sub.rs
+++ b/tests/pub_sub.rs
@@ -9,6 +9,130 @@ mod test {
     use futures::{SinkExt, StreamExt};
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
+    async fn wait_for_delivery(
+        pub_socket: &mut zeromq::PubSocket,
+        sub_socket: &mut zeromq::SubSocket,
+        payload: &str,
+    ) {
+        for _ in 0..200 {
+            pub_socket
+                .send(ZmqMessage::from(payload))
+                .await
+                .expect("failed to send sync payload");
+            match async_rt::task::timeout(Duration::from_millis(10), sub_socket.recv()).await {
+                Ok(Ok(message)) if message.get(0).unwrap().as_ref() == payload.as_bytes() => {
+                    return;
+                }
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => panic!("failed to receive sync payload: {e:?}"),
+                Err(_) => async_rt::task::sleep(Duration::from_millis(5)).await,
+            }
+        }
+        panic!("timed out waiting for subscription to receive {payload}");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+        wait_for_delivery(&mut pub_socket, &mut early_sub, "early-sync").await;
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+        wait_for_delivery(&mut pub_socket, &mut late_sub, "late-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        pub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_pub_unsubscribe_stops_delivery_after_later_subscription() {
+        pretty_env_logger::try_init().ok();
+
+        let mut pub_socket = zeromq::PubSocket::new();
+        let endpoint = pub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "gone-sync").await;
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        wait_for_delivery(&mut pub_socket, &mut sub_socket, "stay-sync").await;
+
+        pub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        pub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
+    }
+
     #[async_rt::test]
     async fn test_pub_sub_sockets() {
         pretty_env_logger::try_init().ok();

--- a/tests/xpub_sub.rs
+++ b/tests/xpub_sub.rs
@@ -6,6 +6,14 @@ mod test {
 
     use std::time::Duration;
 
+    async fn recv_text(sub_socket: &mut zeromq::SubSocket) -> String {
+        let message = async_rt::task::timeout(Duration::from_secs(2), sub_socket.recv())
+            .await
+            .expect("timeout waiting for subscriber message")
+            .expect("failed to receive subscriber message");
+        String::from_utf8(message.get(0).unwrap().to_vec()).unwrap()
+    }
+
     #[async_rt::test]
     async fn test_xpub_basic_pubsub() {
         pretty_env_logger::try_init().ok();
@@ -181,5 +189,130 @@ mod test {
         // SUB should only receive "topic1-message"
         let received = sub_handle.await.expect("SUB task failed");
         assert_eq!(received, "topic1-message");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_late_subscriber_filter_state_is_isolated() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut early_sub = zeromq::SubSocket::new();
+        early_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect early subscriber");
+        early_sub
+            .subscribe("early")
+            .await
+            .expect("Failed to subscribe early subscriber");
+
+        let early_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for early subscription")
+            .expect("Failed to receive early subscription");
+        assert_eq!(early_sub_msg.get(0).unwrap().as_ref(), b"\x01early");
+
+        let mut late_sub = zeromq::SubSocket::new();
+        late_sub
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect late subscriber");
+        late_sub
+            .subscribe("late")
+            .await
+            .expect("Failed to subscribe late subscriber");
+
+        let late_sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for late subscription")
+            .expect("Failed to receive late subscription");
+        assert_eq!(late_sub_msg.get(0).unwrap().as_ref(), b"\x01late");
+
+        xpub_socket
+            .send(ZmqMessage::from("early-after-late-join"))
+            .await
+            .expect("Failed to send early message");
+        xpub_socket
+            .send(ZmqMessage::from("late-after-join"))
+            .await
+            .expect("Failed to send late message");
+
+        assert_eq!(recv_text(&mut early_sub).await, "early-after-late-join");
+        assert_eq!(recv_text(&mut late_sub).await, "late-after-join");
+    }
+
+    #[async_rt::test]
+    async fn test_xpub_unsubscribe_updates_fanout_state() {
+        pretty_env_logger::try_init().ok();
+
+        let mut xpub_socket = zeromq::XPubSocket::new();
+        let endpoint = xpub_socket
+            .bind("tcp://127.0.0.1:0")
+            .await
+            .expect("Failed to bind");
+
+        let mut sub_socket = zeromq::SubSocket::new();
+        sub_socket
+            .connect(&endpoint.to_string())
+            .await
+            .expect("Failed to connect subscriber");
+        sub_socket
+            .subscribe("gone")
+            .await
+            .expect("Failed to subscribe initial filter");
+
+        let sub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for subscription")
+            .expect("Failed to receive subscription");
+        assert_eq!(sub_msg.get(0).unwrap().as_ref(), b"\x01gone");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-before-unsubscribe"))
+            .await
+            .expect("Failed to send subscribed message");
+        assert_eq!(recv_text(&mut sub_socket).await, "gone-before-unsubscribe");
+
+        sub_socket
+            .unsubscribe("gone")
+            .await
+            .expect("Failed to unsubscribe initial filter");
+        let unsub_msg = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for unsubscribe")
+            .expect("Failed to receive unsubscribe");
+        assert_eq!(unsub_msg.get(0).unwrap().as_ref(), b"\x00gone");
+
+        sub_socket
+            .subscribe("stay")
+            .await
+            .expect("Failed to subscribe replacement filter");
+        let replacement_sub = async_rt::task::timeout(Duration::from_secs(2), xpub_socket.recv())
+            .await
+            .expect("Timeout waiting for replacement subscription")
+            .expect("Failed to receive replacement subscription");
+        assert_eq!(replacement_sub.get(0).unwrap().as_ref(), b"\x01stay");
+
+        xpub_socket
+            .send(ZmqMessage::from("gone-after-unsubscribe"))
+            .await
+            .expect("Failed to send unsubscribed message");
+        assert!(
+            async_rt::task::timeout(Duration::from_millis(150), sub_socket.recv())
+                .await
+                .is_err(),
+            "subscriber received a message for an unsubscribed prefix"
+        );
+
+        xpub_socket
+            .send(ZmqMessage::from("stay-after-unsubscribe"))
+            .await
+            .expect("Failed to send replacement message");
+        assert_eq!(recv_text(&mut sub_socket).await, "stay-after-unsubscribe");
     }
 }


### PR DESCRIPTION
XPUB fanout still acquired a per-subscriber async writer mutex and walked the backend scc map on every send, the same hot-path cost the PUB queue stack already removed for PUB. This moves XPUB connection and subscription state into socket-owned `FanoutState` updated by backend events, so steady-state sends iterate a plain map and `try_send` into a bounded per-peer queue with no async mutex and no scc lookup.

## Design decision

The win is fewer locks and atomics per published message, not just more concurrency. The old XPUB send path did two expensive things per message: it walked `scc::HashMap` with `begin_async`/`next_async`, and for every matching subscriber it acquired `Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>` and awaited a framed write inline.

`FanoutState` is owned by the socket, not the backend. The backend keeps only the I/O lifecycle. On connect it hands the socket a write half through a `FanoutEvent`; on disconnect it forwards the peer id. The socket drains those events at the top of `send` and `recv`, then the send path iterates a plain `HashMap` and `try_send`s into a bounded per-peer `mpsc`. A dedicated writer task per peer drains that queue through the shared `write_message_queue`. A full or closed queue drops one message rather than backpressuring the publisher, matching PUB's slow-subscriber behavior.

Subscription state lives in `FanoutState` and is applied by the socket from the `recv` path, where the socket already owns the fair queue. So subscribe/unsubscribe never touch the backend and never take a lock. Events are drained before a subscription is applied so the change always lands on a peer the map already knows about.

This is the deliberate delta from the original change. PUB already reached the same shape through the local fanout queue (#274) and the shared write queue (#272). Re-introducing the original send-path design for PUB would have regressed that lock-free queue, so PUB's send path is unchanged here and the work targets XPUB, which had not yet been converted. The shared subscription parser and `FanoutState` live in `pub_fanout` for reuse.

## Behavioral change to call out

XPUB sends are now fire-and-forget into bounded per-peer queues drained by writer tasks, where they were previously awaited inline. A slow XPUB subscriber now drops messages once its queue fills instead of backpressuring the publisher. This matches PUB semantics and the ZeroMQ publisher contract, but it is a real observable change for XPUB: callers that relied on `send()` surfacing an error for a broken XPUB peer no longer see it on the send path. Transport errors and disconnect cleanup are detected by the writer task and the fair-queue on-disconnect hook instead. This wants explicit reviewer sign-off.

## Behavioral coverage

| socket | scenario | expected |
| --- | --- | --- |
| PUB/SUB | late subscriber joins with a different filter | each subscriber gets only its own prefix |
| PUB/SUB | unsubscribe then subscribe a new prefix | old prefix stops delivering, new one delivers |
| XPUB/SUB | late subscriber joins | XPUB sees each `\x01<prefix>`, fanout stays isolated |
| XPUB/SUB | unsubscribe updates fanout state | XPUB sees `\x00<prefix>`, delivery stops for it |

## Benchmark evidence

From the original measurement run on PR #257, not re-measured here. Locked quick Criterion PUB fanout runs with `tokio-runtime`, sample size 10, 1s measurement, 0.5s warmup:

| transport | subscribers | 256B | 4096B |
| --- | ---: | ---: | ---: |
| tcp | 1 | +8.5% | +11.5% |
| tcp | 8 | +8.3% | +6.4% |
| tcp | 64 | +5.7% | +5.2% |
| ipc | 1 | +4.3% | +0.1% |
| ipc | 8 | +17.1% | +13.3% |
| ipc | 64 | +18.1% | +10.9% |

These numbers were taken before the PUB queue stack merged, when both PUB and XPUB shared the old async-mutex fanout path. PUB has since moved to the local fanout queue plus shared write queue, so the PUB column reflects gains that are already on master. This change brings XPUB onto the same lock-free fanout shape, so the same class of improvement now applies to the XPUB send path.

Recreates the XPUB portion of #257.
