### PR TITLE
Floor futures-channel at 0.3.32 for try_recv

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ bench-internals = []
 async-dispatcher = { version = "0.1", optional = true }
 thiserror = "1"
 futures = "0.3"
+# write_queue.rs uses mpsc::Receiver::try_recv, added in futures-channel 0.3.32.
+# The futures meta-crate's "0.3" range would otherwise allow 0.3.31, which lacks it.
+futures-channel = "0.3.32"
 async-trait = "0.1"
 parking_lot = "0.12"
 rand = "0.9"


### PR DESCRIPTION
A fresh dependency resolution can fail to compile the crate. `src/write_queue.rs` calls `mpsc::Receiver::try_recv`, which `futures-channel` added in 0.3.32, but the manifest only floored `futures = "0.3"`. That range lets `futures-channel` resolve to 0.3.31, which has `try_next` but not `try_recv`, so any resolve landing on 0.3.31 (minimal-versions, a stale index, an older lock) fails with `no method named try_recv`. CI stays green only because it happens to resolve 0.3.32.

This adds an explicit `futures-channel = "0.3.32"` floor.

## Design decision

The requirement belongs in `Cargo.toml`, not a committed lockfile. zmq.rs is a library and correctly gitignores `Cargo.lock`, so the manifest is the only place that pins the build's minimum versions. Flooring `futures-channel` directly is more precise than bumping the `futures` meta-crate, whose range would still admit the older sub-crate. Reverting the call to the older method is not an option either: `try_next` is deprecated as of 0.3.32, and the repo builds with `--deny warnings`.

## Validation

- `cargo update -p futures-channel --precise 0.3.31` is now rejected (requirement `^0.3.32`).
- `cargo build` is clean.
- `cargo clippy --all-targets -- --deny warnings` exits 0 (only the repo's pre-existing renamed-lint notes remain).
