### PR TITLE
 Trim `syn 1` and `once_cell` from the build graph

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ scc = "3.7"
 crossbeam-queue = "0.3"
 uuid = { version = "1", default-features = false, features = ["v4"] }
 regex = { version = "1", default-features = false, features = ["std"] }
-once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
 async-std = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85.0"
 [features]
 default = ["tokio-runtime", "all-transport"]
 tokio-runtime = ["tokio", "tokio-util", "dep:socket2"]
-async-std-runtime = ["async-std"]
+async-std-runtime = ["async-std", "async-std/attributes"]
 async-dispatcher-runtime = ["async-std", "async-dispatcher"]
 async-dispatcher-macros = ["async-dispatcher/macros"]
 all-transport = ["ipc-transport", "tcp-transport"]
@@ -51,7 +51,7 @@ regex = { version = "1", default-features = false, features = ["std"] }
 once_cell = "1"
 log = "0.4"
 asynchronous-codec = "0.7"
-async-std = { version = "1", features = ["attributes"], optional = true }
+async-std = { version = "1", optional = true }
 socket2 = { version = "0.6", optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/src/endpoint/mod.rs
+++ b/src/endpoint/mod.rs
@@ -2,13 +2,13 @@ mod error;
 mod host;
 mod transport;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 use std::fmt;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::LazyLock;
 
 pub use error::EndpointError;
 pub use host::Host;
@@ -16,8 +16,9 @@ pub use transport::Transport;
 
 pub type Port = u16;
 
-static TRANSPORT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^([[:lower:]]+)://(.+)$").unwrap());
-static HOST_PORT_REGEX: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(.+):([0-9]+)$").unwrap());
+static TRANSPORT_REGEX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([[:lower:]]+)://(.+)$").unwrap());
+static HOST_PORT_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(.+):([0-9]+)$").unwrap());
 
 /// Represents a ZMQ Endpoint.
 ///
@@ -148,7 +149,7 @@ mod private {
 mod tests {
     use super::*;
 
-    static PAIRS: Lazy<Vec<(Endpoint, &'static str)>> = Lazy::new(|| {
+    static PAIRS: LazyLock<Vec<(Endpoint, &'static str)>> = LazyLock::new(|| {
         vec![
             (
                 Endpoint::Ipc(Some(PathBuf::from("/tmp/asdf"))),


### PR DESCRIPTION
I was looking at Zed's build graph and noticed this crate pulls in `syn 1` via async-std's `attributes` feature, even though it's mostly unneeded. That feature only provides the `#[async_std::main]` / `#[async_std::test]` macros re exported under `async-std-runtime`, but it was always enabled. Which caused all other runtimes to include   `async-attributes` and a `syn 1.x` as dependencies. This PR scopes `attributes` to the `async-std-runtime` feature, so that path keeps working while other runtimes don't include it.

I also noticed `once_cell` was a direct dependency used only for a couple of lazy regexes. Since the MSRV is already 1.85, I swapped those for the standard library's `std::sync::LazyLock` and dropped the dependency. 

These changes simplify the build graph and slightly improve build times.  Please let me know if you would like these changes to be in two separate PRs. 