### PR TITLE
Implement socket disconnect

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,8 +1,8 @@
-use crate::async_rt;
 use crate::codec::{FramedIo, Message, ZmqFramedRead};
 use crate::fair_queue::QueueInner;
 use crate::util::PeerIdentity;
 use crate::write_queue::write_message_queue;
+use crate::{async_rt, Endpoint};
 use crate::{
     MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, ZmqError, ZmqResult,
 };
@@ -23,6 +23,7 @@ const PEER_SEND_QUEUE_CAPACITY: usize = 100_000;
 
 pub(crate) struct Peer {
     pub(crate) send_queue: mpsc::Sender<Message>,
+    pub(crate) endpoint: Endpoint,
 }
 
 #[derive(Clone)]
@@ -285,7 +286,12 @@ impl SocketBackend for GenericSocketBackend {
 
 #[async_trait]
 impl MultiPeerBackend for GenericSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (recv_queue, send_queue) = io.into_parts();
         let (queue_sender, queue_receiver) = mpsc::channel(PEER_SEND_QUEUE_CAPACITY);
         self.peers
@@ -293,6 +299,7 @@ impl MultiPeerBackend for GenericSocketBackend {
                 peer_id.clone(),
                 Peer {
                     send_queue: queue_sender,
+                    endpoint,
                 },
             )
             .await;
@@ -318,7 +325,14 @@ impl MultiPeerBackend for GenericSocketBackend {
         };
     }
 
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.peers, endpoint, |peer| &peer.endpoint)
+    }
+
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
+        if let Some(monitor) = self.monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
+        }
         self.peers.remove_sync(peer_id);
         self.refresh_single_peer_cache();
         match &self.fair_queue_inner {
@@ -340,7 +354,7 @@ impl MultiPeerBackend for GenericSocketBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ZmqMessage;
+    use crate::{TryIntoEndpoint, ZmqMessage};
 
     use bytes::Bytes;
     use futures::StreamExt;
@@ -361,9 +375,16 @@ mod tests {
         peer_id: PeerIdentity,
     ) -> (PeerIdentity, mpsc::Receiver<Message>) {
         let (send_queue, recv_queue) = mpsc::channel(8);
+        let endpoint = TryIntoEndpoint::try_into("tcp://127.0.0.1:1234").unwrap();
         backend
             .peers
-            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .upsert_async(
+                peer_id.clone(),
+                Peer {
+                    send_queue,
+                    endpoint,
+                },
+            )
             .await;
         backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());
@@ -442,12 +463,19 @@ mod tests {
             GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
         let peer_id: PeerIdentity = "full-peer".parse().expect("peer id");
         let (mut send_queue, mut recv_queue) = mpsc::channel(1);
+        let endpoint = TryIntoEndpoint::try_into("tcp://127.0.0.1:1234").unwrap();
         send_queue
             .try_send(message_with_frame(b"prefilled"))
             .expect("prefill peer queue");
         backend
             .peers
-            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .upsert_async(
+                peer_id.clone(),
+                Peer {
+                    send_queue,
+                    endpoint,
+                },
+            )
             .await;
         backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());
@@ -475,10 +503,17 @@ mod tests {
             GenericSocketBackend::with_options(None, SocketType::PUSH, SocketOptions::default());
         let peer_id: PeerIdentity = "closed-peer".parse().expect("peer id");
         let (send_queue, recv_queue) = mpsc::channel(1);
+        let endpoint = TryIntoEndpoint::try_into("tcp://127.0.0.1:1234").unwrap();
         drop(recv_queue);
         backend
             .peers
-            .upsert_async(peer_id.clone(), Peer { send_queue })
+            .upsert_async(
+                peer_id.clone(),
+                Peer {
+                    send_queue,
+                    endpoint,
+                },
+            )
             .await;
         backend.refresh_single_peer_cache();
         backend.round_robin.push(peer_id.clone());

--- a/src/dealer.rs
+++ b/src/dealer.rs
@@ -7,19 +7,20 @@ use crate::{
     CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
     SocketRecv, SocketSend, SocketType, ZmqError, ZmqMessage, ZmqResult,
 };
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::StreamExt;
 
-use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct DealerSocket {
     backend: Arc<GenericSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for DealerSocket {
@@ -49,6 +50,7 @@ impl Socket for DealerSocket {
             backend,
             fair_queue,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -56,8 +58,12 @@ impl Socket for DealerSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle, RandomState> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum ZmqError {
     Network(#[from] std::io::Error),
     #[error("Socket bind doesn't exist: {0}")]
     NoSuchBind(Endpoint),
+    #[error("Socket connection to {0} doesn't exist")]
+    NoSuchConnection(Endpoint),
     #[error("Codec Error: {0}")]
     Codec(#[from] CodecError),
     #[error("Socket Error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -585,9 +585,13 @@ pub trait Socket: Sized + Send {
         let stop_handle = self.connects().remove(&endpoint);
         let stop_handle = stop_handle.ok_or(ZmqError::NoSuchConnection(endpoint.clone()))?;
 
-        // Stop reconnection before tearing the peers down: `peer_disconnected`
-        // notifies the reconnect task, which would otherwise immediately
-        // reconnect to the endpoint we are disconnecting from.
+        // Stop reconnection before tearing the peers down, for two reasons.
+        // First, `peer_disconnected` notifies the reconnect task, which would
+        // otherwise immediately reconnect to the endpoint we are disconnecting
+        // from. Second, this ordering is what lets a reconnect attempt already
+        // in flight notice it has been cancelled -- `shutdown()` sets its flag
+        // synchronously, so a peer registered after the scan below still gets
+        // torn down by the reconnect task itself. Do not reorder these.
         if let Some(reconnect) = stop_handle.0 {
             reconnect.shutdown();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,12 @@ pub mod __bench {
 
     pub use super::fair_queue::FairQueue;
 
+    /// Bench peers are synthetic and never disconnected by endpoint, so they
+    /// all share one placeholder.
+    fn bench_endpoint() -> super::Endpoint {
+        super::TryIntoEndpoint::try_into("tcp://127.0.0.1:1234").expect("valid endpoint")
+    }
+
     pub struct BenchRoundRobinBackend {
         backend: GenericSocketBackend,
         receivers: Vec<mpsc::Receiver<Message>>,
@@ -71,7 +77,13 @@ pub mod __bench {
                 let (send_queue, recv_queue) = mpsc::channel(queue_capacity);
                 backend
                     .peers
-                    .upsert_async(peer_id.clone(), Peer { send_queue })
+                    .upsert_async(
+                        peer_id.clone(),
+                        Peer {
+                            send_queue,
+                            endpoint: bench_endpoint(),
+                        },
+                    )
                     .await;
                 backend.round_robin.push(peer_id);
                 receivers.push(recv_queue);
@@ -128,6 +140,7 @@ pub mod __bench {
                             subscriptions: subscriptions.clone(),
                             send_queue,
                             _subscription_coro_stop: stop_sender,
+                            endpoint: bench_endpoint(),
                         },
                     )
                     .await;
@@ -204,6 +217,7 @@ pub use crate::xpub::*;
 pub use crate::xsub::*;
 
 use crate::codec::*;
+use crate::reconnect::ReconnectHandle;
 use crate::transport::AcceptStopHandle;
 use util::PeerIdentity;
 
@@ -369,11 +383,36 @@ impl SocketOptions {
     }
 }
 
+/// Handle to the background work owned by a single `connect()`ed endpoint.
+///
+/// Mirrors [`AcceptStopHandle`], which plays the same role for `bind()`. Socket
+/// types with no reconnection support store `None`, so that one uniform map can
+/// cover every socket type.
+pub struct ConnectStopHandle(pub(crate) Option<ReconnectHandle>);
+
+/// The endpoints a socket is bound to, keyed by the *resolved* endpoint.
+pub(crate) type SocketBinds = HashMap<Endpoint, AcceptStopHandle>;
+
+/// The endpoints a socket is connected to, keyed by the endpoint originally
+/// passed to `connect()`.
+pub(crate) type SocketConnects = HashMap<Endpoint, ConnectStopHandle>;
+
 #[async_trait]
 pub trait MultiPeerBackend: SocketBackend {
     /// This should not be public..
     /// Find a better way of doing this
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo);
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    );
+
+    /// The peers currently connected via `endpoint`.
+    ///
+    /// The backend is the source of truth here rather than the socket, because
+    /// reconnection replaces a peer's identity while keeping its endpoint.
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity>;
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity);
 }
@@ -426,16 +465,20 @@ pub trait Socket: Sized + Send {
     /// Returns the endpoint resolved to the exact bound location if applicable
     /// (port # resolved, for example).
     async fn bind(&mut self, endpoint: &str) -> ZmqResult<Endpoint> {
-        let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let original_endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let original_endpoint_clone = original_endpoint.clone();
 
         let cloned_backend = self.backend();
         let cback = move |result: ZmqResult<(FramedIo, Endpoint)>| {
             let cloned_backend = cloned_backend.clone();
+            let cloned_endpoint = original_endpoint_clone.clone();
             async move {
                 let result = match result {
-                    Ok((socket, endpoint)) => util::peer_connected(socket, cloned_backend.clone())
-                        .await
-                        .map(|peer_id| (endpoint, peer_id)),
+                    Ok((socket, endpoint)) => {
+                        util::peer_connected(socket, cloned_backend.clone(), cloned_endpoint)
+                            .await
+                            .map(|peer_id| (endpoint, peer_id))
+                    }
                     Err(e) => Err(e),
                 };
 
@@ -454,7 +497,7 @@ pub trait Socket: Sized + Send {
             }
         };
 
-        let (endpoint, stop_handle) = transport::begin_accept(endpoint, cback).await?;
+        let (endpoint, stop_handle) = transport::begin_accept(original_endpoint, cback).await?;
 
         if let Some(monitor) = self.backend().monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Listening(endpoint.clone()));
@@ -464,7 +507,9 @@ pub trait Socket: Sized + Send {
         Ok(endpoint)
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle>;
+    fn binds(&mut self) -> &mut SocketBinds;
+
+    fn connects(&mut self) -> &mut SocketConnects;
 
     /// Unbinds the endpoint, blocking until the associated endpoint is no
     /// longer in use
@@ -472,7 +517,8 @@ pub trait Socket: Sized + Send {
     /// # Errors
     /// May give a `ZmqError::NoSuchBind` if `endpoint` isn't bound. May also
     /// give any other zmq errors encountered when attempting to disconnect
-    async fn unbind(&mut self, endpoint: Endpoint) -> ZmqResult<()> {
+    async fn unbind(&mut self, endpoint: impl TryIntoEndpoint) -> ZmqResult<()> {
+        let endpoint = TryIntoEndpoint::try_into(endpoint)?;
         let stop_handle = self.binds().remove(&endpoint);
         let stop_handle = stop_handle.ok_or(ZmqError::NoSuchBind(endpoint))?;
         stop_handle.0.shutdown().await
@@ -493,16 +539,24 @@ pub trait Socket: Sized + Send {
     /// Connects to the given endpoint.
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()> {
         let backend = self.backend();
-        let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let original_endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let original_endpoint_clone = original_endpoint.clone();
         let connect_timeout = backend.socket_options().connect_timeout;
 
         let (socket, endpoint, peer_id) = util::run_with_timeout(connect_timeout, async {
-            let (mut socket, endpoint) = util::connect_forever(endpoint).await?;
+            let (mut socket, endpoint) = util::connect_forever(original_endpoint).await?;
             let peer_id = util::peer_handshake(&mut socket, backend.clone()).await?;
             Ok((socket, endpoint, peer_id))
         })
         .await?;
-        backend.peer_connected(&peer_id, socket).await;
+        backend
+            .peer_connected(&peer_id, socket, original_endpoint_clone.clone())
+            .await;
+
+        // Keyed by the endpoint as given, not as resolved: `disconnect()` must
+        // accept the same string that was passed to `connect()`.
+        self.connects()
+            .insert(original_endpoint_clone, ConnectStopHandle(None));
 
         if let Some(monitor) = self.backend().monitor().lock().as_mut() {
             let _ = monitor.try_send(SocketEvent::Connected(endpoint, peer_id));
@@ -520,25 +574,53 @@ pub trait Socket: Sized + Send {
 
     /// Disconnects from the given endpoint, blocking until finished.
     ///
+    /// The endpoint must be the one originally passed to [`Socket::connect`].
+    ///
     /// # Errors
     /// May give a `ZmqError::NoSuchConnection` if `endpoint` isn't connected.
     /// May also give any other zmq errors encountered when attempting to
     /// disconnect
-    // TODO: async fn disconnect(&mut self, endpoint: impl TryIntoEndpoint + 'async_trait) ->
-    // ZmqResult<()>;
+    async fn disconnect(&mut self, endpoint: impl TryIntoEndpoint) -> ZmqResult<()> {
+        let endpoint = TryIntoEndpoint::try_into(endpoint)?;
+        let stop_handle = self.connects().remove(&endpoint);
+        let stop_handle = stop_handle.ok_or(ZmqError::NoSuchConnection(endpoint.clone()))?;
 
-    /// Disconnects all connections, blocking until finished.
-    // TODO: async fn disconnect_all(&mut self) -> ZmqResult<()>;
+        // Stop reconnection before tearing the peers down: `peer_disconnected`
+        // notifies the reconnect task, which would otherwise immediately
+        // reconnect to the endpoint we are disconnecting from.
+        if let Some(reconnect) = stop_handle.0 {
+            reconnect.shutdown();
+        }
 
-    /// Closes the socket, blocking until all associated binds are closed.
-    /// This is equivalent to `drop()`, but with the benefit of blocking until
-    /// resources are released, and getting any underlying errors.
+        let backend = self.backend();
+        for peer_id in backend.peer_list_by_endpoint(&endpoint) {
+            backend.peer_disconnected(&peer_id);
+        }
+        Ok(())
+    }
+
+    /// Disconnects all connected endpoints, blocking until finished.
+    async fn disconnect_all(&mut self) -> Vec<ZmqError> {
+        let mut errs = Vec::new();
+        let endpoints: Vec<_> = self.connects().keys().cloned().collect();
+        for endpoint in endpoints {
+            if let Err(err) = self.disconnect(endpoint).await {
+                errs.push(err);
+            }
+        }
+        errs
+    }
+
+    /// Closes the socket, blocking until all associated connections and binds
+    /// are closed. This is equivalent to `drop()`, but with the benefit of
+    /// blocking until resources are released, and getting any underlying
+    /// errors.
     ///
     /// Returns any encountered errors.
-    // TODO: Call disconnect_all() when added
     async fn close(mut self) -> Vec<ZmqError> {
-        // self.disconnect_all().await?;
-        self.unbind_all().await
+        let mut errs = self.disconnect_all().await;
+        errs.extend(self.unbind_all().await);
+        errs
     }
 }
 

--- a/src/pub.rs
+++ b/src/pub.rs
@@ -2,11 +2,11 @@ use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::message::*;
-use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::write_queue::write_message_queue;
 use crate::{async_rt, CaptureSocket, SocketOptions};
 use crate::{MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketSend, SocketType};
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -64,6 +64,7 @@ pub(crate) struct Subscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
     pub(crate) send_queue: PubSendQueue,
     pub(crate) _subscription_coro_stop: oneshot::Sender<()>,
+    pub(crate) endpoint: Endpoint,
 }
 
 pub(crate) struct PubSocketBackend {
@@ -204,7 +205,12 @@ impl SocketBackend for PubSocketBackend {
 
 #[async_trait]
 impl MultiPeerBackend for PubSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (mut recv_queue, send_queue) = io.into_parts();
         // TODO provide handling for recv_queue
         let (queue_sender, queue_receiver) = mpsc::channel(PUB_SEND_QUEUE_CAPACITY);
@@ -217,6 +223,7 @@ impl MultiPeerBackend for PubSocketBackend {
                     subscriptions: vec![],
                     send_queue: queue_sender,
                     _subscription_coro_stop: sender,
+                    endpoint,
                 },
             )
             .await;
@@ -264,6 +271,10 @@ impl MultiPeerBackend for PubSocketBackend {
         });
     }
 
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.subscribers, endpoint, |sub| &sub.endpoint)
+    }
+
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         log::info!("Client disconnected {:?}", peer_id);
         if let Some(monitor) = self.monitor().lock().as_mut() {
@@ -278,7 +289,8 @@ impl MultiPeerBackend for PubSocketBackend {
 pub struct PubSocket {
     pub(crate) backend: Arc<PubSocketBackend>,
     fanout_queue: PubFanoutQueue,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for PubSocket {
@@ -319,6 +331,7 @@ impl Socket for PubSocket {
             backend,
             fanout_queue,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -326,8 +339,12 @@ impl Socket for PubSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {
@@ -343,7 +360,7 @@ mod tests {
     use crate::util::tests::{
         test_bind_to_any_port_helper, test_bind_to_unspecified_interface_helper,
     };
-    use crate::ZmqResult;
+    use crate::{TryIntoEndpoint, ZmqResult};
     use std::net::IpAddr;
 
     fn test_backend() -> PubSocketBackend {
@@ -370,6 +387,8 @@ mod tests {
                     subscriptions,
                     send_queue: queue_sender,
                     _subscription_coro_stop: stop_sender,
+                    endpoint: TryIntoEndpoint::try_into("tcp://127.0.0.1:1234")
+                        .expect("valid endpoint"),
                 },
             )
             .await;

--- a/src/pull.rs
+++ b/src/pull.rs
@@ -1,25 +1,25 @@
 use crate::backend::GenericSocketBackend;
 use crate::codec::{Message, ZmqFramedRead};
 use crate::fair_queue::FairQueue;
-use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{
-    Endpoint, MultiPeerBackend, Socket, SocketEvent, SocketOptions, SocketRecv, SocketType,
-    ZmqError, ZmqMessage, ZmqResult,
+    MultiPeerBackend, Socket, SocketEvent, SocketOptions, SocketRecv, SocketType, ZmqError,
+    ZmqMessage, ZmqResult,
 };
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
 use futures::StreamExt;
 
-use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct PullSocket {
     backend: Arc<GenericSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 #[async_trait]
@@ -43,6 +43,7 @@ impl Socket for PullSocket {
             backend,
             fair_queue,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -50,8 +51,12 @@ impl Socket for PullSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle, RandomState> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/push.rs
+++ b/src/push.rs
@@ -1,21 +1,21 @@
 use crate::backend::GenericSocketBackend;
 use crate::codec::Message;
-use crate::transport::AcceptStopHandle;
 use crate::{
-    CaptureSocket, Endpoint, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions,
-    SocketSend, SocketType, ZmqMessage, ZmqResult,
+    CaptureSocket, MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketSend,
+    SocketType, ZmqMessage, ZmqResult,
 };
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
 
-use std::collections::hash_map::RandomState;
 use std::collections::HashMap;
 use std::sync::Arc;
 
 pub struct PushSocket {
     backend: Arc<GenericSocketBackend>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for PushSocket {
@@ -34,6 +34,7 @@ impl Socket for PushSocket {
                 options,
             )),
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -41,8 +42,12 @@ impl Socket for PushSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle, RandomState> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -238,7 +238,7 @@ async fn try_reconnect(
 
     // Register the peer with the backend
     // This triggers subscription resync for SUB sockets
-    backend.peer_connected(&peer_id, raw_socket).await;
+    backend.peer_connected(&peer_id, raw_socket, endpoint.clone()).await;
 
     Ok((peer_id, resolved_endpoint))
 }

--- a/src/reconnect.rs
+++ b/src/reconnect.rs
@@ -6,15 +6,17 @@
 
 use crate::async_rt::task::{spawn, JoinHandle};
 use crate::backend::DisconnectNotifier;
+use crate::codec::FramedIo;
 use crate::endpoint::Endpoint;
 use crate::transport;
-use crate::util::{greet_exchange, ready_exchange, PeerIdentity};
+use crate::util::{greet_exchange, ready_exchange, run_with_timeout, PeerIdentity};
 use crate::MultiPeerBackend;
 
 use futures::channel::{mpsc, oneshot};
 use futures::{FutureExt, StreamExt};
 use rand::RngExt;
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -45,6 +47,7 @@ impl Default for ReconnectConfig {
 /// stop the task gracefully.
 pub struct ReconnectHandle {
     shutdown_tx: Option<oneshot::Sender<()>>,
+    shutdown_flag: Arc<AtomicBool>,
     #[allow(dead_code)] // Kept to prevent task from being dropped prematurely
     task_handle: JoinHandle<()>,
 }
@@ -53,8 +56,16 @@ impl ReconnectHandle {
     /// Request graceful shutdown of the reconnection task.
     ///
     /// This signals the task to stop and returns immediately. The task will
-    /// finish its current iteration before stopping.
+    /// abandon any in-flight reconnection attempt rather than finishing it.
+    ///
+    /// The flag is set *before* the wakeup is sent, and is what makes
+    /// [`Socket::disconnect`](crate::Socket::disconnect) safe: the oneshot only
+    /// becomes visible when the task next polls, so a task sitting between
+    /// "handshake complete" and "peer registered" would otherwise register a
+    /// peer for an endpoint the caller has already disconnected. See
+    /// `spawn_reconnect_task` for the full ordering argument.
     pub fn shutdown(mut self) {
+        self.shutdown_flag.store(true, Ordering::Release);
         if let Some(tx) = self.shutdown_tx.take() {
             let _ = tx.send(());
         }
@@ -82,6 +93,18 @@ pub type RegisterDisconnectFn = Box<dyn Fn(PeerIdentity, DisconnectNotifier) + S
 /// * `register_disconnect_fn` - Callback to register disconnect notifiers with the backend
 /// * `config` - Reconnection configuration (intervals, backoff)
 ///
+/// # Shutdown ordering
+/// `ReconnectHandle::shutdown` sets a flag synchronously and then wakes the
+/// task. The task checks that flag immediately *after* registering a
+/// reconnected peer. Since `Socket::disconnect` shuts the task down before it
+/// scans for peers to tear down, every interleaving is covered:
+///
+/// - task registers, then sees the flag set -> the task tears the peer down;
+/// - task registers, flag still clear -> `disconnect` had not started, so its
+///   later scan observes the peer and tears it down;
+/// - task registers after the scan -> the flag was necessarily set before that
+///   scan, so the task observes it and tears the peer down.
+///
 /// # Returns
 /// A `ReconnectHandle` to control the task.
 pub fn spawn_reconnect_task(
@@ -94,6 +117,8 @@ pub fn spawn_reconnect_task(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     // Create the disconnect notification channel - this task owns the receiver
     let (disconnect_tx, mut disconnect_rx) = mpsc::channel::<PeerIdentity>(1);
+    let shutdown_flag = Arc::new(AtomicBool::new(false));
+    let task_shutdown_flag = shutdown_flag.clone();
 
     // Register the initial peer_id
     register_disconnect_fn(initial_peer_id.clone(), disconnect_tx.clone());
@@ -154,9 +179,50 @@ pub fn spawn_reconnect_task(
                     }
                 }
 
-                // Try to connect
-                match try_reconnect(&endpoint, backend.clone()).await {
-                    Ok((new_peer_id, resolved_endpoint)) => {
+                // Connect and handshake. This half is cancel-safe: dropping the
+                // future closes the half-open socket and registers nothing, so
+                // it can be raced against shutdown.
+                let connect_timeout = backend.socket_options().connect_timeout;
+                let handshake =
+                    run_with_timeout(connect_timeout, connect_and_handshake(&endpoint, &backend))
+                        .fuse();
+                futures::pin_mut!(handshake);
+
+                let outcome = futures::select! {
+                    result = handshake => result,
+                    _ = shutdown_rx => {
+                        log::debug!(
+                            "Shutdown received during reconnect attempt to {}, stopping reconnect task",
+                            endpoint
+                        );
+                        return;
+                    }
+                };
+
+                match outcome {
+                    Ok((new_peer_id, resolved_endpoint, raw_socket)) => {
+                        // Registration is *not* cancel-safe - `peer_connected`
+                        // awaits several times while wiring the peer up, and
+                        // being dropped partway would leave it half-registered.
+                        // So run it to completion, then check for shutdown.
+                        backend
+                            .clone()
+                            .peer_connected(&new_peer_id, raw_socket, endpoint.clone())
+                            .await;
+
+                        if task_shutdown_flag.load(Ordering::Acquire) {
+                            // `disconnect()` may have scanned for peers before
+                            // this one existed, so undo the registration here
+                            // rather than leaving an unreachable peer behind.
+                            log::debug!(
+                                "Reconnected to {} after shutdown was requested, tearing down peer {:?}",
+                                endpoint,
+                                new_peer_id
+                            );
+                            backend.peer_disconnected(&new_peer_id);
+                            return;
+                        }
+
                         log::info!(
                             "Successfully reconnected to {} (peer {:?})",
                             endpoint,
@@ -202,23 +268,29 @@ pub fn spawn_reconnect_task(
 
     ReconnectHandle {
         shutdown_tx: Some(shutdown_tx),
+        shutdown_flag,
         task_handle,
     }
 }
 
-/// Attempts a single reconnection to the endpoint.
+/// Connects to the endpoint and performs the ZMTP handshake.
 ///
-/// This performs the full connection sequence:
+/// This performs the connection sequence up to, but not including, peer
+/// registration:
 /// 1. TCP/IPC connection
 /// 2. ZMTP greeting exchange
 /// 3. Ready command exchange
-/// 4. Peer registration via `backend.peer_connected()`
 ///
-/// Returns the new `peer_id` and resolved endpoint on success.
-async fn try_reconnect(
+/// Registration is deliberately left to the caller: this function is
+/// cancel-safe (dropping the future closes the half-open socket and leaves no
+/// trace on the backend), whereas `peer_connected` is not, so only this half
+/// may be raced against a shutdown signal.
+///
+/// Returns the new `peer_id`, the resolved endpoint, and the handshaken socket.
+async fn connect_and_handshake(
     endpoint: &Endpoint,
-    backend: Arc<dyn MultiPeerBackend>,
-) -> crate::ZmqResult<(PeerIdentity, Endpoint)> {
+    backend: &Arc<dyn MultiPeerBackend>,
+) -> crate::ZmqResult<(PeerIdentity, Endpoint, FramedIo)> {
     // Attempt transport-level connection
     let (mut raw_socket, resolved_endpoint) = transport::connect(endpoint).await?;
 
@@ -236,11 +308,7 @@ async fn try_reconnect(
     // Exchange ready commands
     let peer_id = ready_exchange(&mut raw_socket, backend.socket_type(), props).await?;
 
-    // Register the peer with the backend
-    // This triggers subscription resync for SUB sockets
-    backend.peer_connected(&peer_id, raw_socket, endpoint.clone()).await;
-
-    Ok((peer_id, resolved_endpoint))
+    Ok((peer_id, resolved_endpoint, raw_socket))
 }
 
 #[cfg(test)]

--- a/src/rep.rs
+++ b/src/rep.rs
@@ -2,7 +2,6 @@ use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::*;
 use crate::fair_queue::{FairQueue, QueueInner};
-use crate::transport::AcceptStopHandle;
 use crate::*;
 use crate::{SocketType, ZmqResult};
 
@@ -16,6 +15,7 @@ use std::sync::Arc;
 struct RepPeer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: ZmqFramedWrite,
+    pub(crate) endpoint: Endpoint,
 }
 
 struct RepSocketBackend {
@@ -30,7 +30,8 @@ pub struct RepSocket {
     envelope: Option<ZmqMessage>,
     current_request: Option<PeerIdentity>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for RepSocket {
@@ -63,6 +64,7 @@ impl Socket for RepSocket {
             current_request: None,
             fair_queue,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -70,8 +72,12 @@ impl Socket for RepSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {
@@ -83,7 +89,12 @@ impl Socket for RepSocket {
 
 #[async_trait]
 impl MultiPeerBackend for RepSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (recv_queue, send_queue) = io.into_parts();
 
         self.peers
@@ -92,12 +103,17 @@ impl MultiPeerBackend for RepSocketBackend {
                 RepPeer {
                     _identity: peer_id.clone(),
                     send_queue,
+                    endpoint,
                 },
             )
             .await;
         self.fair_queue_inner
             .lock()
             .insert(peer_id.clone(), recv_queue);
+    }
+
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.peers, endpoint, |peer| &peer.endpoint)
     }
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {

--- a/src/req.rs
+++ b/src/req.rs
@@ -1,7 +1,6 @@
 use crate::codec::*;
 use crate::endpoint::Endpoint;
 use crate::error::*;
-use crate::transport::AcceptStopHandle;
 use crate::util::{Peer, PeerIdentity};
 use crate::*;
 use crate::{SocketType, ZmqResult};
@@ -24,7 +23,8 @@ struct ReqSocketBackend {
 pub struct ReqSocket {
     backend: Arc<ReqSocketBackend>,
     current_request: Option<PeerIdentity>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for ReqSocket {
@@ -116,6 +116,7 @@ impl Socket for ReqSocket {
             }),
             current_request: None,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -123,8 +124,12 @@ impl Socket for ReqSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {
@@ -136,7 +141,12 @@ impl Socket for ReqSocket {
 
 #[async_trait]
 impl MultiPeerBackend for ReqSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (recv_queue, send_queue) = io.into_parts();
         self.peers
             .upsert_async(
@@ -145,13 +155,21 @@ impl MultiPeerBackend for ReqSocketBackend {
                     _identity: peer_id.clone(),
                     send_queue,
                     recv_queue,
+                    endpoint,
                 },
             )
             .await;
         self.round_robin.push(peer_id.clone());
     }
 
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.peers, endpoint, |peer| &peer.endpoint)
+    }
+
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
+        if let Some(monitor) = self.monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
+        }
         self.peers.remove_sync(peer_id);
     }
 }

--- a/src/router.rs
+++ b/src/router.rs
@@ -8,6 +8,7 @@ use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{MultiPeerBackend, SocketEvent, SocketOptions, SocketRecv, SocketSend, SocketType};
 use crate::{Socket, SocketBackend};
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -19,7 +20,8 @@ use std::sync::Arc;
 
 pub struct RouterSocket {
     backend: Arc<GenericSocketBackend>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
 }
 
@@ -49,6 +51,7 @@ impl Socket for RouterSocket {
         Self {
             backend,
             binds: HashMap::new(),
+            connects: HashMap::new(),
             fair_queue,
         }
     }
@@ -57,8 +60,12 @@ impl Socket for RouterSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/sub.rs
+++ b/src/sub.rs
@@ -1,16 +1,12 @@
 use crate::codec::{Message, ZmqFramedRead};
-use crate::endpoint::Endpoint;
 use crate::error::{ZmqError, ZmqResult};
 use crate::fair_queue::FairQueue;
 use crate::message::ZmqMessage;
-use crate::reconnect::ReconnectHandle;
-use crate::sub_backend::{
-    connect_with_reconnect, SocketBinds, SubSocketBackend, SubscriptionMessageType,
-};
-use crate::transport::AcceptStopHandle;
+use crate::sub_backend::{connect_with_reconnect, SubSocketBackend, SubscriptionMessageType};
 use crate::util::PeerIdentity;
 use crate::{
-    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketType,
+    MultiPeerBackend, Socket, SocketBackend, SocketBinds, SocketConnects, SocketEvent,
+    SocketOptions, SocketRecv, SocketType,
 };
 
 use async_trait::async_trait;
@@ -24,15 +20,16 @@ pub struct SubSocket {
     backend: Arc<SubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
     binds: SocketBinds,
-    /// Handles to background reconnection tasks
-    reconnect_handles: Vec<ReconnectHandle>,
+    connects: SocketConnects,
 }
 
 impl Drop for SubSocket {
     fn drop(&mut self) {
         // Shutdown all reconnection tasks
-        for handle in self.reconnect_handles.drain(..) {
-            handle.shutdown();
+        for (_, stop_handle) in self.connects.drain() {
+            if let Some(reconnect) = stop_handle.0 {
+                reconnect.shutdown();
+            }
         }
         self.backend.shutdown();
     }
@@ -80,7 +77,7 @@ impl Socket for SubSocket {
             backend,
             fair_queue,
             binds: HashMap::new(),
-            reconnect_handles: Vec::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -88,8 +85,12 @@ impl Socket for SubSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     /// Connects to the given endpoint with automatic reconnection support.
@@ -99,7 +100,7 @@ impl Socket for SubSocket {
     /// is lost. On reconnection, subscriptions are automatically re-sent
     /// to the peer.
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()> {
-        connect_with_reconnect(self.backend.clone(), &mut self.reconnect_handles, endpoint).await
+        connect_with_reconnect(self.backend.clone(), &mut self.connects, endpoint).await
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/sub_backend.rs
+++ b/src/sub_backend.rs
@@ -4,9 +4,9 @@ use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::QueueInner;
 use crate::message::ZmqMessage;
-use crate::reconnect::{ReconnectConfig, ReconnectHandle};
-use crate::transport::AcceptStopHandle;
+use crate::reconnect::ReconnectConfig;
 use crate::util::PeerIdentity;
+use crate::{ConnectStopHandle, SocketConnects};
 use crate::{
     MultiPeerBackend, SocketBackend, SocketEvent, SocketOptions, SocketType, TryIntoEndpoint,
 };
@@ -34,6 +34,7 @@ pub(crate) enum SubscriptionMessageType {
 /// of the framed I/O since receiving is handled through the fair queue.
 pub(crate) struct SubPeer {
     pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) endpoint: Endpoint,
 }
 
 /// Shared backend for [`SubSocket`](crate::SubSocket) and [`XSubSocket`](crate::XSubSocket).
@@ -279,7 +280,12 @@ impl SocketBackend for SubSocketBackend {
 
 #[async_trait]
 impl MultiPeerBackend for SubSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (recv_queue, mut send_queue) = io.into_parts();
 
         for message in self.subscription_messages() {
@@ -294,6 +300,7 @@ impl MultiPeerBackend for SubSocketBackend {
                 peer_id.clone(),
                 SubPeer {
                     send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                    endpoint,
                 },
             )
             .await;
@@ -301,6 +308,10 @@ impl MultiPeerBackend for SubSocketBackend {
         if let Some(inner) = &self.fair_queue_inner {
             inner.lock().insert(peer_id.clone(), recv_queue);
         }
+    }
+
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.peers, endpoint, |peer| &peer.endpoint)
     }
 
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
@@ -329,7 +340,7 @@ impl MultiPeerBackend for SubSocketBackend {
 /// subscriptions are automatically re-sent to the peer.
 pub(crate) async fn connect_with_reconnect(
     backend: Arc<SubSocketBackend>,
-    reconnect_handles: &mut Vec<ReconnectHandle>,
+    connects: &mut SocketConnects,
     endpoint: &str,
 ) -> ZmqResult<()> {
     let endpoint = TryIntoEndpoint::try_into(endpoint)?;
@@ -348,7 +359,10 @@ pub(crate) async fn connect_with_reconnect(
             Ok((socket, resolved_endpoint, peer_id))
         })
         .await?;
-    backend.clone().peer_connected(&peer_id, socket).await;
+    backend
+        .clone()
+        .peer_connected(&peer_id, socket, endpoint.clone())
+        .await;
 
     // Emit Connected event
     if let Some(monitor) = backend.monitor().lock().as_mut() {
@@ -363,16 +377,13 @@ pub(crate) async fn connect_with_reconnect(
 
     // Spawn reconnection task
     let reconnect_handle = crate::reconnect::spawn_reconnect_task(
-        endpoint,
+        endpoint.clone(),
         backend as Arc<dyn MultiPeerBackend>,
         peer_id,
         register_fn,
         ReconnectConfig::default(),
     );
-    reconnect_handles.push(reconnect_handle);
+    connects.insert(endpoint, ConnectStopHandle(Some(reconnect_handle)));
 
     Ok(())
 }
-
-/// Type alias for the bind map shared by SUB and XSUB sockets.
-pub(crate) type SocketBinds = HashMap<Endpoint, AcceptStopHandle>;

--- a/src/util.rs
+++ b/src/util.rs
@@ -100,6 +100,26 @@ pub(crate) struct Peer {
     pub(crate) _identity: PeerIdentity,
     pub(crate) send_queue: FramedWrite<Box<dyn FrameableWrite>, ZmqCodec>,
     pub(crate) recv_queue: ZmqFramedRead,
+    pub(crate) endpoint: Endpoint,
+}
+
+/// Collects the peers whose connection originated from `endpoint`.
+///
+/// Every backend keys its peers by [`PeerIdentity`] but stores a different
+/// value type, so the endpoint is read back through `peer_endpoint`.
+pub(crate) fn peer_list_by_endpoint<V>(
+    peers: &scc::HashMap<PeerIdentity, V>,
+    endpoint: &Endpoint,
+    peer_endpoint: impl Fn(&V) -> &Endpoint,
+) -> Vec<PeerIdentity> {
+    let mut matching = Vec::new();
+    peers.iter_sync(|peer_id, peer| {
+        if peer_endpoint(peer) == endpoint {
+            matching.push(peer_id.clone());
+        }
+        true
+    });
+    matching
 }
 
 /// Given the result of the greetings exchange, determines the version of the
@@ -190,9 +210,10 @@ pub(crate) async fn ready_exchange(
 pub(crate) async fn peer_connected(
     mut raw_socket: FramedIo,
     backend: Arc<dyn MultiPeerBackend>,
+    endpoint: Endpoint,
 ) -> ZmqResult<PeerIdentity> {
     let peer_id = peer_handshake(&mut raw_socket, backend.clone()).await?;
-    backend.peer_connected(&peer_id, raw_socket).await;
+    backend.peer_connected(&peer_id, raw_socket, endpoint).await;
     Ok(peer_id)
 }
 

--- a/src/xpub.rs
+++ b/src/xpub.rs
@@ -3,13 +3,13 @@ use crate::endpoint::Endpoint;
 use crate::error::ZmqResult;
 use crate::fair_queue::{FairQueue, QueueInner};
 use crate::message::*;
-use crate::transport::AcceptStopHandle;
 use crate::util::PeerIdentity;
 use crate::{CaptureSocket, SocketOptions};
 use crate::{
     MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketRecv, SocketSend, SocketType,
     ZmqError,
 };
+use crate::{SocketBinds, SocketConnects};
 
 use async_trait::async_trait;
 use futures::channel::mpsc;
@@ -25,6 +25,7 @@ use std::sync::Arc;
 pub(crate) struct XPubSubscriber {
     pub(crate) subscriptions: Vec<Vec<u8>>,
     pub(crate) send_queue: Arc<AsyncMutex<Pin<Box<ZmqFramedWrite>>>>,
+    pub(crate) endpoint: Endpoint,
 }
 
 pub(crate) struct XPubSocketBackend {
@@ -91,7 +92,12 @@ impl SocketBackend for XPubSocketBackend {
 
 #[async_trait]
 impl MultiPeerBackend for XPubSocketBackend {
-    async fn peer_connected(self: Arc<Self>, peer_id: &PeerIdentity, io: FramedIo) {
+    async fn peer_connected(
+        self: Arc<Self>,
+        peer_id: &PeerIdentity,
+        io: FramedIo,
+        endpoint: Endpoint,
+    ) {
         let (recv_queue, send_queue) = io.into_parts();
 
         self.subscribers
@@ -100,6 +106,7 @@ impl MultiPeerBackend for XPubSocketBackend {
                 XPubSubscriber {
                     subscriptions: vec![],
                     send_queue: Arc::new(AsyncMutex::new(Box::pin(send_queue))),
+                    endpoint,
                 },
             )
             .await;
@@ -109,8 +116,15 @@ impl MultiPeerBackend for XPubSocketBackend {
             .insert(peer_id.clone(), recv_queue);
     }
 
+    fn peer_list_by_endpoint(&self, endpoint: &Endpoint) -> Vec<PeerIdentity> {
+        crate::util::peer_list_by_endpoint(&self.subscribers, endpoint, |sub| &sub.endpoint)
+    }
+
     fn peer_disconnected(&self, peer_id: &PeerIdentity) {
         log::info!("Client disconnected {:?}", peer_id);
+        if let Some(monitor) = self.monitor().lock().as_mut() {
+            let _ = monitor.try_send(SocketEvent::Disconnected(peer_id.clone()));
+        }
         self.subscribers.remove_sync(peer_id);
         self.fair_queue_inner.lock().remove(peer_id);
     }
@@ -119,7 +133,8 @@ impl MultiPeerBackend for XPubSocketBackend {
 pub struct XPubSocket {
     pub(crate) backend: Arc<XPubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
-    binds: HashMap<Endpoint, AcceptStopHandle>,
+    binds: SocketBinds,
+    connects: SocketConnects,
 }
 
 impl Drop for XPubSocket {
@@ -228,6 +243,7 @@ impl Socket for XPubSocket {
             backend,
             fair_queue,
             binds: HashMap::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -235,8 +251,12 @@ impl Socket for XPubSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/src/xsub.rs
+++ b/src/xsub.rs
@@ -1,15 +1,11 @@
 use crate::codec::{Message, ZmqFramedRead};
-use crate::endpoint::Endpoint;
 use crate::error::{ZmqError, ZmqResult};
 use crate::fair_queue::FairQueue;
-use crate::sub_backend::{
-    connect_with_reconnect, SocketBinds, SubSocketBackend, SubscriptionMessageType,
-};
-use crate::transport::AcceptStopHandle;
+use crate::sub_backend::{connect_with_reconnect, SubSocketBackend, SubscriptionMessageType};
 use crate::util::PeerIdentity;
 use crate::{
-    MultiPeerBackend, Socket, SocketBackend, SocketEvent, SocketOptions, SocketRecv, SocketSend,
-    SocketType,
+    MultiPeerBackend, Socket, SocketBackend, SocketBinds, SocketConnects, SocketEvent,
+    SocketOptions, SocketRecv, SocketSend, SocketType,
 };
 
 use async_trait::async_trait;
@@ -23,15 +19,16 @@ pub struct XSubSocket {
     backend: Arc<SubSocketBackend>,
     fair_queue: FairQueue<ZmqFramedRead, PeerIdentity>,
     binds: SocketBinds,
-    /// Handles to background reconnection tasks
-    reconnect_handles: Vec<crate::reconnect::ReconnectHandle>,
+    connects: SocketConnects,
 }
 
 impl Drop for XSubSocket {
     fn drop(&mut self) {
         // Shutdown all reconnection tasks
-        for handle in self.reconnect_handles.drain(..) {
-            handle.shutdown();
+        for (_, stop_handle) in self.connects.drain() {
+            if let Some(reconnect) = stop_handle.0 {
+                reconnect.shutdown();
+            }
         }
         self.backend.shutdown();
     }
@@ -79,7 +76,7 @@ impl Socket for XSubSocket {
             backend,
             fair_queue,
             binds: HashMap::new(),
-            reconnect_handles: Vec::new(),
+            connects: HashMap::new(),
         }
     }
 
@@ -87,8 +84,12 @@ impl Socket for XSubSocket {
         self.backend.clone()
     }
 
-    fn binds(&mut self) -> &mut HashMap<Endpoint, AcceptStopHandle> {
+    fn binds(&mut self) -> &mut SocketBinds {
         &mut self.binds
+    }
+
+    fn connects(&mut self) -> &mut SocketConnects {
+        &mut self.connects
     }
 
     /// Connects to the given endpoint with automatic reconnection support.
@@ -98,7 +99,7 @@ impl Socket for XSubSocket {
     /// is lost. On reconnection, subscriptions are automatically re-sent
     /// to the peer.
     async fn connect(&mut self, endpoint: &str) -> ZmqResult<()> {
-        connect_with_reconnect(self.backend.clone(), &mut self.reconnect_handles, endpoint).await
+        connect_with_reconnect(self.backend.clone(), &mut self.connects, endpoint).await
     }
 
     fn monitor(&mut self) -> mpsc::Receiver<SocketEvent> {

--- a/tests/disconnect.rs
+++ b/tests/disconnect.rs
@@ -1,0 +1,203 @@
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{SocketEvent, ZmqError, ZmqMessage};
+
+use futures::channel::mpsc;
+use futures::StreamExt;
+use std::time::Duration;
+
+const LOCAL: &str = "tcp://127.0.0.1:0";
+
+async fn next_event(monitor: &mut mpsc::Receiver<SocketEvent>) -> SocketEvent {
+    async_rt::task::timeout(Duration::from_secs(2), monitor.next())
+        .await
+        .expect("timed out waiting for a socket event")
+        .expect("monitor channel closed")
+}
+
+/// Asserts that the connecting side of a `binder`/`connector` pair can be
+/// disconnected by the endpoint it was given, for every socket type.
+macro_rules! disconnect_teardown_test {
+    ($name:ident, $binder:ty, $connector:ty) => {
+        #[async_rt::test]
+        async fn $name() {
+            let mut binder = <$binder>::new();
+            let endpoint = binder.bind(LOCAL).await.expect("bind failed");
+
+            let mut connector = <$connector>::new();
+            let mut monitor = connector.monitor();
+            connector
+                .connect(&endpoint.to_string())
+                .await
+                .expect("connect failed");
+
+            let event = next_event(&mut monitor).await;
+            assert!(matches!(event, SocketEvent::Connected(..)), "{event:?}");
+
+            connector
+                .disconnect(endpoint)
+                .await
+                .expect("disconnect failed");
+
+            let event = next_event(&mut monitor).await;
+            assert!(matches!(event, SocketEvent::Disconnected(_)), "{event:?}");
+        }
+    };
+}
+
+disconnect_teardown_test!(disconnect_req, zeromq::RepSocket, zeromq::ReqSocket);
+disconnect_teardown_test!(disconnect_rep, zeromq::DealerSocket, zeromq::RepSocket);
+disconnect_teardown_test!(
+    disconnect_dealer,
+    zeromq::RouterSocket,
+    zeromq::DealerSocket
+);
+disconnect_teardown_test!(
+    disconnect_router,
+    zeromq::DealerSocket,
+    zeromq::RouterSocket
+);
+disconnect_teardown_test!(disconnect_push, zeromq::PullSocket, zeromq::PushSocket);
+disconnect_teardown_test!(disconnect_pull, zeromq::PushSocket, zeromq::PullSocket);
+disconnect_teardown_test!(disconnect_pub, zeromq::SubSocket, zeromq::PubSocket);
+disconnect_teardown_test!(disconnect_sub, zeromq::PubSocket, zeromq::SubSocket);
+disconnect_teardown_test!(disconnect_xpub, zeromq::XSubSocket, zeromq::XPubSocket);
+disconnect_teardown_test!(disconnect_xsub, zeromq::XPubSocket, zeromq::XSubSocket);
+
+#[async_rt::test]
+async fn disconnect_unconnected_endpoint_gives_no_such_connection() {
+    let mut socket = zeromq::DealerSocket::new();
+
+    let err = socket
+        .disconnect("tcp://127.0.0.1:12345")
+        .await
+        .expect_err("disconnect of an unconnected endpoint should fail");
+
+    assert!(matches!(err, ZmqError::NoSuchConnection(_)), "{err:?}");
+}
+
+/// A bound endpoint is not a connected one, so it is not disconnectable.
+#[async_rt::test]
+async fn disconnect_does_not_match_bound_endpoints() {
+    let mut socket = zeromq::RouterSocket::new();
+    let endpoint = socket.bind(LOCAL).await.expect("bind failed");
+
+    let err = socket
+        .disconnect(endpoint)
+        .await
+        .expect_err("a bound endpoint should not be disconnectable");
+
+    assert!(matches!(err, ZmqError::NoSuchConnection(_)), "{err:?}");
+}
+
+/// Disconnecting one endpoint must leave the socket's other connections intact.
+/// This is what proves `peer_list_by_endpoint` filters rather than just counts.
+#[async_rt::test]
+async fn disconnect_only_affects_the_named_endpoint() {
+    let mut kept = zeromq::PullSocket::new();
+    let kept_endpoint = kept.bind(LOCAL).await.expect("bind failed");
+
+    let mut dropped = zeromq::PullSocket::new();
+    let dropped_endpoint = dropped.bind(LOCAL).await.expect("bind failed");
+
+    let mut push = zeromq::PushSocket::new();
+    push.connect(&kept_endpoint.to_string()).await.unwrap();
+    push.connect(&dropped_endpoint.to_string()).await.unwrap();
+
+    push.disconnect(dropped_endpoint)
+        .await
+        .expect("disconnect failed");
+
+    // With only one peer left, every message must land on `kept`.
+    for i in 0..4 {
+        push.send(ZmqMessage::from(format!("m{i}"))).await.unwrap();
+    }
+    for i in 0..4 {
+        let message = async_rt::task::timeout(Duration::from_secs(2), kept.recv())
+            .await
+            .expect("timed out waiting for a message on the kept endpoint")
+            .unwrap();
+        assert_eq!(message.get(0).unwrap().as_ref(), format!("m{i}").as_bytes());
+    }
+}
+
+/// Regression test: `peer_disconnected` notifies the reconnect task, so an
+/// explicit `disconnect()` must stop that task first or the socket immediately
+/// reconnects to the endpoint it was just disconnected from.
+#[async_rt::test]
+async fn disconnect_does_not_trigger_reconnection() {
+    let mut publisher = zeromq::PubSocket::new();
+    let endpoint = publisher.bind(LOCAL).await.expect("bind failed");
+
+    // SUB connects through the reconnecting path (`connect_with_reconnect`).
+    let mut subscriber = zeromq::SubSocket::new();
+    let mut monitor = subscriber.monitor();
+    subscriber.subscribe("").await.unwrap();
+    subscriber
+        .connect(&endpoint.to_string())
+        .await
+        .expect("connect failed");
+
+    let event = next_event(&mut monitor).await;
+    assert!(matches!(event, SocketEvent::Connected(..)), "{event:?}");
+
+    subscriber
+        .disconnect(endpoint)
+        .await
+        .expect("disconnect failed");
+
+    let event = next_event(&mut monitor).await;
+    assert!(matches!(event, SocketEvent::Disconnected(_)), "{event:?}");
+
+    // The reconnect task backs off from 100ms, so a second is many attempts.
+    let reconnected = async_rt::task::timeout(Duration::from_secs(1), async {
+        while let Some(event) = monitor.next().await {
+            if matches!(event, SocketEvent::Connected(..)) {
+                return true;
+            }
+        }
+        false
+    })
+    .await;
+
+    assert!(
+        reconnected.is_err() || !reconnected.unwrap(),
+        "socket reconnected after an explicit disconnect"
+    );
+}
+
+#[async_rt::test]
+async fn close_disconnects_every_connected_endpoint() {
+    let mut first = zeromq::PullSocket::new();
+    let first_endpoint = first.bind(LOCAL).await.expect("bind failed");
+
+    let mut second = zeromq::PullSocket::new();
+    let second_endpoint = second.bind(LOCAL).await.expect("bind failed");
+
+    let mut push = zeromq::PushSocket::new();
+    let mut monitor = push.monitor();
+    push.connect(&first_endpoint.to_string()).await.unwrap();
+    push.connect(&second_endpoint.to_string()).await.unwrap();
+
+    assert!(matches!(
+        next_event(&mut monitor).await,
+        SocketEvent::Connected(..)
+    ));
+    assert!(matches!(
+        next_event(&mut monitor).await,
+        SocketEvent::Connected(..)
+    ));
+
+    let errs = push.close().await;
+    assert!(errs.is_empty(), "close reported errors: {errs:?}");
+
+    // Both connections must have been torn down, not just one.
+    assert!(matches!(
+        next_event(&mut monitor).await,
+        SocketEvent::Disconnected(_)
+    ));
+    assert!(matches!(
+        next_event(&mut monitor).await,
+        SocketEvent::Disconnected(_)
+    ));
+}

--- a/tests/reconnect_disconnect_race.rs
+++ b/tests/reconnect_disconnect_race.rs
@@ -1,0 +1,267 @@
+//! Regression test for `disconnect()` racing an in-flight reconnection attempt.
+//!
+//! `ReconnectHandle::shutdown()` is only observed by the reconnect task at its
+//! `select!` points. A task sitting inside the connect/handshake sequence used
+//! to run that attempt to completion and register the resulting peer -- for an
+//! endpoint the caller had already disconnected, and which `disconnect()` could
+//! no longer reach because it had removed its `connects` entry.
+
+use zeromq::__async_rt as async_rt;
+use zeromq::prelude::*;
+use zeromq::{Endpoint, SocketEvent};
+
+use futures::{FutureExt, StreamExt};
+use std::io::Read;
+use std::sync::mpsc as std_mpsc;
+use std::time::Duration;
+
+/// What a stub listener reports back to the test.
+enum Stub {
+    /// A reconnect attempt connected to us.
+    Accepted,
+    /// That connection was closed by the other side.
+    Closed,
+}
+
+/// A listener that completes the TCP accept but never sends a ZMTP greeting,
+/// parking any reconnect attempt inside the handshake for as long as we like.
+fn spawn_black_hole_listener(port: u16) -> std_mpsc::Receiver<Stub> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", port)).expect("failed to squat port");
+    let (tx, rx) = std_mpsc::channel();
+
+    std::thread::spawn(move || {
+        let Ok((mut stream, _)) = listener.accept() else {
+            return;
+        };
+        let _ = tx.send(Stub::Accepted);
+
+        // Never greet. Just wait for the peer to give up and close, which is
+        // what an abandoned attempt looks like from this side.
+        let mut buf = [0u8; 1024];
+        loop {
+            match stream.read(&mut buf) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {} // their greeting; deliberately unanswered
+            }
+        }
+        let _ = tx.send(Stub::Closed);
+    });
+
+    rx
+}
+
+fn port_of(endpoint: &Endpoint) -> u16 {
+    match endpoint {
+        Endpoint::Tcp(_, port) => *port,
+        other => unreachable!("test binds over tcp, got {other:?}"),
+    }
+}
+
+/// Waits until traffic actually flows between the pair.
+///
+/// A `Connected` event on the SUB only means *its* half of the handshake
+/// finished; the PUB may not have registered the subscriber yet. Closing the
+/// PUB during that window leaves the connection dangling, so the SUB never
+/// observes EOF and no reconnection is ever armed.
+async fn establish(publisher: &mut zeromq::PubSocket, subscriber: &mut zeromq::SubSocket) {
+    for _ in 0..50 {
+        publisher
+            .send(zeromq::ZmqMessage::from("ping"))
+            .await
+            .expect("send failed");
+        if async_rt::task::timeout(Duration::from_millis(100), subscriber.recv())
+            .await
+            .is_ok()
+        {
+            return;
+        }
+    }
+    panic!("publisher and subscriber never exchanged traffic");
+}
+
+/// Awaits a stub report without blocking the executor.
+///
+/// The reconnect task shares this thread under a current-thread runtime, so a
+/// blocking `recv_timeout` here would stall the very task we are waiting on.
+async fn await_stub(signal: &std_mpsc::Receiver<Stub>, budget: Duration) -> Option<Stub> {
+    let deadline = std::time::Instant::now() + budget;
+    while std::time::Instant::now() < deadline {
+        if let Ok(event) = signal.try_recv() {
+            return Some(event);
+        }
+        async_rt::task::sleep(Duration::from_millis(20)).await;
+    }
+    signal.try_recv().ok()
+}
+
+/// Drives `recv()` for a fixed duration so the SUB notices peer loss.
+async fn pump_for(subscriber: &mut zeromq::SubSocket, budget: Duration) {
+    let deadline = std::time::Instant::now() + budget;
+    while std::time::Instant::now() < deadline {
+        futures::select! {
+            _ = subscriber.recv().fuse() => {}
+            _ = async_rt::task::sleep(Duration::from_millis(20)).fuse() => {}
+        }
+    }
+}
+
+/// Drives `recv()` so the SUB notices peer loss, which is what arms the
+/// reconnect task. Returns once `signal` fires or `budget` elapses.
+async fn pump_until(
+    subscriber: &mut zeromq::SubSocket,
+    signal: &std_mpsc::Receiver<Stub>,
+    budget: Duration,
+) -> Option<Stub> {
+    let deadline = std::time::Instant::now() + budget;
+    while std::time::Instant::now() < deadline {
+        if let Ok(event) = signal.try_recv() {
+            return Some(event);
+        }
+        // recv() is cancel-safe, so racing it against a tick is fine.
+        futures::select! {
+            _ = subscriber.recv().fuse() => {}
+            _ = async_rt::task::sleep(Duration::from_millis(20)).fuse() => {}
+        }
+    }
+    signal.try_recv().ok()
+}
+
+#[async_rt::test]
+async fn disconnect_cancels_an_in_flight_reconnect_attempt() {
+    pretty_env_logger::try_init().ok();
+
+    let mut publisher = zeromq::PubSocket::new();
+    let endpoint = publisher
+        .bind("tcp://127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let port = port_of(&endpoint);
+
+    let mut subscriber = zeromq::SubSocket::new();
+    let mut monitor = subscriber.monitor();
+    subscriber.subscribe("").await.expect("subscribe failed");
+    subscriber
+        .connect(&endpoint.to_string())
+        .await
+        .expect("connect failed");
+
+    let connected = async_rt::task::timeout(Duration::from_secs(2), monitor.next())
+        .await
+        .expect("timed out waiting for Connected")
+        .expect("monitor closed");
+    assert!(
+        matches!(connected, SocketEvent::Connected(..)),
+        "{connected:?}"
+    );
+    establish(&mut publisher, &mut subscriber).await;
+
+    // Drop the publisher and squat its port with a listener that never greets,
+    // so the reconnect task parks inside the handshake instead of failing fast.
+    publisher.close().await;
+    async_rt::task::sleep(Duration::from_millis(50)).await;
+    let stub = spawn_black_hole_listener(port);
+
+    // Pump recv() until the reconnect attempt actually reaches the stub.
+    let accepted = pump_until(&mut subscriber, &stub, Duration::from_secs(5)).await;
+    assert!(
+        matches!(accepted, Some(Stub::Accepted)),
+        "reconnect task never attempted a reconnection; the race cannot be exercised"
+    );
+
+    // The attempt is now parked in greet_exchange. Pull the rug out.
+    subscriber
+        .disconnect(endpoint)
+        .await
+        .expect("disconnect failed");
+
+    // The abandoned attempt must close its socket. The connect timeout is 30s,
+    // so anything this prompt is shutdown doing the work, not the timeout.
+    let closed = await_stub(&stub, Duration::from_secs(3))
+        .await
+        .expect("in-flight reconnect attempt was not abandoned after disconnect()");
+    assert!(matches!(closed, Stub::Closed));
+
+    // And no peer may be registered after the disconnect.
+    let resurrected = async_rt::task::timeout(Duration::from_secs(2), async {
+        while let Some(event) = monitor.next().await {
+            if matches!(event, SocketEvent::Connected(..)) {
+                return true;
+            }
+        }
+        false
+    })
+    .await;
+
+    assert!(
+        resurrected.is_err() || !resurrected.expect("checked"),
+        "reconnect task registered a peer for an endpoint that was disconnected"
+    );
+}
+
+/// General property check: a socket must not be connected after `disconnect()`,
+/// even when a reconnection was already armed and the endpoint is reachable
+/// again.
+///
+/// Note this does *not* discriminate the `shutdown_flag` half of the fix -- it
+/// passes against the unfixed code too, because hitting that window requires
+/// `peer_connected` to complete in the gap between `shutdown()` and
+/// `disconnect()`'s peer scan, which cannot be forced from outside the crate.
+/// It is kept as a guard on the broader invariant.
+#[async_rt::test]
+async fn disconnect_is_final_even_if_a_reconnect_lands_late() {
+    let mut publisher = zeromq::PubSocket::new();
+    let endpoint = publisher
+        .bind("tcp://127.0.0.1:0")
+        .await
+        .expect("bind failed");
+    let port = port_of(&endpoint);
+
+    let mut subscriber = zeromq::SubSocket::new();
+    let mut monitor = subscriber.monitor();
+    subscriber.subscribe("").await.expect("subscribe failed");
+    subscriber
+        .connect(&endpoint.to_string())
+        .await
+        .expect("connect failed");
+    let _ = monitor.next().await;
+    establish(&mut publisher, &mut subscriber).await;
+
+    publisher.close().await;
+    async_rt::task::sleep(Duration::from_millis(50)).await;
+
+    // A real publisher this time, so the reconnect can genuinely succeed and
+    // race the disconnect rather than parking forever.
+    let mut replacement = zeromq::PubSocket::new();
+    replacement
+        .bind(&format!("tcp://127.0.0.1:{port}"))
+        .await
+        .expect("rebind failed");
+
+    // Arm the reconnect, then disconnect while it is in flight.
+    pump_for(&mut subscriber, Duration::from_millis(150)).await;
+
+    subscriber
+        .disconnect(endpoint)
+        .await
+        .expect("disconnect failed");
+
+    // Give any in-flight attempt time to complete and self-clean.
+    async_rt::task::sleep(Duration::from_secs(1)).await;
+
+    // Drain the monitor and require that the last connection-lifecycle event is
+    // a disconnect: the socket must not have come back up.
+    let mut last = None;
+    while let Ok(Some(event)) =
+        async_rt::task::timeout(Duration::from_millis(100), monitor.next()).await
+    {
+        match event {
+            SocketEvent::Connected(..) | SocketEvent::Disconnected(_) => last = Some(event),
+            _ => {}
+        }
+    }
+
+    assert!(
+        matches!(last, Some(SocketEvent::Disconnected(_)) | None),
+        "socket ended up connected after an explicit disconnect: {last:?}"
+    );
+}

--- a/tests/req_router_dealer_rep.rs
+++ b/tests/req_router_dealer_rep.rs
@@ -55,9 +55,13 @@ mod test {
         let router_events: Vec<_> = router_monitor.collect().await;
         let dealer_events: Vec<_> = dealer_monitor.collect().await;
         let rep_events: Vec<_> = rep_monitor.collect().await;
-        assert_eq!(2, router_events.len(), "{:?}", &router_events);
-        assert_eq!(2, dealer_events.len(), "{:?}", &dealer_events);
-        assert_eq!(1, rep_events.len(), "{:?}", &rep_events);
+        // Listening, Accepted, then Disconnected once the client that connected
+        // to them closes its socket.
+        assert_eq!(3, router_events.len(), "{:?}", &router_events);
+        assert_eq!(3, dealer_events.len(), "{:?}", &dealer_events);
+        // Connected, then Disconnected: `run_rep_server` closes the socket, and
+        // `close()` disconnects the endpoint REP connected to.
+        assert_eq!(2, rep_events.len(), "{:?}", &rep_events);
 
         Ok(())
     }


### PR DESCRIPTION
**Disclaimer**: AI was used to help with feature implementation (especially with writing unit tests and code review).

## Summary

Implemented `disconnect` and `disconnect_all` feature for all socket kinds.

- I tried to make API similar to the `binds`, `unbind`, `unbind_all` functions
- Added a new function `peer_list_by_endpoint` to `MultiPeerBackend` trait. This is the simplest solution I found to match an endpoint with its underlying peer ID.
- Added a new ZmqError enum `NoSuchConnection`

Second commit is a regression found by Claude consisting in a race condition between disconnect and reconnect features. If a disconnect is called while the reconnection tasks is performing a connection, we could end up with a connected but unreachable peer.

## Validation

```
cargo fmt --check
cargo check --all
cargo test --all
```

